### PR TITLE
fix(ci): prevent headless manifest from overwriting `:latest` tag

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -192,6 +192,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
             type=ref,event=branch,suffix=-headless
             type=semver,pattern={{version}},suffix=-headless


### PR DESCRIPTION
## Summary

- Fix `merge-headless` job generating a bare `:latest` tag that overwrites the full image's `:latest` on GHCR
- Add `flavor: latest=false` to the headless metadata step to disable automatic `:latest` generation

## Root Cause

`docker/metadata-action@v5` defaults to `flavor: latest=auto`, which auto-appends a bare `:latest` tag on semver releases — ignoring any `suffix` applied to tag rules. Both `merge` (full) and `merge-headless` jobs ran in parallel, and whichever finished last won the `:latest` tag.

Evidence from [v2.8.0 release run](https://github.com/vinayakkulkarni/tileserver-rs/actions/runs/22219972489/job/64275882566):

```
Docker tags:
ghcr.io/vinayakkulkarni/tileserver-rs:2.8.0-headless
ghcr.io/vinayakkulkarni/tileserver-rs:2.8-headless
ghcr.io/vinayakkulkarni/tileserver-rs:2-headless
ghcr.io/vinayakkulkarni/tileserver-rs:sha-de63e51-headless
ghcr.io/vinayakkulkarni/tileserver-rs:latest          ← bare :latest from headless job
```

## Fix

One-line addition: `flavor: latest=false` in the headless metadata step. The explicit `type=raw,value=latest-headless` rule already correctly handles the headless latest tag.

Resolves #620