### PR TITLE
feat: POC for CSV to pmtiles conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,6 +668,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3622,6 +3643,7 @@ dependencies = [
  "axum-test",
  "bytes",
  "clap",
+ "csv",
  "deadpool-postgres",
  "dotenvy",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +131,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "as-slice"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
+dependencies = [
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
+ "generic-array 0.14.7",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +174,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -211,6 +238,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -311,7 +339,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -535,6 +563,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
+ "unicode-width",
  "windows-sys 0.59.0",
 ]
 
@@ -565,6 +594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "countio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9702aee5d1d744c01d82f6915644f950f898e014903385464c773b96fefdecb"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,11 +618,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -612,7 +663,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -718,6 +769,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5663fd2b4e3742545500462e4b4929ffc5148f13acbb775a9fca2ea6b6df4d"
 
 [[package]]
+name = "earcutr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+dependencies = [
+ "itertools 0.11.0",
+ "num-traits",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +798,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum_dispatch"
@@ -888,6 +958,12 @@ dependencies = [
  "miniz_oxide",
  "zlib-rs",
 ]
+
+[[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "fmmap"
@@ -1064,12 +1140,47 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "geo"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
+dependencies = [
+ "earcutr",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar 0.12.2",
+ "spade",
 ]
 
 [[package]]
@@ -1089,7 +1200,21 @@ checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
 dependencies = [
  "approx",
  "num-traits",
+ "rstar 0.10.0",
+ "rstar 0.11.0",
+ "rstar 0.12.2",
+ "rstar 0.8.4",
+ "rstar 0.9.3",
  "serde",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -1098,6 +1223,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e26f3c45b36fccc9cf2805e61d4da6bc4bbd5a3a9589b01afa3a40eff703bd79"
 dependencies = [
+ "geo-types",
  "log",
  "serde",
  "serde_json",
@@ -1188,11 +1314,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4041af86e63ac4298ce40e5cca669066e75b6f1aa3390fe2561ffa5e1d9f4cc"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1212,6 +1367,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
+dependencies = [
+ "as-slice",
+ "generic-array 0.14.7",
+ "hash32 0.1.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32 0.2.1",
+ "rustc_version",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1532,6 +1722,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "insta"
 version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1574,6 +1777,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1859,6 +2071,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1972,6 +2201,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc2-core-foundation"
@@ -2146,6 +2381,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pdqselect"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec91767ecc0a0bbe558ce8c9da33c068066c57ecc8bb8477ef8c1ad3ef77c27"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,7 +2468,9 @@ checksum = "0af0f2c4ed52ff814d2d55fff79c881dd8228f4196c9a1d7f5d32f86cbd044f5"
 dependencies = [
  "async-compression",
  "bytes",
+ "countio",
  "fast_hilbert",
+ "flate2",
  "fmmap",
  "reqwest 0.13.2",
  "serde",
@@ -2235,6 +2478,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tilejson",
  "tokio",
+ "twox-hash",
  "varint-rs",
 ]
 
@@ -2521,6 +2765,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,6 +2915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,6 +2928,67 @@ checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
 dependencies = [
  "hashbrown 0.16.1",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rstar"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a45c0e8804d37e4d97e55c6f258bc9ad9c5ee7b07437009dd152d764949a27c"
+dependencies = [
+ "heapless 0.6.1",
+ "num-traits",
+ "pdqselect",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40f1bfe5acdab44bc63e6699c28b74f75ec43afb59f3eda01e145aff86a25fa"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f39465655a1e3d8ae79c6d9e007f4953bfc5d55297602df9dc38f9ae9f1359a"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73111312eb7a2287d229f06c00ff35b51ddee180f017ab6dec1f69d62ac098d6"
+dependencies = [
+ "heapless 0.7.17",
+ "num-traits",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless 0.8.0",
+ "num-traits",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -2730,6 +3061,15 @@ name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -3076,6 +3416,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "spade"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb313e1c8afee5b5647e00ee0fe6855e3d529eb863a0fdae1d60006c4d1e9990"
+dependencies = [
+ "hashbrown 0.15.5",
+ "num-traits",
+ "robust",
+ "smallvec",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "sqlite-wasm-rs"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3266,8 +3627,11 @@ dependencies = [
  "flate2",
  "futures",
  "gdal",
+ "geo",
+ "geojson",
  "geozero",
  "image",
+ "indicatif",
  "insta",
  "maplibre-native-sys",
  "mime_guess",
@@ -3278,6 +3642,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pmtiles",
  "postgres-types",
+ "rayon",
  "reqwest 0.13.2",
  "rusqlite",
  "rust-embed",
@@ -3299,6 +3664,7 @@ dependencies = [
  "urlencoding",
  "utoipa",
  "utoipa-swagger-ui",
+ "uuid",
 ]
 
 [[package]]
@@ -3666,6 +4032,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3733,6 +4105,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ indicatif = { version = "0.17", optional = true }
 geojson = { version = "0.24", optional = true }
 uuid = { version = "1.17", features = ["v4"], optional = true }
 rayon = { version = "1", optional = true }
+csv = { version = "1", optional = true }
 
 [features]
 default = ["postgres", "raster"]
@@ -84,7 +85,7 @@ frontend = ["rust-embed"]
 postgres = ["deadpool-postgres", "tokio-postgres", "postgres-types", "semver", "moka"]
 postgres-integration = ["postgres"]
 raster = ["gdal"]
-convert = ["geo", "indicatif", "geojson", "uuid", "axum/multipart", "rayon"]
+convert = ["geo", "indicatif", "geojson", "uuid", "axum/multipart", "rayon", "csv"]
 # s3 = ["aws-config", "aws-sdk-s3"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,14 +19,14 @@ maplibre-native-sys = { path = "maplibre-native-sys" }
 anyhow = "1.0.102"
 arc-swap = "1.7.1"
 async-trait = "0.1.89"
-axum = "0.8.8"
+axum = { version = "0.8.8", features = [] }
 bytes = "1.11.1"
 clap = { version = "4.5.60", features = ["derive", "env"] }
 dotenvy = "0.15.7"
 futures = "0.3"
 image = { version = "0.25.9", default-features = false, features = ["png", "jpeg", "webp"] }
 mime_guess = "2.0.5"
-pmtiles = { version = "0.19.2", default-features = false, features = ["http-async", "mmap-async-tokio", "tilejson"] }
+pmtiles = { version = "0.19.2", default-features = false, features = ["http-async", "mmap-async-tokio", "tilejson", "write"] }
 reqwest = { version = "0.13.2", default-features = false, features = ["rustls"] }
 shellexpand = { version = "3.1.1", default-features = false, features = ["base-0"] }
 rust-embed = { version = "8.11.0", features = ["axum"], optional = true }
@@ -34,7 +34,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 sha2 = "0.10.9"
 thiserror = "2.0.18"
-geozero = { version = "0.15.1", features = ["with-mvt", "with-geojson"] }
+geozero = { version = "0.15.1", features = ["with-mvt", "with-geojson", "with-geo"] }
 flate2 = "1.1.9"
 tokio = { version = "1.49", features = ["full"] }
 toml = "0.9.12"
@@ -71,12 +71,20 @@ moka = { version = "0.12", features = ["future"], optional = true }
 # aws-config = { version = "1.5", optional = true }
 # aws-sdk-s3 = { version = "1.65", optional = true }
 
+# Geospatial conversion (optional, enabled with `convert` feature)
+geo = { version = "0.28", optional = true }
+indicatif = { version = "0.17", optional = true }
+geojson = { version = "0.24", optional = true }
+uuid = { version = "1.17", features = ["v4"], optional = true }
+rayon = { version = "1", optional = true }
+
 [features]
 default = ["postgres", "raster"]
 frontend = ["rust-embed"]
 postgres = ["deadpool-postgres", "tokio-postgres", "postgres-types", "semver", "moka"]
 postgres-integration = ["postgres"]
 raster = ["gdal"]
+convert = ["geo", "indicatif", "geojson", "uuid", "axum/multipart", "rayon"]
 # s3 = ["aws-config", "aws-sdk-s3"]
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ High-performance vector tile server built in Rust with a modern Nuxt 4 frontend.
 
 - **PMTiles Support** - Serve tiles from local and remote PMTiles archives
 - **MBTiles Support** - Serve tiles from SQLite-based MBTiles files
+- **GeoJSON → PMTiles Conversion** - Convert GeoJSON to PMTiles in-process via CLI or HTTP upload (`--features convert`)
 - **Native Raster Rendering** - Generate PNG/JPEG/WebP tiles using MapLibre Native (C++ FFI)
 - **PostgreSQL Out-DB Rasters** - Serve VRT/COG tiles via PostGIS functions with dynamic filtering
 - **Static Map Images** - Create embeddable map screenshots (like Mapbox/Maptiler Static API)
@@ -39,6 +40,7 @@ High-performance vector tile server built in Rust with a modern Nuxt 4 frontend.
   - [Using Docker](#using-docker)
   - [Building from Source](#building-from-source)
 - [Configuration](#configuration)
+- [GeoJSON Conversion](#geojson-conversion)
 - [API Endpoints](#api-endpoints)
 - [Development](#development)
 - [Contributing](#contributing)
@@ -190,6 +192,9 @@ bun install
 # Build the Rust backend
 cargo build --release
 
+# Build with GeoJSON conversion support (optional)
+cargo build --release --features convert
+
 # Build the frontend
 bun run build:client
 
@@ -259,6 +264,81 @@ This exposes `POST /__admin/reload` on a separate port for reloading configurati
 
 See [config.example.toml](./config.example.toml) for a complete example, or [config.offline.toml](./config.offline.toml) for a local development setup.
 
+## GeoJSON Conversion
+
+tileserver-rs can convert GeoJSON files to PMTiles archives directly — no external tools like tippecanoe required. Enable the feature at build time:
+
+```bash
+cargo build --release --features convert
+```
+
+### CLI Usage
+
+```bash
+# Basic conversion
+tileserver-rs convert input.geojson
+
+# With options
+tileserver-rs convert input.geojson \
+  --output output.pmtiles \
+  --min-zoom 0 \
+  --max-zoom 14 \
+  --layer-name my_layer
+
+# Convert and immediately serve
+tileserver-rs convert input.geojson --serve --port 8080
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `<INPUT>` | *(required)* | GeoJSON file to convert |
+| `-o, --output <FILE>` | `<input>.pmtiles` | Output PMTiles path |
+| `--min-zoom <N>` | `0` | Minimum zoom level |
+| `--max-zoom <N>` | `14` | Maximum zoom level |
+| `--layer-name <NAME>` | input filename stem | MVT layer name |
+| `--simplification <TOL>` | auto | Douglas-Peucker tolerance at z0 |
+| `--serve` | *(flag)* | Start tile server after conversion |
+| `-p, --port <PORT>` | `8080` | Port for `--serve` |
+
+### HTTP Upload
+
+When the server is built with `--features convert`, three additional endpoints are available:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/convert` | Upload GeoJSON (multipart), returns job ID |
+| `GET` | `/convert/{id}/status` | Poll job progress |
+| `GET` | `/convert/{id}/download` | Download finished PMTiles archive |
+
+```bash
+# Upload and start conversion
+curl -X POST http://localhost:8080/convert \
+  -F "file=@input.geojson" \
+  -F "min_zoom=0" \
+  -F "max_zoom=10"
+# → {"id":"<uuid>","status":"Processing"}
+
+# Poll status
+curl http://localhost:8080/convert/<id>/status
+# → {"id":"<uuid>","status":"Done","progress":1.0}
+
+# Download result
+curl -o result.pmtiles http://localhost:8080/convert/<id>/download
+```
+
+Jobs are cleaned up automatically after 1 hour.
+
+### How It Works
+
+The conversion pipeline runs entirely in-process:
+
+1. **Read** — GeoJSON features are loaded and geometries converted to WGS-84
+2. **Tile** — Features are distributed across (z, x, y) tiles using Web Mercator math
+3. **Clip** — Each feature is clipped to the tile's bounding box with a small buffer
+4. **Simplify** — Douglas-Peucker simplification is applied (tolerance scales with zoom)
+5. **Encode** — Clipped features are encoded as Mapbox Vector Tiles (MVT/protobuf)
+6. **Write** — Tiles are written to a PMTiles archive in Hilbert-curve order for optimal read performance
+
 ## API Endpoints
 
 ### Health & Admin Endpoints
@@ -301,6 +381,14 @@ See [config.example.toml](./config.example.toml) for a complete example, or [con
 |----------|-------------|
 | `GET /files/{filepath}` | Serve static files (GeoJSON, icons, etc.) |
 | `GET /index.json` | Combined TileJSON for all sources and styles |
+
+### Conversion Endpoints (`--features convert`)
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /convert` | Upload GeoJSON, start async conversion job |
+| `GET /convert/{id}/status` | Poll job progress (`{status, progress, error}`) |
+| `GET /convert/{id}/download` | Download finished PMTiles archive |
 
 ### PostgreSQL Out-DB Raster Endpoints
 
@@ -398,6 +486,13 @@ tileserver-rs/
 │   │   ├── renderer.rs      # High-level render API
 │   │   ├── native.rs        # Safe Rust wrappers around FFI
 │   │   └── types.rs         # RenderOptions, ImageFormat, etc.
+│   ├── convert/             # GeoJSON → PMTiles pipeline (--features convert)
+│   │   ├── pipeline.rs      # Orchestrates read → tile → encode → write
+│   │   ├── tiler.rs         # Web Mercator tile math
+│   │   ├── mvt_builder.rs   # MVT encoding via geozero/prost
+│   │   ├── writer.rs        # PMTiles archive writer
+│   │   ├── http.rs          # Axum HTTP handlers (/convert/*)
+│   │   └── input/           # Format readers (GeoJSON)
 │   ├── sources/             # Tile source implementations
 │   └── styles/              # Style management + rewriting
 ├── compose.yml              # Docker Compose (development)

--- a/apps/docs/content/4.guides/8.convert.md
+++ b/apps/docs/content/4.guides/8.convert.md
@@ -1,0 +1,313 @@
+---
+title: GeoJSON to PMTiles Conversion
+description: Convert GeoJSON files to PMTiles archives in-process via CLI or HTTP upload — no external tools required
+---
+
+tileserver-rs can convert GeoJSON files to PMTiles archives natively — no external tools like tippecanoe or GDAL required. The conversion runs entirely in Rust using Web Mercator tile math and MVT encoding.
+
+## Prerequisites
+
+The conversion feature is optional and gated behind the `convert` Cargo feature flag. Build the binary with it enabled:
+
+```bash
+cargo build --release --features convert
+```
+
+Pre-built binaries from GitHub Releases include this feature by default.
+
+## CLI
+
+### Basic Usage
+
+```bash
+# Convert a GeoJSON file — output defaults to <input>.pmtiles
+tileserver-rs convert cities.geojson
+
+# Specify output path
+tileserver-rs convert cities.geojson --output /data/cities.pmtiles
+
+# Set zoom range and layer name
+tileserver-rs convert cities.geojson \
+  --min-zoom 0 \
+  --max-zoom 10 \
+  --layer-name cities
+```
+
+### Options Reference
+
+| Option                           | Default                | Description                                      |
+| -------------------------------- | ---------------------- | ------------------------------------------------ |
+| `<INPUT>`                        | _(required)_           | Input GeoJSON file (`.geojson` or `.json`)       |
+| `-o, --output <FILE>`            | `<input stem>.pmtiles` | Output PMTiles archive path                      |
+| `--min-zoom <N>`                 | `0`                    | Minimum zoom level to generate                   |
+| `--max-zoom <N>`                 | Auto-detected          | Maximum zoom level to generate                   |
+| `--layer-name <NAME>`            | Input filename stem    | MVT layer name embedded in the archive           |
+| `--simplification <TOL>`         | Auto                   | Douglas-Peucker tolerance in degrees at z0       |
+| `--id-property <KEY>`            | _(none)_               | Property to use as MVT feature ID                |
+| `--include-properties <A,B,...>` | _(all)_                | Comma-separated whitelist of properties to keep  |
+| `--exclude-properties <A,B,...>` | _(none)_               | Comma-separated blacklist of properties to strip |
+| `--serve`                        | _(flag)_               | Start the tile server after conversion           |
+| `-p, --port <PORT>`              | `8080`                 | Port to bind when using `--serve`                |
+
+### Convert and Serve
+
+The `--serve` flag starts a tile server immediately after conversion, using the resulting PMTiles file as the only source:
+
+```bash
+tileserver-rs convert input.geojson --serve --port 8080
+```
+
+The server auto-assigns the layer name as the source ID, so the tile endpoint becomes:
+
+```
+GET /data/{layer-name}/{z}/{x}/{y}.pbf
+```
+
+### Auto Max Zoom
+
+When `--max-zoom` is not specified, tileserver-rs automatically detects a sensible maximum zoom level from the dataset:
+
+**For datasets with lines and polygons:** the algorithm finds the feature with the smallest bounding-box extent (the shortest or narrowest feature). It then computes the zoom level at which a tile is approximately the same width as that feature:
+
+```
+max_zoom = ceil(log2(360° / min_feature_extent))
+```
+
+This ensures even the smallest feature is visible at the maximum zoom level.
+
+**For point-only datasets:** a tippecanoe-style count heuristic is used:
+
+```
+max_zoom = floor(log2(feature_count)) + 7
+```
+
+The result is always clamped to the range `[0, 14]`.
+
+You can always override the detected value:
+
+```bash
+tileserver-rs convert data.geojson --max-zoom 12
+```
+
+### Simplification
+
+By default, tileserver-rs computes a zoom-appropriate simplification tolerance automatically using a **pixel-based formula**:
+
+```
+tolerance(z) = (360 / 2^z) / 4096 * 1.5
+```
+
+This equals ~1.5 pixels of tolerance at the given zoom level. It reduces coordinate count by 30–70% while being visually lossless for most datasets.
+
+You can override the base tolerance (in degrees, at zoom 0) — it is then halved at each additional zoom level:
+
+```bash
+tileserver-rs convert roads.geojson --simplification 0.01
+# tolerance at z5 = 0.01 / 2^5 = 0.0003125°
+```
+
+Set `--simplification 0` to disable simplification entirely.
+
+### Property Filtering
+
+Use `--include-properties` and `--exclude-properties` to control which feature properties end up in the tiles. Smaller tiles mean faster map loads.
+
+**Whitelist — keep only specific properties:**
+
+```bash
+tileserver-rs convert countries.geojson \
+  --include-properties name,iso_a3,pop_est
+```
+
+Only `name`, `iso_a3`, and `pop_est` will be present in the MVT tiles; all other properties are dropped.
+
+**Blacklist — strip specific properties:**
+
+```bash
+tileserver-rs convert countries.geojson \
+  --exclude-properties admin,featurecla,scalerank
+```
+
+All properties are kept except the listed ones.
+
+When both options are provided, `--include-properties` takes precedence and `--exclude-properties` is ignored.
+
+### Feature IDs
+
+MVT features can carry a numeric ID that enables [MapLibre feature state](https://maplibre.org/maplibre-gl-js/docs/API/classes/Map/#setfeaturestate) — for example, highlighting a feature on hover without re-rendering the tile.
+
+Use `--id-property` to specify which GeoJSON property to use as the feature ID:
+
+```bash
+tileserver-rs convert countries.geojson --id-property id
+```
+
+Each feature gets the value of its own `id` property as its MVT feature ID. The value must be an integer (or a string that parses as one); features with null or non-numeric values for that property receive no ID.
+
+```javascript
+// After conversion, use in MapLibre GL JS:
+map.setFeatureState({ source: "countries", id: 42 }, { hover: true });
+```
+
+## HTTP API
+
+When the server is started with the `convert` feature, three endpoints are added:
+
+| Method                       | Path                                        | Description |
+| ---------------------------- | ------------------------------------------- | ----------- |
+| `POST /convert`              | Upload GeoJSON (multipart), start async job |
+| `GET /convert/{id}/status`   | Poll job progress                           |
+| `GET /convert/{id}/download` | Download the finished PMTiles archive       |
+
+### Start a Conversion
+
+```bash
+curl -X POST http://localhost:8080/convert \
+  -F "file=@cities.geojson" \
+  -F "min_zoom=0" \
+  -F "max_zoom=10" \
+  -F "layer_name=cities" \
+  -F "id_property=id" \
+  -F "include_properties=name,population" \
+  -F "exclude_properties=featurecla,scalerank"
+```
+
+All fields except `file` are optional. When `max_zoom` is omitted, it is auto-detected from the dataset (same algorithm as the CLI).
+
+Response (`202 Accepted`):
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "Processing"
+}
+```
+
+### Poll Status
+
+```bash
+curl http://localhost:8080/convert/550e8400.../status
+```
+
+Response while running:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "Processing",
+  "progress": 0.42,
+  "error": null
+}
+```
+
+Response on completion:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "status": "Done",
+  "progress": 1.0,
+  "error": null
+}
+```
+
+### Download Result
+
+```bash
+curl -o result.pmtiles \
+  http://localhost:8080/convert/550e8400.../download
+```
+
+The file is streamed as `application/octet-stream`. After download the job is marked for cleanup.
+
+### Error Handling
+
+If conversion fails, the status response reflects it:
+
+```json
+{
+  "id": "...",
+  "status": "Failed",
+  "progress": 0.0,
+  "error": "Input file contains no features"
+}
+```
+
+### Job Lifecycle
+
+- Jobs are held in memory (no disk persistence).
+- Completed jobs are automatically removed 1 hour after creation via a background sweep.
+- Downloading the result does not immediately delete the job — it remains accessible until the TTL expires.
+
+## Supported Input Formats
+
+| Extension  | Format  | Notes                                        |
+| ---------- | ------- | -------------------------------------------- |
+| `.geojson` | GeoJSON | FeatureCollection, Feature, or bare Geometry |
+| `.json`    | GeoJSON | Same as `.geojson`                           |
+
+Support for additional formats (FlatGeobuf, GeoParquet) may be added in future releases.
+
+## Supported Geometry Types
+
+| Type                             | Handling                                  |
+| -------------------------------- | ----------------------------------------- |
+| `Point` / `MultiPoint`           | Point-in-tile containment test            |
+| `LineString` / `MultiLineString` | Clip to tile bounding box                 |
+| `Polygon` / `MultiPolygon`       | Intersection with tile bounding box       |
+| `GeometryCollection`             | Each sub-geometry processed independently |
+
+## Pipeline Details
+
+```
+GeoJSON file
+    ↓  read (geojson crate)                          sequential
+Vec<Feature> (geo::Geometry + JSON properties)
+    ↓  tile assignment (Web Mercator math)            sequential
+Per-tile feature sets
+    ↓  clip + simplify + encode  ×N tiles             parallel (rayon, all CPU cores)
+MVT bytes per tile
+    ↓  write (pmtiles::PmTilesWriter, Hilbert-ordered) sequential
+PMTiles archive
+```
+
+Tiles are inserted in Hilbert curve order, which produces a **clustered** PMTiles archive — nearby tiles on screen are also nearby on disk, minimising range requests for map viewers.
+
+## Example Workflow
+
+```bash
+# 1. Download a GeoJSON from any source
+
+# 2. Convert to PMTiles (zoom 0–12, layer name "airports")
+tileserver-rs convert airports.geojson \
+  --max-zoom 12 \
+  --layer-name airports
+
+# 3. Serve the result
+tileserver-rs airports.pmtiles
+# → http://localhost:8080/data/airports/{z}/{x}/{y}.pbf
+```
+
+## Troubleshooting
+
+### "Input file contains no features"
+
+The GeoJSON was parsed successfully but contained zero geometries. Check that the file is a valid `FeatureCollection` with at least one feature that has a non-null geometry.
+
+### Output file is very small
+
+At low zoom levels with point data, many tiles are empty and skipped per the PMTiles spec. Use `--min-zoom` closer to the zoom level where your data becomes visible.
+
+### Conversion is slow
+
+Tile encoding runs in parallel across all CPU cores automatically. If conversion is still slow:
+
+- Reduce `--max-zoom` — tile count grows as 4× per zoom level, so z14 has 16× more tiles than z10
+- Add `--simplification` — reduces geometry complexity before encoding
+- Ensure you are running a release build (`cargo build --release --features convert`) for ~10× faster encoding than debug builds
+
+## Next Steps
+
+- [Serving Vector Tiles](/guides/vector-tiles) — Configure the server to serve the resulting archive
+- [Zero-Config Auto-Detection](/guides/auto-detect) — Point the server at a file or directory
+- [Hot Reload](/guides/hot-reload) — Add new sources without restarting

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,10 +1,22 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use std::path::PathBuf;
+
+/// Subcommands (optional — no subcommand runs the tile server).
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Convert geospatial data to PMTiles archives
+    #[cfg(feature = "convert")]
+    Convert(tileserver_rs::convert::ConvertArgs),
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "tileserver-rs")]
 #[command(author, version, about = "A high-performance tile server for PMTiles and MBTiles", long_about = None)]
 pub struct Cli {
+    /// Subcommand to run (omit to start the tile server)
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+
     /// Path to a tile file or directory to auto-detect sources/styles from
     #[arg(value_name = "PATH")]
     pub path: Option<PathBuf>,

--- a/src/convert/args.rs
+++ b/src/convert/args.rs
@@ -1,0 +1,138 @@
+use clap::Args;
+use std::path::PathBuf;
+
+/// Convert geospatial data to PMTiles archives.
+#[derive(Args, Debug, Clone)]
+pub struct ConvertArgs {
+    /// Input GeoJSON file to convert
+    #[arg(value_name = "INPUT")]
+    pub input: PathBuf,
+
+    /// Output PMTiles file [default: <input>.pmtiles]
+    #[arg(short, long, value_name = "FILE")]
+    pub output: Option<PathBuf>,
+
+    /// Minimum zoom level
+    #[arg(long, default_value = "0")]
+    pub min_zoom: u8,
+
+    /// Maximum zoom level [default: auto-detected from dataset geometry]
+    #[arg(long)]
+    pub max_zoom: Option<u8>,
+
+    /// MVT layer name [default: input filename stem]
+    #[arg(long)]
+    pub layer_name: Option<String>,
+
+    /// Douglas-Peucker simplification tolerance at zoom 0 (auto if unset)
+    #[arg(long)]
+    pub simplification: Option<f64>,
+
+    /// Property name to use as MVT feature ID (enables MapLibre feature state)
+    #[arg(long)]
+    pub id_property: Option<String>,
+
+    /// Only include these properties in tiles (comma-separated whitelist)
+    #[arg(long, value_delimiter = ',')]
+    pub include_properties: Option<Vec<String>>,
+
+    /// Strip these properties from tiles (comma-separated blacklist)
+    #[arg(long, value_delimiter = ',')]
+    pub exclude_properties: Vec<String>,
+
+    /// After conversion, start the tile server on the resulting file
+    #[arg(long)]
+    pub serve: bool,
+
+    /// Port to bind when using --serve
+    #[arg(short, long, default_value = "8080")]
+    pub port: u16,
+}
+
+impl ConvertArgs {
+    /// Resolve the output path: explicit --output or <input stem>.pmtiles
+    pub fn resolve_output(&self) -> PathBuf {
+        if let Some(ref out) = self.output {
+            return out.clone();
+        }
+        let stem = self
+            .input
+            .file_stem()
+            .unwrap_or_else(|| self.input.as_os_str());
+        let mut out = self.input.with_file_name(stem);
+        out.set_extension("pmtiles");
+        out
+    }
+
+    /// Resolve the MVT layer name: explicit --layer-name or input filename stem
+    pub fn resolve_layer_name(&self) -> String {
+        if let Some(ref name) = self.layer_name {
+            return name.clone();
+        }
+        self.input
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("layer")
+            .to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args_with_input(input: &str) -> ConvertArgs {
+        ConvertArgs {
+            input: PathBuf::from(input),
+            output: None,
+            min_zoom: 0,
+            max_zoom: None,
+            layer_name: None,
+            simplification: None,
+            id_property: None,
+            include_properties: None,
+            exclude_properties: vec![],
+            serve: false,
+            port: 8080,
+        }
+    }
+
+    #[test]
+    fn resolve_output_defaults_to_input_stem_with_pmtiles_extension() {
+        let args = args_with_input("/tmp/my_data.geojson");
+        assert_eq!(args.resolve_output(), PathBuf::from("/tmp/my_data.pmtiles"));
+    }
+
+    #[test]
+    fn resolve_output_respects_explicit_flag() {
+        let mut args = args_with_input("/tmp/input.geojson");
+        args.output = Some(PathBuf::from("/out/custom.pmtiles"));
+        assert_eq!(args.resolve_output(), PathBuf::from("/out/custom.pmtiles"));
+    }
+
+    #[test]
+    fn resolve_output_handles_file_without_extension() {
+        let args = args_with_input("/tmp/data");
+        // file_stem of "data" is "data"
+        assert_eq!(args.resolve_output(), PathBuf::from("/tmp/data.pmtiles"));
+    }
+
+    #[test]
+    fn resolve_layer_name_defaults_to_file_stem() {
+        let args = args_with_input("/data/roads.geojson");
+        assert_eq!(args.resolve_layer_name(), "roads");
+    }
+
+    #[test]
+    fn resolve_layer_name_respects_explicit_flag() {
+        let mut args = args_with_input("/data/roads.geojson");
+        args.layer_name = Some("my_layer".to_string());
+        assert_eq!(args.resolve_layer_name(), "my_layer");
+    }
+
+    #[test]
+    fn resolve_layer_name_strips_all_extensions() {
+        let args = args_with_input("/data/admin_boundaries.geojson");
+        assert_eq!(args.resolve_layer_name(), "admin_boundaries");
+    }
+}

--- a/src/convert/http.rs
+++ b/src/convert/http.rs
@@ -1,0 +1,272 @@
+use axum::{
+    body::Body,
+    extract::{Extension, Multipart, Path},
+    http::{header, StatusCode},
+    response::{IntoResponse, Json, Response},
+};
+use serde_json::json;
+use std::sync::Arc;
+use tokio::fs;
+use uuid::Uuid;
+
+use crate::convert::{
+    job::{ConvertJob, ConvertState, JobStatus},
+    pipeline::{run, ConvertOptions},
+    progress::HttpProgressReporter,
+};
+
+/// POST /convert
+///
+/// Accepts a multipart upload with a GeoJSON file.
+/// Starts a background job and returns the job ID immediately.
+///
+/// Form fields:
+/// - `file`: the GeoJSON file bytes (required)
+/// - `min_zoom`: minimum zoom level (optional, default 0)
+/// - `max_zoom`: maximum zoom level (optional, default 14)
+/// - `layer_name`: MVT layer name (optional)
+pub async fn start_conversion(
+    Extension(state): Extension<ConvertState>,
+    mut multipart: Multipart,
+) -> Response {
+    // Parse multipart fields
+    let mut file_bytes: Option<Vec<u8>> = None;
+    let mut file_name = String::from("layer");
+    let mut min_zoom: u8 = 0;
+    let mut max_zoom: Option<u8> = None;
+    let mut layer_name: Option<String> = None;
+    let mut id_property: Option<String> = None;
+    let mut include_properties: Option<Vec<String>> = None;
+    let mut exclude_properties: Vec<String> = Vec::new();
+
+    while let Ok(Some(field)) = multipart.next_field().await {
+        let name = field.name().unwrap_or("").to_owned();
+        match name.as_str() {
+            "file" => {
+                if let Some(fname) = field.file_name() {
+                    // Extract stem for default layer name
+                    file_name = std::path::Path::new(fname)
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("layer")
+                        .to_owned();
+                }
+                match field.bytes().await {
+                    Ok(b) => file_bytes = Some(b.to_vec()),
+                    Err(e) => {
+                        return (
+                            StatusCode::BAD_REQUEST,
+                            Json(json!({"error": format!("Failed to read file: {e}")})),
+                        )
+                            .into_response();
+                    }
+                }
+            }
+            "min_zoom" => {
+                if let Ok(b) = field.bytes().await {
+                    if let Ok(s) = std::str::from_utf8(&b) {
+                        min_zoom = s.trim().parse().unwrap_or(0);
+                    }
+                }
+            }
+            "max_zoom" => {
+                if let Ok(b) = field.bytes().await {
+                    if let Ok(s) = std::str::from_utf8(&b) {
+                        max_zoom = s.trim().parse().ok();
+                    }
+                }
+            }
+            "layer_name" => {
+                if let Ok(b) = field.bytes().await {
+                    if let Ok(s) = std::str::from_utf8(&b) {
+                        layer_name = Some(s.trim().to_owned());
+                    }
+                }
+            }
+            "id_property" => {
+                if let Ok(b) = field.bytes().await {
+                    if let Ok(s) = std::str::from_utf8(&b) {
+                        let v = s.trim().to_owned();
+                        if !v.is_empty() {
+                            id_property = Some(v);
+                        }
+                    }
+                }
+            }
+            "include_properties" => {
+                if let Ok(b) = field.bytes().await {
+                    if let Ok(s) = std::str::from_utf8(&b) {
+                        let props: Vec<String> = s
+                            .split(',')
+                            .map(str::trim)
+                            .filter(|p| !p.is_empty())
+                            .map(str::to_owned)
+                            .collect();
+                        if !props.is_empty() {
+                            include_properties = Some(props);
+                        }
+                    }
+                }
+            }
+            "exclude_properties" => {
+                if let Ok(b) = field.bytes().await {
+                    if let Ok(s) = std::str::from_utf8(&b) {
+                        exclude_properties = s
+                            .split(',')
+                            .map(str::trim)
+                            .filter(|p| !p.is_empty())
+                            .map(str::to_owned)
+                            .collect();
+                    }
+                }
+            }
+            _ => {
+                let _ = field.bytes().await;
+            }
+        }
+    }
+
+    let Some(bytes) = file_bytes else {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "Missing 'file' field in multipart form"})),
+        )
+            .into_response();
+    };
+
+    let id = Uuid::new_v4().to_string();
+    let job = ConvertJob::new(&id);
+    let progress = Arc::clone(&job.progress);
+    state.insert(job);
+
+    let resolved_layer = layer_name.unwrap_or(file_name);
+    let output_path = state.temp_dir().join(format!("{id}.pmtiles"));
+    let input_path = state.temp_dir().join(format!("{id}.geojson"));
+
+    // Write uploaded file to temp location
+    if let Err(e) = fs::write(&input_path, &bytes).await {
+        state.update(&id, |job| {
+            job.status = JobStatus::Failed;
+            job.error = Some(format!("Failed to write temp file: {e}"));
+        });
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": "Failed to store uploaded file"})),
+        )
+            .into_response();
+    }
+
+    let opts = ConvertOptions {
+        min_zoom,
+        max_zoom,
+        layer_name: resolved_layer,
+        simplification: None,
+        id_property,
+        include_properties,
+        exclude_properties,
+    };
+
+    let state_clone = state.clone();
+    let id_clone = id.clone();
+    let output_clone = output_path.clone();
+
+    // Run conversion in a blocking thread (CPU-bound work)
+    tokio::task::spawn_blocking(move || {
+        let reporter = HttpProgressReporter::new(progress);
+        match run(&input_path, &output_clone, &opts, &reporter) {
+            Ok(()) => {
+                state_clone.update(&id_clone, |job| {
+                    job.status = JobStatus::Done;
+                    job.output_path = Some(output_clone);
+                });
+            }
+            Err(e) => {
+                state_clone.update(&id_clone, |job| {
+                    job.status = JobStatus::Failed;
+                    job.error = Some(e.to_string());
+                });
+            }
+        }
+        // Clean up the input temp file regardless
+        let _ = std::fs::remove_file(&input_path);
+    });
+
+    let progress_url = format!("/convert/{id}/status");
+    (
+        StatusCode::ACCEPTED,
+        Json(json!({
+            "id": id,
+            "status": "processing",
+            "progress_url": progress_url,
+        })),
+    )
+        .into_response()
+}
+
+/// GET /convert/{id}/status
+pub async fn job_status(
+    Path(id): Path<String>,
+    Extension(state): Extension<ConvertState>,
+) -> Response {
+    match state.get_status(&id) {
+        Some(status) => Json(status).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "Job not found"})),
+        )
+            .into_response(),
+    }
+}
+
+/// GET /convert/{id}/download
+///
+/// Returns the PMTiles file when the job is done.
+pub async fn download_result(
+    Path(id): Path<String>,
+    Extension(state): Extension<ConvertState>,
+) -> Response {
+    let Some(output_path) = state.get_output_path(&id) else {
+        let status = state.get_status(&id);
+        return match status {
+            None => (
+                StatusCode::NOT_FOUND,
+                Json(json!({"error": "Job not found"})),
+            )
+                .into_response(),
+            Some(s) if s.status == JobStatus::Processing => (
+                StatusCode::ACCEPTED,
+                Json(json!({"error": "Job still processing", "progress": s.progress})),
+            )
+                .into_response(),
+            Some(s) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": s.error.unwrap_or_else(|| "Conversion failed".into())})),
+            )
+                .into_response(),
+        };
+    };
+
+    let file_name = output_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("result.pmtiles");
+
+    match fs::read(&output_path).await {
+        Ok(bytes) => {
+            let content_disposition = format!("attachment; filename=\"{file_name}\"");
+            (
+                [
+                    (header::CONTENT_TYPE, "application/octet-stream"),
+                    (header::CONTENT_DISPOSITION, &content_disposition),
+                ],
+                Body::from(bytes),
+            )
+                .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("Failed to read output file: {e}")})),
+        )
+            .into_response(),
+    }
+}

--- a/src/convert/input/csv.rs
+++ b/src/convert/input/csv.rs
@@ -1,0 +1,240 @@
+use anyhow::{bail, Context, Result};
+use geo::Geometry;
+use std::path::Path;
+
+use super::Feature;
+
+/// Column-name aliases recognised as the longitude field (case-insensitive).
+const LON_ALIASES: &[&str] = &["lon", "longitude", "x", "lng"];
+/// Column-name aliases recognised as the latitude field (case-insensitive).
+const LAT_ALIASES: &[&str] = &["lat", "latitude", "y"];
+
+/// Read a CSV file and return one Point feature per row.
+///
+/// The file must have a header row. One column must be recognisable as longitude
+/// and one as latitude (see `LON_ALIASES` / `LAT_ALIASES`). All other columns
+/// are included as feature properties, with automatic type inference: values
+/// that parse as `f64` become JSON numbers; everything else becomes a JSON string.
+pub fn read(path: &Path) -> Result<Vec<Feature>> {
+    let mut reader = csv::Reader::from_path(path)
+        .with_context(|| format!("Failed to open CSV file: {}", path.display()))?;
+
+    let headers = reader
+        .headers()
+        .with_context(|| format!("Failed to read CSV headers: {}", path.display()))?
+        .clone();
+
+    // Locate the lon/lat columns by matching aliases.
+    let lon_idx = find_column(&headers, LON_ALIASES).with_context(|| {
+        format!(
+            "CSV file has no recognisable longitude column (tried: {}): {}",
+            LON_ALIASES.join(", "),
+            path.display()
+        )
+    })?;
+    let lat_idx = find_column(&headers, LAT_ALIASES).with_context(|| {
+        format!(
+            "CSV file has no recognisable latitude column (tried: {}): {}",
+            LAT_ALIASES.join(", "),
+            path.display()
+        )
+    })?;
+
+    // Build the list of property column indices (everything except lon/lat).
+    let prop_cols: Vec<(usize, &str)> = headers
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| *i != lon_idx && *i != lat_idx)
+        .collect();
+
+    let mut features = Vec::new();
+
+    for (row_num, result) in reader.records().enumerate() {
+        let record = result.with_context(|| {
+            format!(
+                "Failed to parse CSV row {} in: {}",
+                row_num + 2, // +2: 1-based + header row
+                path.display()
+            )
+        })?;
+
+        let lon: f64 = record
+            .get(lon_idx)
+            .unwrap_or("")
+            .trim()
+            .parse()
+            .with_context(|| {
+                format!(
+                    "Invalid longitude value at row {} in: {}",
+                    row_num + 2,
+                    path.display()
+                )
+            })?;
+
+        let lat: f64 = record
+            .get(lat_idx)
+            .unwrap_or("")
+            .trim()
+            .parse()
+            .with_context(|| {
+                format!(
+                    "Invalid latitude value at row {} in: {}",
+                    row_num + 2,
+                    path.display()
+                )
+            })?;
+
+        if !(-180.0..=180.0).contains(&lon) || !(-90.0..=90.0).contains(&lat) {
+            bail!(
+                "Coordinates out of range at row {} (lon={lon}, lat={lat}) in: {}",
+                row_num + 2,
+                path.display()
+            );
+        }
+
+        let mut properties = serde_json::Map::new();
+        for (idx, name) in &prop_cols {
+            let raw = record.get(*idx).unwrap_or("").trim();
+            let value = infer_value(raw);
+            properties.insert((*name).to_owned(), value);
+        }
+
+        features.push(Feature {
+            geometry: Geometry::Point(geo::Point::new(lon, lat)),
+            properties,
+        });
+    }
+
+    Ok(features)
+}
+
+/// Find the first column whose lowercased name matches any of `aliases`.
+fn find_column(headers: &csv::StringRecord, aliases: &[&str]) -> Option<usize> {
+    headers.iter().position(|h| {
+        let lower = h.to_ascii_lowercase();
+        aliases.iter().any(|a| *a == lower)
+    })
+}
+
+/// Infer a JSON value from a raw string: try `f64`, fall back to string.
+/// Empty strings become `null`.
+fn infer_value(raw: &str) -> serde_json::Value {
+    if raw.is_empty() {
+        return serde_json::Value::Null;
+    }
+    if let Ok(n) = raw.parse::<f64>() {
+        if let Some(v) = serde_json::Number::from_f64(n) {
+            return serde_json::Value::Number(v);
+        }
+    }
+    serde_json::Value::String(raw.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::Builder;
+
+    fn write_csv(content: &str) -> tempfile::NamedTempFile {
+        let mut f = Builder::new()
+            .suffix(".csv")
+            .tempfile()
+            .expect("create tempfile");
+        f.write_all(content.as_bytes()).expect("write csv");
+        f
+    }
+
+    #[test]
+    fn reads_basic_lon_lat_columns() {
+        let f = write_csv("lon,lat,name\n13.4,52.5,Berlin\n2.35,48.85,Paris\n");
+        let features = read(f.path()).unwrap();
+        assert_eq!(features.len(), 2);
+        assert!(matches!(features[0].geometry, geo::Geometry::Point(_)));
+        assert_eq!(features[0].properties["name"], serde_json::json!("Berlin"));
+    }
+
+    #[test]
+    fn accepts_longitude_latitude_aliases() {
+        let f = write_csv("longitude,latitude\n10.0,50.0\n");
+        let features = read(f.path()).unwrap();
+        assert_eq!(features.len(), 1);
+        if let geo::Geometry::Point(p) = &features[0].geometry {
+            assert!((p.x() - 10.0).abs() < 1e-10);
+            assert!((p.y() - 50.0).abs() < 1e-10);
+        } else {
+            panic!("expected Point");
+        }
+    }
+
+    #[test]
+    fn accepts_x_y_aliases() {
+        let f = write_csv("x,y,value\n5.0,45.0,42\n");
+        let features = read(f.path()).unwrap();
+        assert_eq!(features.len(), 1);
+        assert_eq!(features[0].properties["value"], serde_json::json!(42.0));
+    }
+
+    #[test]
+    fn infers_numeric_properties() {
+        let f = write_csv("lon,lat,pop,name\n0.0,0.0,1000000,City\n");
+        let features = read(f.path()).unwrap();
+        let props = &features[0].properties;
+        // Numeric strings become JSON numbers
+        assert!(props["pop"].is_number());
+        assert!(props["name"].is_string());
+    }
+
+    #[test]
+    fn empty_property_becomes_null() {
+        let f = write_csv("lon,lat,note\n0.0,0.0,\n");
+        let features = read(f.path()).unwrap();
+        assert_eq!(features[0].properties["note"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn returns_error_for_missing_lon_column() {
+        let f = write_csv("x_coord,lat\n10.0,50.0\n");
+        let result = read(f.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("longitude"));
+    }
+
+    #[test]
+    fn returns_error_for_missing_lat_column() {
+        let f = write_csv("lon,y_coord\n10.0,50.0\n");
+        let result = read(f.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("latitude"));
+    }
+
+    #[test]
+    fn returns_error_for_invalid_coordinate() {
+        let f = write_csv("lon,lat\nnot_a_number,50.0\n");
+        let result = read(f.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn returns_error_for_out_of_range_coordinates() {
+        let f = write_csv("lon,lat\n999.0,50.0\n");
+        let result = read(f.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("out of range"));
+    }
+
+    #[test]
+    fn dispatches_via_read_features() {
+        use super::super::read_features;
+        let f = write_csv("lon,lat,name\n13.4,52.5,Berlin\n");
+        let features = read_features(f.path()).unwrap();
+        assert_eq!(features.len(), 1);
+    }
+
+    #[test]
+    fn case_insensitive_column_names() {
+        let f = write_csv("LON,LAT,Name\n1.0,2.0,Test\n");
+        let features = read(f.path()).unwrap();
+        assert_eq!(features.len(), 1);
+    }
+}

--- a/src/convert/input/geojson.rs
+++ b/src/convert/input/geojson.rs
@@ -145,10 +145,10 @@ mod tests {
         // Test via read_features dispatch (wrong extension)
         use super::super::read_features;
         let mut f = Builder::new()
-            .suffix(".csv")
+            .suffix(".xlsx")
             .tempfile()
             .expect("create tempfile");
-        f.write_all(b"lon,lat\n13.4,52.5").expect("write");
+        f.write_all(b"dummy").expect("write");
         let result = read_features(f.path());
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Unsupported"));

--- a/src/convert/input/geojson.rs
+++ b/src/convert/input/geojson.rs
@@ -1,0 +1,156 @@
+use anyhow::{Context, Result};
+use geojson::{Feature as GeoFeature, FeatureCollection, GeoJson};
+use std::path::Path;
+
+use super::Feature;
+
+/// Read a GeoJSON file and return all features with their geometries and properties.
+pub fn read(path: &Path) -> Result<Vec<Feature>> {
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read GeoJSON file: {}", path.display()))?;
+
+    let geojson: GeoJson = content
+        .parse()
+        .with_context(|| format!("Failed to parse GeoJSON: {}", path.display()))?;
+
+    let collection = match geojson {
+        GeoJson::FeatureCollection(fc) => fc,
+        GeoJson::Feature(f) => FeatureCollection {
+            bbox: None,
+            features: vec![f],
+            foreign_members: None,
+        },
+        GeoJson::Geometry(g) => FeatureCollection {
+            bbox: None,
+            features: vec![GeoFeature {
+                bbox: None,
+                geometry: Some(g),
+                id: None,
+                properties: None,
+                foreign_members: None,
+            }],
+            foreign_members: None,
+        },
+    };
+
+    let mut features = Vec::with_capacity(collection.features.len());
+    for geo_feature in collection.features {
+        if let Some(geom) = geo_feature.geometry {
+            let geometry: geo::Geometry<f64> = geom
+                .try_into()
+                .context("Failed to convert GeoJSON geometry to geo_types")?;
+            let properties = geo_feature.properties.unwrap_or_default();
+            features.push(Feature {
+                geometry,
+                properties,
+            });
+        }
+    }
+
+    Ok(features)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::Builder;
+
+    fn write_geojson(content: &str) -> tempfile::NamedTempFile {
+        let mut f = Builder::new()
+            .suffix(".geojson")
+            .tempfile()
+            .expect("create tempfile");
+        f.write_all(content.as_bytes()).expect("write geojson");
+        f
+    }
+
+    #[test]
+    fn reads_single_point_from_feature_collection() {
+        let f = write_geojson(
+            r#"{"type":"FeatureCollection","features":[
+                {"type":"Feature","geometry":{"type":"Point","coordinates":[13.4,52.5]},"properties":{"name":"Berlin"}}
+            ]}"#,
+        );
+        let features = read(f.path()).unwrap();
+        assert_eq!(features.len(), 1);
+        assert!(matches!(features[0].geometry, geo::Geometry::Point(_)));
+    }
+
+    #[test]
+    fn reads_properties_correctly() {
+        let f = write_geojson(
+            r#"{"type":"Feature","geometry":{"type":"Point","coordinates":[0.0,0.0]},
+               "properties":{"string":"hello","number":42,"bool":true,"null_val":null}}"#,
+        );
+        let features = read(f.path()).unwrap();
+        assert_eq!(features.len(), 1);
+        let props = &features[0].properties;
+        assert_eq!(props["string"], serde_json::json!("hello"));
+        assert_eq!(props["number"], serde_json::json!(42));
+        assert_eq!(props["bool"], serde_json::json!(true));
+        assert_eq!(props["null_val"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn wraps_bare_geometry_in_feature() {
+        let f = write_geojson(r#"{"type":"Point","coordinates":[5.0,45.0]}"#);
+        let features = read(f.path()).unwrap();
+        assert_eq!(features.len(), 1);
+        assert!(matches!(features[0].geometry, geo::Geometry::Point(_)));
+    }
+
+    #[test]
+    fn wraps_bare_feature_without_collection() {
+        let f = write_geojson(
+            r#"{"type":"Feature","geometry":{"type":"Point","coordinates":[0.0,0.0]},"properties":{}}"#,
+        );
+        let features = read(f.path()).unwrap();
+        assert_eq!(features.len(), 1);
+    }
+
+    #[test]
+    fn skips_features_without_geometry() {
+        let f = write_geojson(
+            r#"{"type":"FeatureCollection","features":[
+                {"type":"Feature","geometry":null,"properties":{}},
+                {"type":"Feature","geometry":{"type":"Point","coordinates":[1.0,2.0]},"properties":{}}
+            ]}"#,
+        );
+        let features = read(f.path()).unwrap();
+        assert_eq!(features.len(), 1);
+    }
+
+    #[test]
+    fn reads_multiple_geometry_types() {
+        let f = write_geojson(
+            r#"{"type":"FeatureCollection","features":[
+                {"type":"Feature","geometry":{"type":"Point","coordinates":[0.0,0.0]},"properties":{}},
+                {"type":"Feature","geometry":{"type":"LineString","coordinates":[[0,0],[1,1]]},"properties":{}},
+                {"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]},"properties":{}}
+            ]}"#,
+        );
+        let features = read(f.path()).unwrap();
+        assert_eq!(features.len(), 3);
+    }
+
+    #[test]
+    fn returns_error_for_invalid_json() {
+        let f = write_geojson("this is not json {{{");
+        assert!(read(f.path()).is_err());
+    }
+
+    #[test]
+    fn returns_error_for_unsupported_extension() {
+        // Test via read_features dispatch (wrong extension)
+        use super::super::read_features;
+        let mut f = Builder::new()
+            .suffix(".csv")
+            .tempfile()
+            .expect("create tempfile");
+        f.write_all(b"lon,lat\n13.4,52.5").expect("write");
+        let result = read_features(f.path());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unsupported"));
+    }
+}

--- a/src/convert/input/mod.rs
+++ b/src/convert/input/mod.rs
@@ -3,6 +3,7 @@ use geo::Geometry;
 use serde_json::{Map, Value};
 use std::path::Path;
 
+pub mod csv;
 pub mod geojson;
 
 /// A single geospatial feature with WGS-84 geometry and JSON properties.
@@ -15,6 +16,7 @@ pub struct Feature {
 /// Supported input formats (for future extension).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputFormat {
+    Csv,
     GeoJson,
 }
 
@@ -23,6 +25,7 @@ impl InputFormat {
     pub fn from_path(path: &Path) -> Option<Self> {
         let ext = path.extension()?.to_str()?.to_ascii_lowercase();
         match ext.as_str() {
+            "csv" => Some(Self::Csv),
             "geojson" | "json" => Some(Self::GeoJson),
             _ => None,
         }
@@ -35,6 +38,7 @@ pub fn read_features(path: &Path) -> Result<Vec<Feature>> {
         .ok_or_else(|| anyhow::anyhow!("Unsupported file extension: {}", path.display()))?;
 
     match fmt {
+        InputFormat::Csv => csv::read(path),
         InputFormat::GeoJson => geojson::read(path),
     }
 }

--- a/src/convert/input/mod.rs
+++ b/src/convert/input/mod.rs
@@ -1,0 +1,40 @@
+use anyhow::Result;
+use geo::Geometry;
+use serde_json::{Map, Value};
+use std::path::Path;
+
+pub mod geojson;
+
+/// A single geospatial feature with WGS-84 geometry and JSON properties.
+#[derive(Debug, Clone)]
+pub struct Feature {
+    pub geometry: Geometry<f64>,
+    pub properties: Map<String, Value>,
+}
+
+/// Supported input formats (for future extension).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputFormat {
+    GeoJson,
+}
+
+impl InputFormat {
+    /// Detect format from file extension.
+    pub fn from_path(path: &Path) -> Option<Self> {
+        let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+        match ext.as_str() {
+            "geojson" | "json" => Some(Self::GeoJson),
+            _ => None,
+        }
+    }
+}
+
+/// Read all features from a file, dispatching by format.
+pub fn read_features(path: &Path) -> Result<Vec<Feature>> {
+    let fmt = InputFormat::from_path(path)
+        .ok_or_else(|| anyhow::anyhow!("Unsupported file extension: {}", path.display()))?;
+
+    match fmt {
+        InputFormat::GeoJson => geojson::read(path),
+    }
+}

--- a/src/convert/job.rs
+++ b/src/convert/job.rs
@@ -1,0 +1,129 @@
+use serde::Serialize;
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Arc, Mutex, RwLock},
+    time::{Duration, Instant},
+};
+
+/// Status of a conversion job.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum JobStatus {
+    Processing,
+    Done,
+    Failed,
+}
+
+/// A running or completed conversion job.
+#[derive(Debug, Clone)]
+pub struct ConvertJob {
+    pub id: String,
+    pub status: JobStatus,
+    /// Progress from 0.0 to 1.0.
+    pub progress: Arc<Mutex<f32>>,
+    /// Path to the output PMTiles file (set when Done).
+    pub output_path: Option<PathBuf>,
+    /// Error message (set when Failed).
+    pub error: Option<String>,
+    /// When the job was created (for TTL cleanup).
+    pub created_at: Instant,
+}
+
+impl ConvertJob {
+    pub fn new(id: &str) -> Self {
+        Self {
+            id: id.to_owned(),
+            status: JobStatus::Processing,
+            progress: Arc::new(Mutex::new(0.0)),
+            output_path: None,
+            error: None,
+            created_at: Instant::now(),
+        }
+    }
+
+    pub fn current_progress(&self) -> f32 {
+        *self.progress.lock().unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+/// HTTP response body for GET /convert/{id}/status
+#[derive(Serialize)]
+pub struct JobStatusResponse {
+    pub id: String,
+    pub status: JobStatus,
+    pub progress: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Shared job store for HTTP endpoint.
+#[derive(Clone, Default)]
+pub struct ConvertState {
+    inner: Arc<RwLock<HashMap<String, ConvertJob>>>,
+    temp_dir: Arc<PathBuf>,
+}
+
+impl ConvertState {
+    pub fn new() -> Self {
+        let temp_dir = std::env::temp_dir().join("tileserver-rs-convert");
+        let _ = std::fs::create_dir_all(&temp_dir);
+        Self {
+            inner: Arc::default(),
+            temp_dir: Arc::new(temp_dir),
+        }
+    }
+
+    pub fn temp_dir(&self) -> &PathBuf {
+        &self.temp_dir
+    }
+
+    pub fn insert(&self, job: ConvertJob) {
+        self.inner
+            .write()
+            .expect("ConvertState lock poisoned")
+            .insert(job.id.clone(), job);
+    }
+
+    /// Update a job's status and optional output path / error in place.
+    pub fn update<F>(&self, id: &str, f: F)
+    where
+        F: FnOnce(&mut ConvertJob),
+    {
+        if let Ok(mut jobs) = self.inner.write() {
+            if let Some(job) = jobs.get_mut(id) {
+                f(job);
+            }
+        }
+    }
+
+    pub fn get_status(&self, id: &str) -> Option<JobStatusResponse> {
+        let jobs = self.inner.read().ok()?;
+        let job = jobs.get(id)?;
+        Some(JobStatusResponse {
+            id: job.id.clone(),
+            status: job.status.clone(),
+            progress: job.current_progress(),
+            error: job.error.clone(),
+        })
+    }
+
+    pub fn get_output_path(&self, id: &str) -> Option<PathBuf> {
+        let jobs = self.inner.read().ok()?;
+        let job = jobs.get(id)?;
+        if job.status == JobStatus::Done {
+            job.output_path.clone()
+        } else {
+            None
+        }
+    }
+
+    /// Remove completed/failed jobs older than `ttl`.
+    pub fn sweep_expired(&self, ttl: Duration) {
+        if let Ok(mut jobs) = self.inner.write() {
+            jobs.retain(|_, job| {
+                job.status == JobStatus::Processing || job.created_at.elapsed() < ttl
+            });
+        }
+    }
+}

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -1,0 +1,103 @@
+//! GeoJSON → PMTiles conversion pipeline.
+//!
+//! # Module layout
+//!
+//! | File | Responsibility |
+//! |------|---------------|
+//! | `args.rs` | CLI `ConvertArgs` struct |
+//! | `http.rs` | Axum HTTP handlers |
+//! | `job.rs` | `ConvertJob` / `ConvertState` (HTTP job store) |
+//! | `pipeline.rs` | Full conversion orchestrator |
+//! | `tiler.rs` | Web Mercator tile math |
+//! | `mvt_builder.rs` | MVT tile encoding |
+//! | `writer.rs` | PMTiles archive writer |
+//! | `progress.rs` | `ProgressReporter` trait + implementations |
+//! | `input/` | Format-specific readers |
+//!
+//! # Public API (called from `main.rs` / `cli.rs`)
+//!
+//! ```ignore
+//! convert::run_cli(args)?;          // CLI subcommand
+//! convert::router(state)            // Axum HTTP sub-router
+//! ```
+
+pub mod args;
+pub mod http;
+pub mod input;
+pub mod job;
+pub mod mvt_builder;
+pub mod pipeline;
+pub mod progress;
+pub mod tiler;
+pub mod writer;
+
+pub use args::ConvertArgs;
+pub use job::ConvertState;
+
+use anyhow::Result;
+use axum::{routing, Extension, Router};
+use std::{path::PathBuf, time::Duration};
+
+/// Result of the CLI convert subcommand.
+pub struct ConvertResult {
+    /// Path to the written PMTiles file.
+    pub output_path: PathBuf,
+    /// Source ID used as the layer name (for --serve).
+    pub source_id: String,
+}
+
+/// Entry point for the CLI `convert` subcommand.
+///
+/// Returns `ConvertResult` so that `main.rs` can start a tile server when
+/// `--serve` is requested without duplicating startup logic.
+pub fn run_cli(args: &ConvertArgs) -> Result<ConvertResult> {
+    use pipeline::{run, ConvertOptions};
+    use progress::IndicatifReporter;
+
+    let output = args.resolve_output();
+    let layer_name = args.resolve_layer_name();
+
+    let opts = ConvertOptions {
+        min_zoom: args.min_zoom,
+        max_zoom: args.max_zoom,
+        layer_name: layer_name.clone(),
+        simplification: args.simplification,
+        id_property: args.id_property.clone(),
+        include_properties: args.include_properties.clone(),
+        exclude_properties: args.exclude_properties.clone(),
+    };
+
+    let reporter = IndicatifReporter::new();
+    run(&args.input, &output, &opts, &reporter)?;
+
+    eprintln!("Written {} tiles to {}", layer_name, output.display());
+
+    Ok(ConvertResult {
+        output_path: output,
+        source_id: layer_name,
+    })
+}
+
+/// Build the Axum sub-router for HTTP conversion endpoints.
+///
+/// Mount this onto the main router with `.merge(convert::router(state))`.
+pub fn router(state: ConvertState) -> Router {
+    // Background TTL sweep: remove jobs older than 1 hour every 10 minutes
+    let sweep_state = state.clone();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(600));
+        loop {
+            interval.tick().await;
+            sweep_state.sweep_expired(Duration::from_secs(3600));
+        }
+    });
+
+    Router::new()
+        .route("/convert", routing::post(http::start_conversion))
+        .route("/convert/{id}/status", routing::get(http::job_status))
+        .route(
+            "/convert/{id}/download",
+            routing::get(http::download_result),
+        )
+        .layer(Extension(state))
+}

--- a/src/convert/mvt_builder.rs
+++ b/src/convert/mvt_builder.rs
@@ -1,0 +1,304 @@
+use anyhow::Result;
+use geo::{Geometry, Rect};
+use geozero::mvt::{tile, Message, Tile};
+use geozero::ToMvt;
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+
+/// A feature ready for MVT encoding (geometry already clipped and in geographic space).
+pub struct TileFeature {
+    pub geometry: Geometry<f64>,
+    pub properties: Map<String, Value>,
+    /// Optional MVT feature ID (enables MapLibre feature state).
+    pub id: Option<u64>,
+}
+
+/// Build a complete MVT tile and return the encoded protobuf bytes.
+///
+/// `bbox` is the geographic extent of the tile (west/south/east/north in WGS-84).
+/// The returned bytes are uncompressed; the PMTiles writer compresses them.
+pub fn build_tile_bytes(
+    features: &[TileFeature],
+    bbox: &Rect<f64>,
+    layer_name: &str,
+) -> Result<Vec<u8>> {
+    if features.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    const EXTENT: u32 = 4096;
+
+    let west = bbox.min().x;
+    let south = bbox.min().y;
+    let east = bbox.max().x;
+    let north = bbox.max().y;
+
+    let mut keys: Vec<String> = Vec::new();
+    let mut values: Vec<tile::Value> = Vec::new();
+    let mut key_index: HashMap<String, usize> = HashMap::new();
+    let mut mvt_features: Vec<tile::Feature> = Vec::new();
+
+    for feat in features {
+        // Convert geometry to MVT coordinates (scaled to 0..EXTENT)
+        let mvt_geom = match feat.geometry.to_mvt(EXTENT, west, south, east, north) {
+            Ok(g) => g,
+            Err(_) => continue, // skip degenerate geometries
+        };
+
+        if mvt_geom.geometry.is_empty() {
+            continue;
+        }
+
+        // Encode properties into the key/value tables
+        let tags = encode_properties(&feat.properties, &mut keys, &mut values, &mut key_index);
+
+        mvt_features.push(tile::Feature {
+            id: feat.id,
+            tags,
+            r#type: mvt_geom.r#type,
+            geometry: mvt_geom.geometry,
+        });
+    }
+
+    if mvt_features.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let layer = tile::Layer {
+        version: 2,
+        name: layer_name.to_owned(),
+        features: mvt_features,
+        keys,
+        values,
+        extent: Some(EXTENT),
+    };
+
+    let tile = Tile {
+        layers: vec![layer],
+    };
+
+    Ok(tile.encode_to_vec())
+}
+
+/// Encode a properties map into MVT key/value tables.
+/// Returns the tag list (pairs of key_index, value_index).
+fn encode_properties(
+    properties: &Map<String, Value>,
+    keys: &mut Vec<String>,
+    values: &mut Vec<tile::Value>,
+    key_index: &mut HashMap<String, usize>,
+) -> Vec<u32> {
+    let mut tags = Vec::new();
+
+    for (k, v) in properties {
+        // Key index
+        let ki = if let Some(&i) = key_index.get(k) {
+            i
+        } else {
+            let i = keys.len();
+            keys.push(k.clone());
+            key_index.insert(k.clone(), i);
+            i
+        };
+
+        // Value
+        let mv = json_to_mvt_value(v);
+        let vi = values.len();
+        values.push(mv);
+
+        tags.push(ki as u32);
+        tags.push(vi as u32);
+    }
+
+    tags
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use geo::{Geometry, LineString, Point, Polygon, Rect};
+
+    fn unit_bbox() -> Rect<f64> {
+        Rect::new(geo::Coord { x: 0.0, y: 0.0 }, geo::Coord { x: 1.0, y: 1.0 })
+    }
+
+    fn point_feature(x: f64, y: f64) -> TileFeature {
+        TileFeature {
+            geometry: Geometry::Point(Point::new(x, y)),
+            properties: Map::new(),
+            id: None,
+        }
+    }
+
+    #[test]
+    fn empty_features_slice_returns_empty_bytes() {
+        let bytes = build_tile_bytes(&[], &unit_bbox(), "test").unwrap();
+        assert!(bytes.is_empty());
+    }
+
+    #[test]
+    fn single_point_produces_non_empty_tile() {
+        let feat = point_feature(0.5, 0.5);
+        let bytes = build_tile_bytes(&[feat], &unit_bbox(), "my_layer").unwrap();
+        assert!(!bytes.is_empty());
+    }
+
+    #[test]
+    fn tile_bytes_decode_to_valid_protobuf() {
+        let feat = point_feature(0.5, 0.5);
+        let bytes = build_tile_bytes(&[feat], &unit_bbox(), "layer").unwrap();
+        let tile = Tile::decode(bytes.as_slice()).expect("must decode as protobuf");
+        assert_eq!(tile.layers.len(), 1);
+        assert_eq!(tile.layers[0].name, "layer");
+        assert_eq!(tile.layers[0].version, 2);
+        assert_eq!(tile.layers[0].extent, Some(4096));
+    }
+
+    #[test]
+    fn layer_name_is_preserved() {
+        let feat = point_feature(0.5, 0.5);
+        let bytes = build_tile_bytes(&[feat], &unit_bbox(), "my_custom_layer").unwrap();
+        let tile = Tile::decode(bytes.as_slice()).unwrap();
+        assert_eq!(tile.layers[0].name, "my_custom_layer");
+    }
+
+    #[test]
+    fn properties_produce_keys_and_values() {
+        let mut props = Map::new();
+        props.insert("city".to_string(), Value::String("Berlin".to_string()));
+        props.insert("pop".to_string(), serde_json::json!(3_600_000i64));
+        let feat = TileFeature {
+            geometry: Geometry::Point(Point::new(0.5, 0.5)),
+            properties: props,
+            id: None,
+        };
+        let bytes = build_tile_bytes(&[feat], &unit_bbox(), "layer").unwrap();
+        let tile = Tile::decode(bytes.as_slice()).unwrap();
+        let layer = &tile.layers[0];
+        assert!(layer.keys.contains(&"city".to_string()));
+        assert!(layer.keys.contains(&"pop".to_string()));
+        assert_eq!(layer.values.len(), 2);
+    }
+
+    #[test]
+    fn feature_outside_bbox_is_skipped() {
+        // Point at (5, 5) is outside the bbox (0..1, 0..1) after MVT projection
+        // geozero will produce empty geometry → feature is skipped
+        let feat = TileFeature {
+            geometry: Geometry::Point(Point::new(5.0, 5.0)),
+            properties: Map::new(),
+            id: None,
+        };
+        let bytes = build_tile_bytes(&[feat], &unit_bbox(), "layer").unwrap();
+        // May be empty or have a layer with 0 features; either is acceptable
+        if !bytes.is_empty() {
+            let tile = Tile::decode(bytes.as_slice()).unwrap();
+            if !tile.layers.is_empty() {
+                // If a layer exists, feature count may be 0 or 1 (clamped coords)
+                // Just verify it doesn't panic
+            }
+        }
+    }
+
+    #[test]
+    fn linestring_feature_encodes() {
+        let ls = LineString::from(vec![(0.1, 0.1), (0.5, 0.5), (0.9, 0.9)]);
+        let feat = TileFeature {
+            geometry: Geometry::LineString(ls),
+            properties: Map::new(),
+            id: None,
+        };
+        let bytes = build_tile_bytes(&[feat], &unit_bbox(), "roads").unwrap();
+        if !bytes.is_empty() {
+            let tile = Tile::decode(bytes.as_slice()).unwrap();
+            assert_eq!(tile.layers[0].name, "roads");
+        }
+    }
+
+    #[test]
+    fn polygon_feature_encodes() {
+        let ring = geo::LineString::from(vec![
+            (0.1, 0.1),
+            (0.9, 0.1),
+            (0.9, 0.9),
+            (0.1, 0.9),
+            (0.1, 0.1),
+        ]);
+        let poly = Polygon::new(ring, vec![]);
+        let feat = TileFeature {
+            geometry: Geometry::Polygon(poly),
+            properties: Map::new(),
+            id: None,
+        };
+        let bytes = build_tile_bytes(&[feat], &unit_bbox(), "areas").unwrap();
+        assert!(!bytes.is_empty());
+        let tile = Tile::decode(bytes.as_slice()).unwrap();
+        assert_eq!(tile.layers[0].name, "areas");
+    }
+
+    #[test]
+    fn multiple_features_share_key_table() {
+        // Two features with the same property key should deduplicate the key
+        let mut props = Map::new();
+        props.insert("name".to_string(), Value::String("A".to_string()));
+        let feat_a = TileFeature {
+            geometry: Geometry::Point(Point::new(0.3, 0.3)),
+            properties: props.clone(),
+            id: None,
+        };
+        props.insert("name".to_string(), Value::String("B".to_string()));
+        let feat_b = TileFeature {
+            geometry: Geometry::Point(Point::new(0.7, 0.7)),
+            properties: props,
+            id: None,
+        };
+        let bytes = build_tile_bytes(&[feat_a, feat_b], &unit_bbox(), "layer").unwrap();
+        let tile = Tile::decode(bytes.as_slice()).unwrap();
+        let layer = &tile.layers[0];
+        // "name" key should appear exactly once
+        let name_count = layer.keys.iter().filter(|k| k.as_str() == "name").count();
+        assert_eq!(name_count, 1, "Shared key should be deduplicated");
+        // But two values ("A" and "B")
+        assert_eq!(layer.values.len(), 2);
+    }
+}
+
+fn json_to_mvt_value(v: &Value) -> tile::Value {
+    match v {
+        Value::String(s) => tile::Value {
+            string_value: Some(s.clone()),
+            ..Default::default()
+        },
+        Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                tile::Value {
+                    int_value: Some(i),
+                    ..Default::default()
+                }
+            } else if let Some(u) = n.as_u64() {
+                tile::Value {
+                    uint_value: Some(u),
+                    ..Default::default()
+                }
+            } else {
+                tile::Value {
+                    double_value: n.as_f64(),
+                    ..Default::default()
+                }
+            }
+        }
+        Value::Bool(b) => tile::Value {
+            bool_value: Some(*b),
+            ..Default::default()
+        },
+        Value::Null => tile::Value {
+            string_value: Some(String::new()),
+            ..Default::default()
+        },
+        // Nested objects/arrays: serialize to string
+        other => tile::Value {
+            string_value: Some(other.to_string()),
+            ..Default::default()
+        },
+    }
+}

--- a/src/convert/pipeline.rs
+++ b/src/convert/pipeline.rs
@@ -1,0 +1,312 @@
+use anyhow::{bail, Result};
+use geo::{
+    BooleanOps, BoundingRect, Geometry, Intersects, MultiLineString, Polygon, Rect, Simplify,
+};
+use rayon::prelude::*;
+use std::path::Path;
+
+use serde_json::{Map, Value};
+
+use crate::convert::{
+    input::read_features,
+    mvt_builder::{build_tile_bytes, TileFeature},
+    progress::ProgressReporter,
+    tiler::{
+        auto_max_zoom, dataset_bbox, expand_bbox, simplify_tolerance, tile_range_from_bbox,
+        tile_to_bbox,
+    },
+    writer::PmTilesCollector,
+};
+
+/// Options for the conversion pipeline.
+#[derive(Debug, Clone)]
+pub struct ConvertOptions {
+    pub min_zoom: u8,
+    /// Maximum zoom level. `None` → auto-detected from the dataset.
+    pub max_zoom: Option<u8>,
+    pub layer_name: String,
+    /// Base Douglas-Peucker tolerance at zoom 0, in degrees.
+    /// `None` → pixel-based auto formula (~1.5 px at each zoom).
+    pub simplification: Option<f64>,
+    /// Property name to use as MVT feature ID (enables MapLibre feature state).
+    /// `None` → features have no ID.
+    pub id_property: Option<String>,
+    /// If set, only these properties are included in tiles (whitelist).
+    pub include_properties: Option<Vec<String>>,
+    /// Properties to strip from tiles (blacklist). Ignored when `include_properties` is set.
+    pub exclude_properties: Vec<String>,
+}
+
+/// Run the full conversion pipeline: read → tile → encode → write.
+///
+/// `reporter` receives progress updates; use `SilentReporter` to suppress output.
+pub fn run(
+    input: &Path,
+    output: &Path,
+    opts: &ConvertOptions,
+    reporter: &dyn ProgressReporter,
+) -> Result<()> {
+    reporter.set_message("reading input");
+    let features = read_features(input)?;
+
+    if features.is_empty() {
+        bail!("Input file contains no features");
+    }
+
+    tracing::info!(
+        "Loaded {} features from {}",
+        features.len(),
+        input.display()
+    );
+
+    // Pre-compute bounding boxes once in parallel.
+    // bounding_rect() traverses all coordinates of a geometry — for complex polygons
+    // (e.g. country coastlines with 10k–50k points) this is expensive. Doing it
+    // in parallel here pays the cost once for the entire pipeline instead of once
+    // per zoom level in the candidate-tile loop plus once each in dataset_bbox /
+    // auto_max_zoom / estimate_total_tiles.
+    reporter.set_message("indexing");
+    let bboxes: Vec<Option<Rect<f64>>> = features
+        .par_iter()
+        .map(|f| f.geometry.bounding_rect())
+        .collect();
+
+    let bbox = dataset_bbox(&bboxes)
+        .unwrap_or_else(|| Rect::new((-180.0f64, -90.0f64), (180.0f64, 90.0f64)));
+
+    // Resolve max_zoom: explicit value or auto-detect from dataset geometry
+    let max_zoom = opts.max_zoom.unwrap_or_else(|| {
+        let z = auto_max_zoom(&bboxes, features.len());
+        tracing::info!("Auto-detected max zoom: {z}");
+        z
+    });
+
+    // Estimate total tiles for progress reporting
+    let total_tiles: u64 = estimate_total_tiles(&bboxes, opts.min_zoom, max_zoom);
+    reporter.set_total(total_tiles);
+
+    let mut collector =
+        PmTilesCollector::new(opts.min_zoom, max_zoom, bbox, opts.layer_name.clone());
+
+    for z in opts.min_zoom..=max_zoom {
+        reporter.set_message(&format!("z{z}"));
+        let tolerance = simplify_tolerance(z, opts.simplification);
+
+        // Collect the set of candidate tile coords from pre-computed bounding boxes.
+        // Using pre-computed bboxes avoids re-scanning all coordinates each zoom level.
+        let mut candidate_tiles: std::collections::HashSet<(u32, u32)> =
+            std::collections::HashSet::new();
+        for bbox in bboxes.iter().flatten() {
+            let range = tile_range_from_bbox(bbox, z);
+            for coord in range.iter() {
+                candidate_tiles.insert(coord);
+            }
+        }
+
+        // For each tile: clip + simplify + encode in parallel.
+        // Features are shared read-only across threads (Vec<Feature>: Sync).
+        let layer_name = &opts.layer_name;
+        let encoded: Result<Vec<(u32, u32, Vec<u8>)>> = candidate_tiles
+            .into_par_iter()
+            .map(|(x, y)| {
+                let tile_bbox = tile_to_bbox(z, x, y);
+                let buffered = expand_bbox(&tile_bbox, 0.01);
+
+                // Clip and simplify each feature against this tile's bbox
+                let tile_feats: Vec<TileFeature> = features
+                    .iter()
+                    .filter_map(|feat| {
+                        let clipped = clip_geometry(&feat.geometry, &buffered)?;
+                        let simplified = simplify_geometry(clipped, tolerance);
+                        Some(TileFeature {
+                            geometry: simplified,
+                            properties: filter_properties(
+                                &feat.properties,
+                                opts.include_properties.as_deref(),
+                                &opts.exclude_properties,
+                            ),
+                            id: resolve_feature_id(&feat.properties, opts.id_property.as_deref()),
+                        })
+                    })
+                    .collect();
+
+                let bytes = build_tile_bytes(&tile_feats, &tile_bbox, layer_name)?;
+                reporter.inc(1);
+                Ok((x, y, bytes))
+            })
+            .collect();
+
+        // Insert into the Hilbert-ordered BTreeMap (sequential)
+        for (x, y, bytes) in encoded? {
+            collector.add_tile(z, x, y, bytes)?;
+        }
+    }
+
+    tracing::info!(
+        "Writing {} tiles to {}",
+        collector.tile_count(),
+        output.display()
+    );
+    reporter.set_message("writing");
+    collector.write(output)?;
+    reporter.finish();
+
+    tracing::info!("Conversion complete: {}", output.display());
+    Ok(())
+}
+
+/// Filter a feature's properties according to whitelist / blacklist rules.
+///
+/// - If `include` is `Some`, only keys in that slice are kept (whitelist wins).
+/// - Otherwise, keys in `exclude` are removed (blacklist).
+fn filter_properties(
+    props: &Map<String, Value>,
+    include: Option<&[String]>,
+    exclude: &[String],
+) -> Map<String, Value> {
+    if let Some(whitelist) = include {
+        props
+            .iter()
+            .filter(|(k, _)| whitelist.iter().any(|w| w == *k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    } else if exclude.is_empty() {
+        props.clone()
+    } else {
+        props
+            .iter()
+            .filter(|(k, _)| !exclude.iter().any(|e| e == *k))
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+}
+
+/// Extract a feature ID from a named property.
+///
+/// The value is converted to `u64`:
+/// - JSON integers → cast directly
+/// - JSON strings  → parsed as decimal integer
+/// - Anything else → `None`
+fn resolve_feature_id(props: &Map<String, Value>, id_property: Option<&str>) -> Option<u64> {
+    let key = id_property?;
+    match props.get(key)? {
+        Value::Number(n) => n.as_u64().or_else(|| n.as_i64().map(|i| i as u64)),
+        Value::String(s) => s.trim().parse::<u64>().ok(),
+        _ => None,
+    }
+}
+
+/// Clip a geometry to a bounding rectangle. Returns None if the result is empty.
+fn clip_geometry(geom: &Geometry<f64>, bbox: &Rect<f64>) -> Option<Geometry<f64>> {
+    // Quick reject: bounding box doesn't intersect tile at all
+    if let Some(geom_bbox) = geom.bounding_rect() {
+        if !geom_bbox.intersects(bbox) {
+            return None;
+        }
+    }
+
+    // Convert the tile bbox to a Polygon for BooleanOps
+    let clip_poly: Polygon<f64> = (*bbox).into();
+
+    match geom {
+        Geometry::Point(p) => {
+            if bbox.intersects(p) {
+                Some(geom.clone())
+            } else {
+                None
+            }
+        }
+        Geometry::MultiPoint(mp) => {
+            let pts: Vec<_> =
+                mp.0.iter()
+                    .filter(|p| bbox.intersects(*p))
+                    .cloned()
+                    .collect();
+            if pts.is_empty() {
+                None
+            } else {
+                Some(Geometry::MultiPoint(geo::MultiPoint(pts)))
+            }
+        }
+        Geometry::LineString(ls) => {
+            let mls = MultiLineString::new(vec![ls.clone()]);
+            let clipped = clip_poly.clip(&mls, false);
+            if clipped.0.is_empty() {
+                None
+            } else {
+                Some(Geometry::MultiLineString(clipped))
+            }
+        }
+        Geometry::MultiLineString(mls) => {
+            let clipped = clip_poly.clip(mls, false);
+            if clipped.0.is_empty() {
+                None
+            } else {
+                Some(Geometry::MultiLineString(clipped))
+            }
+        }
+        Geometry::Polygon(poly) => {
+            let clipped = poly.intersection(&clip_poly);
+            if clipped.0.is_empty() {
+                None
+            } else {
+                Some(Geometry::MultiPolygon(clipped))
+            }
+        }
+        Geometry::MultiPolygon(mpoly) => {
+            // Intersect each sub-polygon with the tile rect
+            let parts: Vec<geo::Polygon<f64>> = mpoly
+                .0
+                .iter()
+                .flat_map(|p| p.intersection(&clip_poly).0)
+                .collect();
+            if parts.is_empty() {
+                None
+            } else {
+                Some(Geometry::MultiPolygon(geo::MultiPolygon(parts)))
+            }
+        }
+        Geometry::GeometryCollection(gc) => {
+            let parts: Vec<Geometry<f64>> =
+                gc.0.iter().filter_map(|g| clip_geometry(g, bbox)).collect();
+            if parts.is_empty() {
+                None
+            } else {
+                Some(Geometry::GeometryCollection(geo::GeometryCollection(parts)))
+            }
+        }
+        // Pass through for unsupported geometry types
+        other => Some(other.clone()),
+    }
+}
+
+/// Simplify a geometry using Douglas-Peucker with the given tolerance.
+fn simplify_geometry(geom: Geometry<f64>, tolerance: f64) -> Geometry<f64> {
+    if tolerance <= 0.0 {
+        return geom;
+    }
+    match geom {
+        Geometry::LineString(ls) => Geometry::LineString(ls.simplify(&tolerance)),
+        Geometry::MultiLineString(mls) => Geometry::MultiLineString(mls.simplify(&tolerance)),
+        Geometry::Polygon(p) => Geometry::Polygon(p.simplify(&tolerance)),
+        Geometry::MultiPolygon(mp) => Geometry::MultiPolygon(mp.simplify(&tolerance)),
+        other => other,
+    }
+}
+
+/// Estimate total tile count for progress reporting.
+/// Uses pre-computed bounding boxes to avoid re-scanning geometry coordinates.
+fn estimate_total_tiles(bboxes: &[Option<Rect<f64>>], min_zoom: u8, max_zoom: u8) -> u64 {
+    let mut total = 0u64;
+    for z in min_zoom..=max_zoom {
+        let mut seen = std::collections::HashSet::new();
+        for bbox in bboxes.iter().flatten() {
+            let range = tile_range_from_bbox(bbox, z);
+            for coord in range.iter() {
+                seen.insert(coord);
+            }
+        }
+        total += seen.len() as u64;
+    }
+    total.max(1)
+}

--- a/src/convert/progress.rs
+++ b/src/convert/progress.rs
@@ -1,0 +1,96 @@
+use std::sync::{Arc, Mutex};
+
+/// Abstracts progress reporting for both CLI and HTTP contexts.
+pub trait ProgressReporter: Send + Sync {
+    fn set_total(&self, total: u64);
+    fn inc(&self, delta: u64);
+    fn set_message(&self, msg: &str);
+    fn finish(&self);
+}
+
+/// CLI progress reporter backed by `indicatif`.
+pub struct IndicatifReporter {
+    bar: indicatif::ProgressBar,
+}
+
+impl Default for IndicatifReporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IndicatifReporter {
+    pub fn new() -> Self {
+        use indicatif::{ProgressBar, ProgressStyle};
+        let bar = ProgressBar::new(0);
+        bar.set_style(
+            ProgressStyle::default_bar()
+                .template(
+                    "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] \
+                     {pos}/{len} tiles {msg}",
+                )
+                .unwrap_or_else(|_| ProgressStyle::default_bar())
+                .progress_chars("=>-"),
+        );
+        Self { bar }
+    }
+}
+
+impl ProgressReporter for IndicatifReporter {
+    fn set_total(&self, total: u64) {
+        self.bar.set_length(total);
+    }
+    fn inc(&self, delta: u64) {
+        self.bar.inc(delta);
+    }
+    fn set_message(&self, msg: &str) {
+        self.bar.set_message(msg.to_string());
+    }
+    fn finish(&self) {
+        self.bar.finish_with_message("done");
+    }
+}
+
+/// HTTP progress reporter: stores progress in a shared float.
+pub struct HttpProgressReporter {
+    progress: Arc<Mutex<f32>>,
+    total: Mutex<u64>,
+    done: Mutex<u64>,
+}
+
+impl HttpProgressReporter {
+    pub fn new(progress: Arc<Mutex<f32>>) -> Self {
+        Self {
+            progress,
+            total: Mutex::new(1),
+            done: Mutex::new(0),
+        }
+    }
+}
+
+impl ProgressReporter for HttpProgressReporter {
+    fn set_total(&self, total: u64) {
+        *self.total.lock().unwrap() = total.max(1);
+    }
+    fn inc(&self, delta: u64) {
+        let mut done = self.done.lock().unwrap();
+        *done += delta;
+        let total = *self.total.lock().unwrap();
+        let pct = (*done as f32 / total as f32).min(1.0);
+        *self.progress.lock().unwrap() = pct;
+    }
+    fn set_message(&self, _msg: &str) {}
+    fn finish(&self) {
+        *self.progress.lock().unwrap() = 1.0;
+    }
+}
+
+/// A no-op reporter for tests or silent mode.
+pub struct SilentReporter;
+
+impl ProgressReporter for SilentReporter {
+    fn set_total(&self, _total: u64) {}
+    fn inc(&self, _delta: u64) {}
+    fn set_message(&self, _msg: &str) {}
+    fn finish(&self) {}
+}

--- a/src/convert/tiler.rs
+++ b/src/convert/tiler.rs
@@ -1,0 +1,374 @@
+use geo::{BoundingRect, Geometry, Rect};
+
+/// Convert a longitude to a tile X coordinate at the given zoom level.
+#[inline]
+pub fn lon_to_tile_x(lon: f64, z: u8) -> u32 {
+    let n = 2u32.pow(u32::from(z));
+    let x = ((lon + 180.0) / 360.0 * f64::from(n)) as u32;
+    x.min(n - 1)
+}
+
+/// Convert a latitude to a tile Y coordinate at the given zoom level.
+#[inline]
+pub fn lat_to_tile_y(lat: f64, z: u8) -> u32 {
+    let n = 2u32.pow(u32::from(z));
+    let lat_rad = lat.to_radians();
+    let y = ((1.0 - (lat_rad.tan() + 1.0 / lat_rad.cos()).ln() / std::f64::consts::PI) / 2.0
+        * f64::from(n)) as u32;
+    y.min(n - 1)
+}
+
+/// Return the geographic bounding box (west, south, east, north) for a tile.
+pub fn tile_to_bbox(z: u8, x: u32, y: u32) -> Rect<f64> {
+    let n = 2u32.pow(u32::from(z)) as f64;
+    let west = x as f64 / n * 360.0 - 180.0;
+    let east = (x + 1) as f64 / n * 360.0 - 180.0;
+    let north = tile_y_to_lat(y, z);
+    let south = tile_y_to_lat(y + 1, z);
+    Rect::new(
+        geo::Coord { x: west, y: south },
+        geo::Coord { x: east, y: north },
+    )
+}
+
+fn tile_y_to_lat(y: u32, z: u8) -> f64 {
+    let n = 2u32.pow(u32::from(z)) as f64;
+    let lat_rad = (std::f64::consts::PI * (1.0 - 2.0 * y as f64 / n))
+        .sinh()
+        .atan();
+    lat_rad.to_degrees()
+}
+
+/// Compute a Douglas-Peucker simplification tolerance (in degrees) for a given zoom level.
+///
+/// When `base_tolerance` is `Some(t)`, the user-specified value is scaled per zoom:
+/// `tolerance = t / 2^z` — same behaviour as before.
+///
+/// When `None`, a **pixel-based auto formula** is used:
+/// `tolerance = tile_width_degrees(z) / 4096 * 1.5`
+/// This equals ~1.5 pixels of tolerance at the given zoom — visually lossless for
+/// most datasets while reducing coordinate count by 30–70%.
+pub fn simplify_tolerance(z: u8, base_tolerance: Option<f64>) -> f64 {
+    match base_tolerance {
+        Some(base) => base / 2f64.powi(i32::from(z)),
+        None => {
+            // tile_width_degrees(z) = 360 / 2^z
+            // 1 pixel = tile_width / MVT_EXTENT (4096)
+            let tile_width = 360.0 / f64::from(1u32 << u32::from(z));
+            tile_width / 4096.0 * 1.5
+        }
+    }
+}
+
+/// Auto-detect a sensible maximum zoom level from pre-computed feature bounding boxes.
+///
+/// **Algorithm:** find the feature with the smallest geographic extent (largest
+/// bounding-box dimension). Compute the Web Mercator zoom level at which that
+/// feature spans exactly one tile. That zoom is the minimum needed to resolve
+/// the feature at tile-level granularity; clamped to `[0, 14]`.
+///
+/// For point-only datasets (no bounding-box area), a tippecanoe-style
+/// count-based heuristic is used: `floor(log2(count)) + 7`, clamped to `[0, 14]`.
+///
+/// `bboxes` must be pre-computed (e.g. via a parallel `bounding_rect` sweep) so
+/// that the per-coordinate cost is paid only once across the whole pipeline.
+pub fn auto_max_zoom(bboxes: &[Option<Rect<f64>>], feature_count: usize) -> u8 {
+    let mut min_extent_deg: f64 = f64::INFINITY;
+    let mut has_non_point = false;
+
+    for bbox in bboxes.iter().flatten() {
+        let w = (bbox.max().x - bbox.min().x).abs();
+        let h = (bbox.max().y - bbox.min().y).abs();
+        // Use the *larger* dimension — represents the feature's overall scale
+        let extent = w.max(h);
+        if extent > 1e-7 {
+            has_non_point = true;
+            min_extent_deg = min_extent_deg.min(extent);
+        }
+    }
+
+    if !has_non_point {
+        // Point-only: count-based heuristic (tippecanoe-style)
+        let z = (feature_count as f64).log2().floor() as i32 + 7;
+        return z.clamp(0, 14) as u8;
+    }
+
+    // Zoom where the smallest feature spans approximately one tile:
+    //   tile_width_at_z = 360 / 2^z
+    //   min_extent = tile_width  →  z = log2(360 / min_extent)
+    let z = (360.0_f64 / min_extent_deg).log2().ceil() as i32;
+    z.clamp(0, 14) as u8
+}
+
+/// Tile assignment for a feature: returns the range of (x, y) tile coords at zoom `z`
+/// that the feature's bounding box overlaps.
+pub fn tile_range(geometry: &Geometry<f64>, z: u8) -> Option<TileRange> {
+    let bbox = geometry.bounding_rect()?;
+    Some(tile_range_from_bbox(&bbox, z))
+}
+
+/// Tile range from a pre-computed bounding box — avoids re-scanning all coordinates.
+pub fn tile_range_from_bbox(bbox: &Rect<f64>, z: u8) -> TileRange {
+    let min_x = lon_to_tile_x(bbox.min().x, z);
+    let max_x = lon_to_tile_x(bbox.max().x, z);
+    // Note: lat_to_tile_y is inverted (north has smaller Y)
+    let min_y = lat_to_tile_y(bbox.max().y, z);
+    let max_y = lat_to_tile_y(bbox.min().y, z);
+    TileRange {
+        min_x,
+        max_x,
+        min_y,
+        max_y,
+    }
+}
+
+/// A rectangular range of tile coordinates.
+#[derive(Debug, Clone, Copy)]
+pub struct TileRange {
+    pub min_x: u32,
+    pub max_x: u32,
+    pub min_y: u32,
+    pub max_y: u32,
+}
+
+impl TileRange {
+    /// Total tile count in this range.
+    pub fn count(&self) -> u64 {
+        (self.max_x - self.min_x + 1) as u64 * (self.max_y - self.min_y + 1) as u64
+    }
+
+    /// Iterate over all (x, y) pairs in this range.
+    pub fn iter(&self) -> impl Iterator<Item = (u32, u32)> + '_ {
+        (self.min_y..=self.max_y).flat_map(move |y| (self.min_x..=self.max_x).map(move |x| (x, y)))
+    }
+}
+
+/// Compute the overall dataset bounding box from pre-computed feature bounding boxes.
+pub fn dataset_bbox(bboxes: &[Option<Rect<f64>>]) -> Option<Rect<f64>> {
+    let mut west = f64::INFINITY;
+    let mut south = f64::INFINITY;
+    let mut east = f64::NEG_INFINITY;
+    let mut north = f64::NEG_INFINITY;
+    let mut any = false;
+
+    for bbox in bboxes.iter().flatten() {
+        west = west.min(bbox.min().x);
+        south = south.min(bbox.min().y);
+        east = east.max(bbox.max().x);
+        north = north.max(bbox.max().y);
+        any = true;
+    }
+
+    if any {
+        Some(Rect::new(
+            geo::Coord { x: west, y: south },
+            geo::Coord { x: east, y: north },
+        ))
+    } else {
+        None
+    }
+}
+
+/// Expand a bounding rectangle by a fractional buffer (e.g. 0.02 = 2%).
+pub fn expand_bbox(bbox: &Rect<f64>, fraction: f64) -> Rect<f64> {
+    let dx = (bbox.max().x - bbox.min().x) * fraction;
+    let dy = (bbox.max().y - bbox.min().y) * fraction;
+    Rect::new(
+        geo::Coord {
+            x: (bbox.min().x - dx).max(-180.0),
+            y: (bbox.min().y - dy).max(-90.0),
+        },
+        geo::Coord {
+            x: (bbox.max().x + dx).min(180.0),
+            y: (bbox.max().y + dy).min(90.0),
+        },
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tile_x_at_zoom0() {
+        assert_eq!(lon_to_tile_x(0.0, 0), 0);
+        assert_eq!(lon_to_tile_x(-180.0, 0), 0);
+    }
+
+    #[test]
+    fn tile_y_at_zoom0() {
+        assert_eq!(lat_to_tile_y(0.0, 0), 0);
+    }
+
+    #[test]
+    fn tile_bbox_roundtrip() {
+        let bbox = tile_to_bbox(1, 1, 0);
+        assert!((bbox.min().x - 0.0).abs() < 1.0);
+        assert!(bbox.max().x > 0.0);
+    }
+
+    #[test]
+    fn tile_x_boundary_values() {
+        // -180° → tile 0 at any zoom
+        assert_eq!(lon_to_tile_x(-180.0, 1), 0);
+        // 180° wraps to last tile
+        assert_eq!(lon_to_tile_x(180.0, 1), 1);
+        // Prime meridian at zoom 1: left half
+        assert_eq!(lon_to_tile_x(0.0, 1), 1);
+    }
+
+    #[test]
+    fn tile_y_north_is_zero() {
+        // Northern latitudes map to smaller tile Y
+        let y_north = lat_to_tile_y(85.0, 2);
+        let y_south = lat_to_tile_y(-85.0, 2);
+        assert!(
+            y_north < y_south,
+            "Northern tiles should have lower Y index"
+        );
+    }
+
+    #[test]
+    fn simplify_tolerance_equals_base_at_zoom0() {
+        let base = 0.5;
+        let t = simplify_tolerance(0, Some(base));
+        assert!((t - base).abs() < 1e-10);
+    }
+
+    #[test]
+    fn simplify_tolerance_halves_each_zoom() {
+        let base = 0.4;
+        let t0 = simplify_tolerance(0, Some(base));
+        let t1 = simplify_tolerance(1, Some(base));
+        let t2 = simplify_tolerance(2, Some(base));
+        assert!((t1 - t0 / 2.0).abs() < 1e-12);
+        assert!((t2 - t0 / 4.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn simplify_tolerance_auto_is_pixel_based() {
+        // Auto formula: (360 / 2^z) / 4096 * 1.5
+        // At z=0: 360 / 4096 * 1.5 ≈ 0.13183
+        let t = simplify_tolerance(0, None);
+        let expected = 360.0 / 4096.0 * 1.5;
+        assert!((t - expected).abs() < 1e-10);
+    }
+
+    #[test]
+    fn simplify_tolerance_stays_positive_at_high_zoom() {
+        let t = simplify_tolerance(22, None);
+        assert!(t > 0.0);
+        assert!(t.is_finite());
+    }
+
+    #[test]
+    fn tile_range_point_is_single_tile() {
+        use geo::{Geometry, Point};
+        let geom = Geometry::Point(Point::new(13.4, 52.5)); // Berlin
+        let range = tile_range(&geom, 6).unwrap();
+        assert_eq!(range.count(), 1, "A point should map to exactly one tile");
+    }
+
+    #[test]
+    fn tile_range_world_bbox_at_zoom0() {
+        let world = Rect::new(
+            geo::Coord {
+                x: -180.0,
+                y: -90.0,
+            },
+            geo::Coord { x: 180.0, y: 90.0 },
+        );
+        let geom = Geometry::Rect(world);
+        let range = tile_range(&geom, 0).unwrap();
+        assert_eq!(range.min_x, 0);
+        assert_eq!(range.max_x, 0);
+        assert_eq!(range.min_y, 0);
+        assert_eq!(range.max_y, 0);
+    }
+
+    #[test]
+    fn tile_range_count_matches_iter_len() {
+        use geo::{Geometry, Point};
+        let geom = Geometry::Point(Point::new(0.0, 0.0));
+        let range = tile_range(&geom, 4).unwrap();
+        let iter_count = range.iter().count() as u64;
+        assert_eq!(range.count(), iter_count);
+    }
+
+    #[test]
+    fn dataset_bbox_empty_returns_none() {
+        let result = dataset_bbox(&[]);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn dataset_bbox_single_point() {
+        let pt_bbox = Some(Rect::new(
+            geo::Coord { x: 10.0, y: 50.0 },
+            geo::Coord { x: 10.0, y: 50.0 },
+        ));
+        let bbox = dataset_bbox(&[pt_bbox]).unwrap();
+        assert!((bbox.min().x - 10.0).abs() < 1e-10);
+        assert!((bbox.min().y - 50.0).abs() < 1e-10);
+        assert!((bbox.max().x - 10.0).abs() < 1e-10);
+        assert!((bbox.max().y - 50.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn dataset_bbox_two_points_spans_both() {
+        let bboxes = vec![
+            Some(Rect::new(
+                geo::Coord { x: -10.0, y: 20.0 },
+                geo::Coord { x: -10.0, y: 20.0 },
+            )),
+            Some(Rect::new(
+                geo::Coord { x: 30.0, y: 60.0 },
+                geo::Coord { x: 30.0, y: 60.0 },
+            )),
+        ];
+        let bbox = dataset_bbox(&bboxes).unwrap();
+        assert!((bbox.min().x - (-10.0)).abs() < 1e-10);
+        assert!((bbox.min().y - 20.0).abs() < 1e-10);
+        assert!((bbox.max().x - 30.0).abs() < 1e-10);
+        assert!((bbox.max().y - 60.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn expand_bbox_increases_all_sides() {
+        let bbox = Rect::new(
+            geo::Coord { x: 0.0, y: 0.0 },
+            geo::Coord { x: 10.0, y: 10.0 },
+        );
+        let expanded = expand_bbox(&bbox, 0.1);
+        assert!(expanded.min().x < bbox.min().x);
+        assert!(expanded.min().y < bbox.min().y);
+        assert!(expanded.max().x > bbox.max().x);
+        assert!(expanded.max().y > bbox.max().y);
+    }
+
+    #[test]
+    fn expand_bbox_clamped_to_world_bounds() {
+        let world = Rect::new(
+            geo::Coord {
+                x: -180.0,
+                y: -90.0,
+            },
+            geo::Coord { x: 180.0, y: 90.0 },
+        );
+        let expanded = expand_bbox(&world, 1.0);
+        assert!(expanded.min().x >= -180.0);
+        assert!(expanded.min().y >= -90.0);
+        assert!(expanded.max().x <= 180.0);
+        assert!(expanded.max().y <= 90.0);
+    }
+
+    #[test]
+    fn tile_to_bbox_covers_full_world_at_zoom0() {
+        let bbox = tile_to_bbox(0, 0, 0);
+        assert!((bbox.min().x - (-180.0)).abs() < 1e-6);
+        assert!(bbox.max().x > 179.0);
+        // Mercator north/south are clamped (~85.05°)
+        assert!(bbox.max().y > 80.0);
+        assert!(bbox.min().y < -80.0);
+    }
+}

--- a/src/convert/writer.rs
+++ b/src/convert/writer.rs
@@ -1,0 +1,104 @@
+use anyhow::{Context, Result};
+use geo::Rect;
+use pmtiles::{Compression, PmTilesWriter, TileCoord, TileType};
+use serde_json::json;
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::path::Path;
+
+/// Collects MVT tile data and writes a PMTiles archive at the end.
+///
+/// Tiles are stored in a BTreeMap sorted by Hilbert tile ID to produce a
+/// clustered, read-optimised archive.
+pub struct PmTilesCollector {
+    tiles: BTreeMap<u64, (TileCoord, Vec<u8>)>,
+    min_zoom: u8,
+    max_zoom: u8,
+    bbox: Rect<f64>,
+    layer_name: String,
+}
+
+impl PmTilesCollector {
+    pub fn new(min_zoom: u8, max_zoom: u8, bbox: Rect<f64>, layer_name: String) -> Self {
+        Self {
+            tiles: BTreeMap::new(),
+            min_zoom,
+            max_zoom,
+            bbox,
+            layer_name,
+        }
+    }
+
+    /// Insert a tile. Non-empty `data` only; empty tiles are skipped per PMTiles spec.
+    pub fn add_tile(&mut self, z: u8, x: u32, y: u32, data: Vec<u8>) -> Result<()> {
+        if data.is_empty() {
+            return Ok(());
+        }
+        let coord = TileCoord::new(z, x, y).context("Invalid tile coordinate")?;
+        let id: pmtiles::TileId = coord.into();
+        self.tiles.insert(id.value(), (coord, data));
+        Ok(())
+    }
+
+    /// Total number of non-empty tiles collected.
+    pub fn tile_count(&self) -> usize {
+        self.tiles.len()
+    }
+
+    /// Finalize and write the PMTiles archive to `output_path`.
+    pub fn write(self, output_path: &Path) -> Result<()> {
+        let west = self.bbox.min().x;
+        let south = self.bbox.min().y;
+        let east = self.bbox.max().x;
+        let north = self.bbox.max().y;
+        let center_lon = (west + east) / 2.0;
+        let center_lat = (south + north) / 2.0;
+        let center_zoom = (self.min_zoom + self.max_zoom) / 2;
+
+        // Build TileJSON-compatible metadata for the archive
+        let metadata = json!({
+            "name": self.layer_name,
+            "format": "pbf",
+            "minzoom": self.min_zoom,
+            "maxzoom": self.max_zoom,
+            "bounds": [west, south, east, north],
+            "center": [center_lon, center_lat, center_zoom],
+            "vector_layers": [{
+                "id": self.layer_name,
+                "description": "",
+                "minzoom": self.min_zoom,
+                "maxzoom": self.max_zoom,
+                "fields": {}
+            }]
+        });
+
+        let file = File::create(output_path)
+            .with_context(|| format!("Failed to create output file: {}", output_path.display()))?;
+
+        let mut writer = PmTilesWriter::new(TileType::Mvt)
+            .min_zoom(self.min_zoom)
+            .max_zoom(self.max_zoom)
+            .bounds(west, south, east, north)
+            .center(center_lon, center_lat)
+            .center_zoom(center_zoom)
+            // MVT default is Gzip; tiles are pre-uncompressed, writer compresses them
+            .tile_compression(Compression::Gzip)
+            .internal_compression(Compression::Gzip)
+            .metadata(&metadata.to_string())
+            .create(file)
+            .context("Failed to initialise PMTiles writer")?;
+
+        // Tiles are already sorted by Hilbert tile ID (BTreeMap order)
+        for (_id, (coord, data)) in self.tiles {
+            writer
+                .add_tile(coord, &data)
+                .context("Failed to write tile to PMTiles archive")?;
+        }
+
+        writer
+            .finalize()
+            .context("Failed to finalise PMTiles archive")?;
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! This module exposes the core functionality for testing and embedding.
 
+#[cfg(feature = "convert")]
+pub mod convert;
+
 pub mod admin;
 pub mod autodetect;
 pub mod cache_control;

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ mod cli;
 mod logging;
 mod telemetry;
 
-use cli::Cli;
+use cli::{Cli, Commands};
 use tileserver_rs::admin;
 use tileserver_rs::autodetect;
 use tileserver_rs::cache_control;
@@ -53,9 +53,37 @@ async fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
 
     // Parse CLI arguments
-    let cli = Cli::parse_args();
+    let mut cli = Cli::parse_args();
     let ui_enabled = cli.ui_enabled();
     let verbose = cli.verbose;
+
+    // --- Convert subcommand (feature-gated) ---
+    // Runs conversion synchronously (CPU-bound, no async needed).
+    // If --serve is requested, override cli.path with the output file so that
+    // the normal server startup auto-detects and serves it.
+    #[cfg(feature = "convert")]
+    {
+        // Clone the args out of cli.command to avoid borrow conflicts when we
+        // need to mutate cli (cli.path, cli.port, cli.command) afterward.
+        let convert_args = if let Some(Commands::Convert(ref a)) = cli.command {
+            Some(a.clone())
+        } else {
+            None
+        };
+        if let Some(args) = convert_args {
+            let result = tileserver_rs::convert::run_cli(&args)?;
+
+            if args.serve {
+                // Override the positional path so the server auto-detects the output.
+                cli.path = Some(result.output_path);
+                cli.port = Some(args.port);
+                // Clear the subcommand so we fall through to normal server startup.
+                cli.command = None;
+            } else {
+                return Ok(());
+            }
+        }
+    }
 
     // Resolve configuration via startup priority chain:
     // 1. --config path (explicit)
@@ -180,6 +208,14 @@ async fn main() -> anyhow::Result<()> {
         .allow_methods([Method::GET, Method::OPTIONS, Method::HEAD]);
 
     let mut router = Router::new().merge(api_router(shared.clone()));
+
+    // Mount convert routes when the feature is enabled
+    #[cfg(feature = "convert")]
+    {
+        let convert_state = tileserver_rs::convert::ConvertState::new();
+        router = router.merge(tileserver_rs::convert::router(convert_state));
+        tracing::info!("Convert endpoint enabled at POST /convert");
+    }
 
     // Add Swagger UI at /_openapi with bundled assets (works in air-gapped environments)
     let mut openapi_spec = openapi::ApiDoc::openapi();

--- a/tests/convert.rs
+++ b/tests/convert.rs
@@ -1,0 +1,245 @@
+//! Integration tests for the `convert` feature.
+//!
+//! Tests the full GeoJSON → PMTiles pipeline end to end using the public API.
+//! Run with: `cargo test --features convert -p tileserver-rs convert`
+
+#![cfg(feature = "convert")]
+
+use std::io::Write;
+use tempfile::{Builder, TempDir};
+use tileserver_rs::convert::pipeline::{run, ConvertOptions};
+use tileserver_rs::convert::progress::SilentReporter;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn geojson_file(content: &str) -> tempfile::NamedTempFile {
+    let mut f = Builder::new()
+        .suffix(".geojson")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(content.as_bytes()).expect("write geojson");
+    f
+}
+
+fn opts(layer: &str) -> ConvertOptions {
+    ConvertOptions {
+        min_zoom: 0,
+        max_zoom: Some(4),
+        layer_name: layer.to_string(),
+        simplification: None,
+        id_property: None,
+        include_properties: None,
+        exclude_properties: vec![],
+    }
+}
+
+fn output_in(dir: &TempDir) -> std::path::PathBuf {
+    dir.path().join("out.pmtiles")
+}
+
+// ── pipeline success cases ────────────────────────────────────────────────────
+
+#[test]
+fn converts_point_geojson_to_pmtiles() {
+    let input = geojson_file(
+        r#"{"type":"FeatureCollection","features":[
+            {"type":"Feature","geometry":{"type":"Point","coordinates":[13.4,52.5]},"properties":{"name":"Berlin"}}
+        ]}"#,
+    );
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+
+    run(input.path(), &out, &opts("places"), &SilentReporter).unwrap();
+
+    let meta = std::fs::metadata(&out).expect("output file must exist");
+    assert!(meta.len() > 0, "PMTiles archive must not be empty");
+}
+
+#[test]
+fn converts_linestring_geojson_to_pmtiles() {
+    let input = geojson_file(
+        r#"{"type":"FeatureCollection","features":[
+            {"type":"Feature","geometry":{"type":"LineString","coordinates":[[0,0],[10,10],[20,5]]},"properties":{}}
+        ]}"#,
+    );
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+
+    run(input.path(), &out, &opts("lines"), &SilentReporter).unwrap();
+
+    assert!(std::fs::metadata(&out).unwrap().len() > 0);
+}
+
+#[test]
+fn converts_polygon_geojson_to_pmtiles() {
+    let input = geojson_file(
+        r#"{"type":"FeatureCollection","features":[
+            {"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[10,0],[10,10],[0,10],[0,0]]]},"properties":{"area":"square"}}
+        ]}"#,
+    );
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+
+    run(input.path(), &out, &opts("areas"), &SilentReporter).unwrap();
+
+    assert!(std::fs::metadata(&out).unwrap().len() > 0);
+}
+
+#[test]
+fn converts_multipolygon_geojson_to_pmtiles() {
+    let input = geojson_file(
+        r#"{"type":"FeatureCollection","features":[
+            {"type":"Feature","geometry":{"type":"MultiPolygon","coordinates":
+                [[[[0,0],[5,0],[5,5],[0,5],[0,0]]],[[[10,10],[20,10],[20,20],[10,20],[10,10]]]]
+            },"properties":{}}
+        ]}"#,
+    );
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+
+    run(input.path(), &out, &opts("regions"), &SilentReporter).unwrap();
+
+    assert!(std::fs::metadata(&out).unwrap().len() > 0);
+}
+
+#[test]
+fn converts_multiple_features_to_pmtiles() {
+    let input = geojson_file(
+        r#"{"type":"FeatureCollection","features":[
+            {"type":"Feature","geometry":{"type":"Point","coordinates":[-74.0,40.7]},"properties":{"city":"New York","pop":8000000}},
+            {"type":"Feature","geometry":{"type":"Point","coordinates":[2.35,48.85]},"properties":{"city":"Paris","pop":2000000}},
+            {"type":"Feature","geometry":{"type":"Point","coordinates":[139.7,35.7]},"properties":{"city":"Tokyo","pop":14000000}},
+            {"type":"Feature","geometry":{"type":"Point","coordinates":[13.4,52.5]},"properties":{"city":"Berlin","pop":3600000}}
+        ]}"#,
+    );
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+
+    run(input.path(), &out, &opts("cities"), &SilentReporter).unwrap();
+
+    assert!(std::fs::metadata(&out).unwrap().len() > 0);
+}
+
+#[test]
+fn converts_bare_geometry_geojson() {
+    // A GeoJSON file that is just a Geometry (no Feature wrapper)
+    let input = geojson_file(r#"{"type":"Point","coordinates":[0.0,0.0]}"#);
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+
+    run(input.path(), &out, &opts("point"), &SilentReporter).unwrap();
+
+    assert!(std::fs::metadata(&out).unwrap().len() > 0);
+}
+
+#[test]
+fn output_is_created_at_specified_path() {
+    let input = geojson_file(
+        r#"{"type":"Feature","geometry":{"type":"Point","coordinates":[0,0]},"properties":{}}"#,
+    );
+    let dir = TempDir::new().unwrap();
+    let custom_out = dir.path().join("my_tiles.pmtiles");
+
+    run(input.path(), &custom_out, &opts("layer"), &SilentReporter).unwrap();
+
+    assert!(custom_out.exists(), "output file must exist at given path");
+}
+
+// ── narrow zoom range ─────────────────────────────────────────────────────────
+
+#[test]
+fn respects_min_max_zoom_range() {
+    let input = geojson_file(
+        r#"{"type":"Feature","geometry":{"type":"Point","coordinates":[0.0,0.0]},"properties":{}}"#,
+    );
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+
+    let narrow = ConvertOptions {
+        min_zoom: 2,
+        max_zoom: Some(3),
+        layer_name: "test".to_string(),
+        simplification: None,
+        id_property: None,
+        include_properties: None,
+        exclude_properties: vec![],
+    };
+    run(input.path(), &out, &narrow, &SilentReporter).unwrap();
+
+    assert!(std::fs::metadata(&out).unwrap().len() > 0);
+}
+
+#[test]
+fn single_zoom_level_works() {
+    let input = geojson_file(
+        r#"{"type":"Feature","geometry":{"type":"Point","coordinates":[0.0,0.0]},"properties":{}}"#,
+    );
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+
+    let single = ConvertOptions {
+        min_zoom: 5,
+        max_zoom: Some(5),
+        layer_name: "test".to_string(),
+        simplification: None,
+        id_property: None,
+        include_properties: None,
+        exclude_properties: vec![],
+    };
+    run(input.path(), &out, &single, &SilentReporter).unwrap();
+
+    assert!(std::fs::metadata(&out).unwrap().len() > 0);
+}
+
+// ── error cases ───────────────────────────────────────────────────────────────
+
+#[test]
+fn empty_feature_collection_returns_error() {
+    let input = geojson_file(r#"{"type":"FeatureCollection","features":[]}"#);
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+
+    let result = run(input.path(), &out, &opts("empty"), &SilentReporter);
+    assert!(result.is_err(), "empty feature collection must fail");
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("no features") || msg.contains("empty"),
+        "error message should mention empty/no features: {msg}"
+    );
+}
+
+#[test]
+fn invalid_json_returns_error() {
+    let input = geojson_file("this is not valid json {{{");
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+
+    let result = run(input.path(), &out, &opts("invalid"), &SilentReporter);
+    assert!(result.is_err(), "invalid JSON must return an error");
+}
+
+#[test]
+fn unsupported_extension_returns_error() {
+    // A file with .csv extension should be rejected before any parsing
+    let mut f = Builder::new()
+        .suffix(".csv")
+        .tempfile()
+        .expect("create tempfile");
+    f.write_all(b"lon,lat\n13.4,52.5").expect("write");
+
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+
+    let result = run(f.path(), &out, &opts("csv"), &SilentReporter);
+    assert!(result.is_err(), "unsupported extension must fail");
+}
+
+#[test]
+fn nonexistent_input_returns_error() {
+    let dir = TempDir::new().unwrap();
+    let out = output_in(&dir);
+    let missing = std::path::Path::new("/tmp/nonexistent_tileserver_test_file_xyz.geojson");
+
+    let result = run(missing, &out, &opts("missing"), &SilentReporter);
+    assert!(result.is_err(), "missing input file must fail");
+}


### PR DESCRIPTION
This is basically a POC to show how an additional converter would be added. It is to test if my design is sound and extensible.
There is a lot of work left to do (tests and documentation)


## The following has to be noted for input format dispatch & future extensibility
### Current design
All conversion code lives under src/convert/input/. Adding a new input format requires exactly four changes in two files:

src/convert/input/mod.rs (the only file you touch for dispatch):

Add a module declaration (pub mod csv;)
Add an enum variant (InputFormat::Csv)
Add an extension match arm ("csv" => Some(Self::Csv))
Add a dispatch arm (InputFormat::Csv => csv::read(path))
src/convert/input/<format>.rs (new file):

Implement one function: pub fn read(path: &Path) -> Result<Vec<Feature>>
The CSV reader added in this PR is a concrete proof.

### Current limitation: batch-load model
Every format reader returns Vec<Feature> — i.e., the entire dataset is loaded into memory before tiling begins. This works well for GeoJSON and CSV, where sequential reads are the only access pattern anyway. For a 500 MB world-countries file the peak memory is ~2–3× the raw coordinate data, which is acceptable.

Future consideration: streaming / spatially-indexed formats
Formats like FlatGeobuf and GeoParquet embed a spatial index that allows bbox-filtered reads — only the features that overlap a given tile bbox are decoded from disk, which is O(k) rather than O(n). Exploiting this with the current batch-load API is impossible: we'd load all features into memory first, defeating the index entirely.

If these formats become a priority, the right fix is to change the reader contract from:

```
// current: load everything once
pub fn read(path: &Path) -> Result<Vec<Feature>>
```

to a streaming interface, for example:

```
// future: lazy iteration, bbox-filtered
pub trait FeatureSource: Send {
    fn features_in_bbox(&self, bbox: &Rect<f64>) -> Result<impl Iterator<Item = Feature>>;
}
```

With this interface the pipeline inner loop would call features_in_bbox(&tile_bbox) per tile, and FlatGeobuf could answer with only the relevant features. GeoJSON/CSV readers would fall back to a simple in-memory scan (same behaviour as today).

**I don't think the refactor should be done in the step for the converter but should be done when needed**