### PR TITLE
fix(build): enable mlt feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ moka = { version = "0.12", features = ["future"], optional = true }
 # aws-sdk-s3 = { version = "1.65", optional = true }
 
 [features]
-default = ["postgres", "raster"]
+default = ["postgres", "raster", "mlt"]
 frontend = ["rust-embed"]
 postgres = ["deadpool-postgres", "tokio-postgres", "postgres-types", "semver", "moka"]
 postgres-integration = ["postgres"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN cmake --preset linux-opengl \
 # =============================================================================
 FROM oven/bun:1 AS node-builder
 
-ARG FEATURES="frontend"
+ARG FEATURES="frontend mlt"
 
 WORKDIR /app
 
@@ -139,8 +139,8 @@ RUN mkdir -p src benches && echo "fn main() {}" > src/main.rs && echo "fn main()
 # Copy the embedded SPA
 COPY --from=node-builder /app/apps/client/.output/public ./apps/client/.output/public
 
-# Features are now enabled by default in Cargo.toml (postgres, raster)
-ARG FEATURES="frontend"
+# Features are now enabled by default in Cargo.toml (postgres, raster, mlt)
+ARG FEATURES="frontend mlt"
 
 # Build dependencies only (may fail on first try, that's ok)
 RUN if [ -n "$FEATURES" ]; then \


### PR DESCRIPTION
## Summary

- Add `mlt` to default features in `Cargo.toml` so all builds include MLT transcoding
- Update Dockerfile `FEATURES` arg to include `mlt` explicitly

Without this, Docker images and default `cargo build` produce binaries where `serve_as = "mlt"` silently serves raw MVT bytes unchanged — the transcoding code from #644 is never compiled in.

Closes #646