### PR TITLE
feat(docker): include stac feature in default Docker builds

### DIFF
--- a/.github/workflows/release-docker-images.yml
+++ b/.github/workflows/release-docker-images.yml
@@ -63,12 +63,12 @@ jobs:
             platform: linux/amd64
             arch: amd64
             variant: full
-            features: frontend geoparquet
+            features: frontend geoparquet stac
           - runner: ubuntu-24.04-arm
             platform: linux/arm64
             arch: arm64
             variant: full
-            features: frontend geoparquet
+            features: frontend geoparquet stac
           # Headless builds (no frontend, server-only)
           - runner: ubuntu-latest
             platform: linux/amd64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,7 +245,7 @@ geo              = { workspace = true, optional = true }
 duckdb           = { workspace = true, optional = true }
 
 [features]
-default = ["postgres", "raster", "mlt", "cloud"]
+default = ["postgres", "raster", "mlt", "cloud", "stac"]
 frontend = ["rust-embed"]
 postgres = ["deadpool-postgres", "tokio-postgres", "postgres-types", "semver", "dep:ogcapi-types", "dep:geojson", "dep:cql2"]
 postgres-integration = ["postgres"]


### PR DESCRIPTION
## Problem

The v2.25.0 Docker image was built with `FEATURES='frontend geoparquet'` which **excludes the `stac` feature** introduced in this release. demo.tileserver.app (and every other deployment using the published image) therefore cannot load STAC sources from config, even though the code paths exist.

## Changes

1. Add `stac` to `default` features in `Cargo.toml`. Unscoped builds (cargo install, local dev, binary installers) now get STAC support out of the box, matching the precedent of `postgres`/`raster`/`mlt`/`cloud`.
2. Add `stac` to the Docker matrix `full` variant features list in `release-docker-images.yml` so `ghcr.io/vinayakkulkarni/tileserver-rs:x.y.z` images can load STAC sources.

## Why default + full only (not headless)

STAC uses the `stac` crate as its only extra dep (`stac = ["raster", "dep:stac"]`); `raster` is already in defaults, so the only new runtime cost is the stac crate itself. Keeping headless variant minimal for users who want the smallest image.

## Verification

- Local gates: `cargo fmt --all -- --check` + `cargo clippy --all-targets -- -D warnings` (both clean with new defaults).
- Next published image (v2.25.1 via release-plz, or any tagged build) will ship with `stac`, unblocking STAC source configs on demo.tileserver.app.

## Deploy plan after merge

Once v2.25.1 is tagged + pushed:
1. bump `infra/compose/tileserver.yml` image tag to 2.25.1 in `vinayakkulkarni/telemetry`
2. add `[[sources]] type = "stac"` block to `apps/tileserver/config.toml` (sentinel-2 L2A over India/Bay of Bengal, read-only)
3. `docker compose pull tileserver && docker compose up -d tileserver`

Closes the STAC-on-demo gap flagged during the v2.25.0 deploy.