### PR TITLE
chore: release v2.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [2.25.1](https://github.com/vinayakkulkarni/tileserver-rs/compare/v2.25.0...v2.25.1) - 2026-04-19
+
+### Fixed
+
+- *(ci)* supply mbgl-sys binaries to release-plz so verify succeeds
+
+### Other
+
+- *(release-plz)* use semantic chore/release-plz- branch prefix
+- *(lint-branch)* allow release-plz automated branches
+- Merge pull request #791 from vinayakkulkarni/feat/include-stac-in-default-docker-builds
+- *(marketing)* run bun lint:fix + format on agent-generated code
+- Merge pull request #790 from vinayakkulkarni/feat/mlt-core-0-7
+- *(homebrew)* update formula to v2.25.0
+
 ## [2.25.0](https://github.com/vinayakkulkarni/tileserver-rs/compare/v2.24.0...v2.25.0) (2026-04-18)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5663,7 +5663,7 @@ dependencies = [
 
 [[package]]
 name = "tileserver-rs"
-version = "2.25.0"
+version = "2.25.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ undocumented_unsafe_blocks = "warn"
 
 [package]
 name = "tileserver-rs"
-version = "2.25.0"
+version = "2.25.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["Vinayak Kulkarni <inbox.vinayak@gmail.com>"]


### PR DESCRIPTION



## 🤖 New release

* `tileserver-rs`: 2.25.0 -> 2.25.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.25.1](https://github.com/vinayakkulkarni/tileserver-rs/compare/v2.25.0...v2.25.1) - 2026-04-19

### Fixed

- *(ci)* supply mbgl-sys binaries to release-plz so verify succeeds

### Other

- *(release-plz)* use semantic chore/release-plz- branch prefix
- *(lint-branch)* allow release-plz automated branches
- Merge pull request #791 from vinayakkulkarni/feat/include-stac-in-default-docker-builds
- *(marketing)* run bun lint:fix + format on agent-generated code
- Merge pull request #790 from vinayakkulkarni/feat/mlt-core-0-7
- *(homebrew)* update formula to v2.25.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).