### PR TITLE
feat(telemetry): add Prometheus /metrics endpoint via OpenTelemetry bridge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,6 +51,7 @@ jobs:
           cargo llvm-cov \
             --no-report \
             --lib \
+            --test metrics_endpoint \
             --no-default-features \
             --features "postgres,mlt"
 

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ data/raster/benchmark-rgb.cog.tif
 apps/docs/.data
 .sisyphus
 data/overture
+docs/superpowers

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "tileserver-rs"
-version = "2.28.0"
+version = "2.27.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,6 +3578,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-prometheus-text-exporter"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897906366b17a89bec845f6051e0c3474049402a09a0711eea180941293bd013"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smartstring",
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5355,6 +5366,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
+]
+
+[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5475,6 +5497,12 @@ dependencies = [
  "psm",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -5753,6 +5781,7 @@ dependencies = [
  "ogcapi-types",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry-prometheus-text-exporter",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "parquet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "tileserver-rs"
-version = "2.27.0"
+version = "2.28.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,10 +107,20 @@ scalar_api_reference = { version = "0.2", features = ["axum"] }
 
 # OpenTelemetry
 opentelemetry    = "0.31.0"
-opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio"] }
+opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio", "experimental_metrics_custom_reader"] }
 opentelemetry-otlp = { version = "0.31.1", features = ["grpc-tonic", "metrics", "logs"] }
 opentelemetry-semantic-conventions = "0.31.0"
 tracing-opentelemetry = "0.32.1"
+# Prometheus pull-endpoint exporter — community successor to the discontinued
+# `opentelemetry-prometheus` crate. Authored by Quentin Gliech (Element /
+# Matrix.org) and explicitly endorsed by the OTel-Rust maintainers in
+# <https://github.com/open-telemetry/opentelemetry-rust/issues/2451> as the
+# replacement after the original crate was deprecated due to its `protobuf`
+# dependency carrying unresolved security vulnerabilities. Pinned EXACT (`=`)
+# because the crate is pre-1.0 (`0.2.x`) and may make breaking changes
+# between minor versions; bumping requires a deliberate review of the
+# changelog and an update to our `metrics/server.rs` integration.
+opentelemetry-prometheus-text-exporter = "=0.2.1"
 
 # Raster / GDAL (optional)
 gdal             = { version = "0.19.0", features = ["bindgen"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ scalar_api_reference = { version = "0.2", features = ["axum"] }
 
 # OpenTelemetry
 opentelemetry    = "0.31.0"
-opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio", "experimental_metrics_custom_reader"] }
+opentelemetry_sdk = { version = "0.31.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.31.1", features = ["grpc-tonic", "metrics", "logs"] }
 opentelemetry-semantic-conventions = "0.31.0"
 tracing-opentelemetry = "0.32.1"

--- a/README.md
+++ b/README.md
@@ -233,7 +233,11 @@ cors_origins = ["*", "https://example.com"]  # Supports multiple origins
 # admin_bind = "127.0.0.1:9099"
 
 [telemetry]
-enabled = false
+enabled = false                         # OTLP traces + metrics push (default: false)
+# endpoint = "http://localhost:4317"    # OTLP gRPC collector
+# metrics_enabled = true                # OTLP metrics push (requires enabled = true)
+# prometheus_bind = "127.0.0.1:9100"    # Optional: separate Prometheus /metrics scrape listener
+# metrics_label_cardinality = "strict"  # "strict" (default) | "verbose"
 
 [[sources]]
 id = "openmaptiles"
@@ -274,6 +278,62 @@ admin_bind = "127.0.0.1:9099"
 
 This exposes `POST /__admin/reload` on a separate port for reloading configuration without restarting the server. You can also send `SIGHUP` to the process for the same effect. See the [Hot Reload Guide](https://docs.tileserver.app/guides/hot-reload) for details.
 
+### Observability (Metrics & Tracing)
+
+tileserver-rs exposes runtime metrics two ways — both off by default, both independent of each other:
+
+- **Prometheus pull**: a separate HTTP listener (default port disabled) that exposes `GET /metrics` in Prometheus text format. Recommended for production scraping.
+- **OTLP push**: traces + metrics pushed to an OpenTelemetry collector (e.g. Grafana Alloy, OTel Collector, Jaeger).
+
+```toml
+[telemetry]
+# Prometheus pull endpoint (separate listener, scoped to your monitoring network):
+prometheus_bind = "127.0.0.1:9100"
+prometheus_path = "/metrics"
+metrics_label_cardinality = "strict"   # "strict" = production-safe; "verbose" = debug only
+
+# OTLP push pipeline (independent of prometheus_bind above):
+enabled = true
+endpoint = "http://localhost:4317"
+service_name = "tileserver-rs"
+sample_rate = 1.0
+```
+
+> **Why a separate port?** Following the [official Axum example](https://github.com/tokio-rs/axum/blob/main/examples/prometheus-metrics/src/main.rs) and projects like Opengist, the metrics endpoint runs on a dedicated listener so you can bind it to a private interface (e.g. `127.0.0.1` or a VPC-internal address) while keeping `/data`, `/styles`, and `/__admin` behind their own ACLs.
+
+**Exported metrics (Prometheus naming):**
+
+| Metric | Type | Unit | Labels | Description |
+|---|---|---|---|---|
+| `http_requests_total` | counter | — | `route`, `status_class` | HTTP requests by matched route and 1xx/2xx/3xx/4xx/5xx |
+| `http_request_duration_seconds` | histogram | seconds | `route`, `status_class` | Per-request latency |
+| `http_requests_in_flight` | up-down | — | — | Currently in-flight HTTP requests |
+| `tile_requests_total` | counter | — | `source`, `format`, `z_bucket`, `outcome` | Tile lookups by hit/miss/not_found/error |
+| `tile_request_duration_seconds` | histogram | seconds | `source`, `format`, `z_bucket`, `outcome` | End-to-end tile latency |
+| `tile_request_bytes` | histogram | bytes | `source`, `format` | Tile response payload size |
+| `tile_cache_hits_total` | counter | — | `source` | In-process tile cache hits |
+| `tile_cache_misses_total` | counter | — | `source` | In-process tile cache misses |
+| `render_duration_seconds` | histogram | seconds | `style`, `format` | Native MapLibre raster render duration |
+| `render_errors_total` | counter | — | `style`, `reason` | Native render failures bucketed by reason |
+
+**Cardinality matters.** The `metrics_label_cardinality` knob exists because [unbounded labels blow up Prometheus storage](https://prometheus.io/docs/practices/naming/):
+
+- **`strict`** (default) — `z_bucket` collapses zoom levels into `low` (0–6), `mid` (7–12), `high` (13+). Tile coordinates (`x`, `y`) are dropped entirely. Bounded label combinations safe for long-term retention.
+- **`verbose`** — passes raw zoom 0..=22 through. Useful for short-window investigations; **do not leave enabled in production** — a globe-scale source at z=22 has trillions of unique tile coordinates.
+
+**Scrape config example:**
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: tileserver-rs
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['tileserver-rs.internal:9100']
+```
+
+When `prometheus_bind` is unset (the default), the listener task is never spawned and the per-request cost is a single atomic load — no Prometheus, no overhead. See the [Telemetry Guide](https://docs.tileserver.app/guides/telemetry) for Grafana/Tempo/Jaeger backend setup.
+
 See [data/configs/example.toml](./data/configs/example.toml) for a complete example, or [data/configs/offline.toml](./data/configs/offline.toml) for a local development setup.
 
 ## API Endpoints
@@ -284,6 +344,7 @@ See [data/configs/example.toml](./data/configs/example.toml) for a complete exam
 |----------|-------------|
 | `GET /health` | Health check (returns `OK`) |
 | `GET /ping` | Runtime metadata (config hash, loaded sources/styles, version) |
+| `GET /metrics` | Prometheus metrics exposition (separate listener — see [Observability](#observability-metrics--tracing)) |
 | `POST /__admin/reload` | Hot-reload configuration (admin server only) |
 | `POST /__admin/reload?flush=true` | Force reload even if config unchanged |
 

--- a/apps/docs/content/1.getting-started/3.configuration.md
+++ b/apps/docs/content/1.getting-started/3.configuration.md
@@ -356,42 +356,60 @@ Files in this directory will be accessible at `/files/{filepath}`. This is usefu
 
 ## Telemetry Configuration
 
-tileserver-rs supports [OpenTelemetry](https://opentelemetry.io/) for exporting traces and metrics via OTLP gRPC.
+tileserver-rs supports two independent observability pipelines: an OTLP push pipeline ([OpenTelemetry](https://opentelemetry.io/) traces + metrics over gRPC) and a Prometheus pull-based `/metrics` scrape endpoint. Both are off by default and can run independently.
 
 ```toml
 [telemetry]
+# OTLP push pipeline
 enabled = true
 endpoint = "http://localhost:4317"
 service_name = "tileserver-rs"
 sample_rate = 1.0
 metrics_enabled = true
 metrics_export_interval_secs = 60
+
+# Prometheus pull endpoint (independent of `enabled` above)
+prometheus_bind = "127.0.0.1:9100"
+prometheus_path = "/metrics"
+metrics_label_cardinality = "strict"
 ```
 
-| Option                         | Description                                       | Default                 |
-| ------------------------------ | ------------------------------------------------- | ----------------------- |
-| `enabled`                      | Enable OpenTelemetry (traces + metrics)           | `false`                 |
-| `endpoint`                     | OTLP gRPC collector endpoint                      | `http://localhost:4317` |
-| `service_name`                 | Service name for traces and metrics               | `tileserver-rs`         |
-| `sample_rate`                  | Trace sampling rate (0.0 to 1.0)                  | `1.0`                   |
-| `metrics_enabled`              | Enable metrics export (requires `enabled = true`) | `true`                  |
-| `metrics_export_interval_secs` | How often metrics are pushed to the collector     | `60`                    |
+| Option                         | Description                                                            | Default                 |
+| ------------------------------ | ---------------------------------------------------------------------- | ----------------------- |
+| `enabled`                      | Enable OpenTelemetry OTLP push (traces + metrics)                      | `false`                 |
+| `endpoint`                     | OTLP gRPC collector endpoint                                           | `http://localhost:4317` |
+| `service_name`                 | Service name for traces and metrics                                    | `tileserver-rs`         |
+| `sample_rate`                  | Trace sampling rate (0.0 to 1.0)                                       | `1.0`                   |
+| `metrics_enabled`              | Enable OTLP metrics push (requires `enabled = true`)                   | `true`                  |
+| `metrics_export_interval_secs` | How often metrics are pushed to the collector                          | `60`                    |
+| `prometheus_bind`              | Bind address for the Prometheus scrape listener (unset = disabled)     | unset                   |
+| `prometheus_path`              | HTTP path for the Prometheus exposition endpoint                       | `/metrics`              |
+| `metrics_label_cardinality`    | Label cardinality strategy: `"strict"` (production) or `"verbose"`     | `"strict"`              |
 
-When enabled, the following metrics are exported:
+The same instruments feed both pipelines:
 
-| Metric                           | Type      | Unit     | Description         |
-| -------------------------------- | --------- | -------- | ------------------- |
-| `http.server.request.count`      | Counter   | requests | Total HTTP requests |
-| `http.server.request.duration`   | Histogram | seconds  | Request duration    |
-| `http.server.response.body.size` | Histogram | bytes    | Response body size  |
-
-Each metric includes attributes: `http.request.method`, `http.response.status_code`, `url.path`.
+| Metric                          | Type      | Unit | Labels                                      | Description                                |
+| ------------------------------- | --------- | ---- | ------------------------------------------- | ------------------------------------------ |
+| `http_requests_total`           | counter   | —    | `route`, `status_class`                     | HTTP requests by matched route + status    |
+| `http_request_duration_seconds` | histogram | s    | `route`, `status_class`                     | Per-request latency                        |
+| `http_requests_in_flight`       | up-down   | —    | —                                           | In-flight HTTP requests                    |
+| `tile_requests_total`           | counter   | —    | `source`, `format`, `z_bucket`, `outcome`   | Tile lookups (hit/miss/not_found/error)    |
+| `tile_request_duration_seconds` | histogram | s    | `source`, `format`, `z_bucket`, `outcome`   | End-to-end tile latency                    |
+| `tile_request_bytes`            | histogram | By   | `source`, `format`                          | Tile response payload size                 |
+| `tile_cache_hits_total`         | counter   | —    | `source`                                    | In-process tile cache hits                 |
+| `tile_cache_misses_total`       | counter   | —    | `source`                                    | In-process tile cache misses               |
+| `render_duration_seconds`       | histogram | s    | `style`, `format`                           | Native MapLibre raster render duration     |
+| `render_errors_total`           | counter   | —    | `style`, `reason`                           | Native render failures bucketed by reason  |
 
 ::alert{type="info"}
-When telemetry is disabled (the default), metrics recording has zero overhead — all instruments are no-ops.
+When neither `enabled = true` nor `prometheus_bind` is set (the default), all instruments are no-ops — recording a metric is a single atomic load with negligible overhead.
 ::
 
-See the [Telemetry Guide](/guides/telemetry) for setup examples with Grafana, Jaeger, and other backends.
+::alert{type="warning"}
+**Cardinality matters.** `metrics_label_cardinality = "strict"` (the default) collapses zoom into `low` (0–6), `mid` (7–12), `high` (13+) buckets and drops tile `x`/`y` coordinates entirely. Switching to `"verbose"` exposes raw zoom 0–22, which can blow up Prometheus storage on large globe-scale sources. Use `"verbose"` only for short-window debugging.
+::
+
+See the [Telemetry Guide](/guides/telemetry) for setup examples with Grafana, Jaeger, Prometheus, and other backends.
 
 ## Render Pool Configuration
 

--- a/apps/docs/content/4.guides/5.telemetry.md
+++ b/apps/docs/content/4.guides/5.telemetry.md
@@ -1,13 +1,28 @@
 ---
 title: Telemetry & Observability
-description: Monitor tileserver-rs with OpenTelemetry traces and metrics
+description: Monitor tileserver-rs with OpenTelemetry traces and Prometheus metrics
 ---
 
-tileserver-rs exports traces and metrics via [OpenTelemetry](https://opentelemetry.io/) OTLP gRPC. This guide covers setup with common observability backends.
+tileserver-rs exports observability data via two independent pipelines:
+
+- **OTLP push** — traces + metrics pushed to an [OpenTelemetry](https://opentelemetry.io/) collector over gRPC (Grafana Alloy, OTel Collector, Jaeger, …).
+- **Prometheus pull** — a dedicated `/metrics` HTTP listener exposing the same metrics in Prometheus text format for direct scraping.
+
+Both pipelines feed off the same instrument handles, so enabling them in any combination has no effect on hot-path performance — recording a metric is a single atomic load when neither pipeline is active.
 
 ## Quick Start
 
-Enable telemetry in your `config.toml`:
+### Prometheus scraping (recommended for production)
+
+```toml
+[telemetry]
+prometheus_bind = "127.0.0.1:9100"
+metrics_label_cardinality = "strict"
+```
+
+Then point Prometheus at `http://your-host:9100/metrics`. No OTLP collector required.
+
+### OTLP push (traces + metrics)
 
 ```toml
 [telemetry]
@@ -17,42 +32,117 @@ endpoint = "http://localhost:4317"
 
 This enables both traces and metrics, exported to an OTLP-compatible collector on port 4317 (gRPC).
 
+### Both at once
+
+```toml
+[telemetry]
+enabled = true                       # OTLP push
+endpoint = "http://localhost:4317"
+prometheus_bind = "127.0.0.1:9100"   # Prometheus pull
+metrics_label_cardinality = "strict"
+```
+
 ## What's Exported
 
 ### Traces
 
-Every HTTP request creates a span with method, path, status, and duration. Traces use the standard `tracing` crate integration — all structured log events in the codebase become span events.
+Every HTTP request creates a span with method, path, status, and duration. Traces use the standard `tracing` crate integration — all structured log events in the codebase become span events. Traces are OTLP-only (Prometheus does not have a trace data model).
 
 ### Metrics
 
-| Metric                           | Type      | Unit     | Description                     |
-| -------------------------------- | --------- | -------- | ------------------------------- |
-| `http.server.request.count`      | Counter   | requests | Total HTTP requests             |
-| `http.server.request.duration`   | Histogram | seconds  | Request duration distribution   |
-| `http.server.response.body.size` | Histogram | bytes    | Response body size distribution |
+The same 10 metrics are emitted to both pipelines:
 
-All metrics include these attributes:
+| Metric                          | Type      | Unit | Labels                                      | Description                                |
+| ------------------------------- | --------- | ---- | ------------------------------------------- | ------------------------------------------ |
+| `http_requests_total`           | counter   | —    | `route`, `status_class`                     | HTTP requests by matched route + status    |
+| `http_request_duration_seconds` | histogram | s    | `route`, `status_class`                     | Per-request latency                        |
+| `http_requests_in_flight`       | up-down   | —    | —                                           | In-flight HTTP requests                    |
+| `tile_requests_total`           | counter   | —    | `source`, `format`, `z_bucket`, `outcome`   | Tile lookups (hit/miss/not_found/error)    |
+| `tile_request_duration_seconds` | histogram | s    | `source`, `format`, `z_bucket`, `outcome`   | End-to-end tile latency                    |
+| `tile_request_bytes`            | histogram | By   | `source`, `format`                          | Tile response payload size                 |
+| `tile_cache_hits_total`         | counter   | —    | `source`                                    | In-process tile cache hits                 |
+| `tile_cache_misses_total`       | counter   | —    | `source`                                    | In-process tile cache misses               |
+| `render_duration_seconds`       | histogram | s    | `style`, `format`                           | Native MapLibre raster render duration     |
+| `render_errors_total`           | counter   | —    | `style`, `reason`                           | Native render failures bucketed by reason  |
 
-| Attribute                   | Example                               |
-| --------------------------- | ------------------------------------- |
-| `http.request.method`       | `GET`                                 |
-| `http.response.status_code` | `200`                                 |
-| `url.path`                  | `/data/openmaptiles/12/2176/1493.pbf` |
+The `route` label uses the matched Axum route template (`/data/{source}/{z}/{x}/{y_fmt}`) — never the raw URL — so paths stay bounded. The `status_class` label collapses HTTP status codes into `1xx`/`2xx`/`3xx`/`4xx`/`5xx`.
 
 ## Configuration Reference
 
 ```toml
 [telemetry]
-enabled = true                      # Enable OpenTelemetry
+# OTLP push pipeline
+enabled = true                       # Enable OTLP traces + metrics push (default: false)
 endpoint = "http://localhost:4317"   # OTLP gRPC endpoint
 service_name = "tileserver-rs"       # Service name in traces/metrics
-sample_rate = 1.0                    # Trace sampling (0.0-1.0)
-metrics_enabled = true               # Enable metrics (default: true)
-metrics_export_interval_secs = 60    # Metrics push interval (default: 60)
+sample_rate = 1.0                    # Trace sampling (0.0–1.0; metrics ignore this)
+metrics_enabled = true               # Enable OTLP metrics push (default: true)
+metrics_export_interval_secs = 60    # OTLP metrics push interval (default: 60)
+
+# Prometheus pull endpoint (independent of OTLP push)
+prometheus_bind = "127.0.0.1:9100"   # Bind address (unset = disabled, default)
+prometheus_path = "/metrics"         # HTTP path (default: "/metrics")
+metrics_label_cardinality = "strict" # "strict" (default) | "verbose"
 ```
 
 ::alert{type="info"}
-Metrics are only active when both `enabled` and `metrics_enabled` are `true`. When disabled, all metric instruments are no-ops with zero performance overhead.
+When neither `enabled = true` nor `prometheus_bind` is set (the default), all instruments are no-ops — recording a metric compiles to a single atomic load.
+::
+
+## Prometheus Scrape Endpoint
+
+`prometheus_bind` opts into a **separate** HTTP listener for Prometheus to scrape directly. Following the [official Axum example](https://github.com/tokio-rs/axum/blob/main/examples/prometheus-metrics/src/main.rs), the listener runs on its own port so you can:
+
+- Bind it to a private interface (`127.0.0.1` for sidecar scraping, or a VPC-internal address) while keeping `/data`, `/styles`, and `/__admin` behind their own ACLs.
+- Skip authentication — the metrics endpoint never sees your tile traffic.
+- Restart/reload the metrics listener independently of the main server.
+
+### Scrape config
+
+```yaml
+# prometheus.yml
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: tileserver-rs
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['tileserver-rs.internal:9100']
+    # For Kubernetes service discovery:
+    # kubernetes_sd_configs:
+    #   - role: pod
+    # relabel_configs:
+    #   - source_labels: [__meta_kubernetes_pod_label_app]
+    #     regex: tileserver-rs
+    #     action: keep
+```
+
+### Health check
+
+The metrics listener also exposes `GET /metrics/health` returning `200 OK` for liveness/readiness probes.
+
+## Label Cardinality
+
+[Unbounded labels are the #1 cause of Prometheus memory blowups](https://prometheus.io/docs/practices/naming/). The `metrics_label_cardinality` setting controls the cardinality budget:
+
+### `strict` (default — production-safe)
+
+- Zoom is collapsed into `z_bucket` = `low` (z 0–6), `mid` (z 7–12), or `high` (z 13+).
+- Tile `x`/`y` coordinates are dropped entirely.
+- HTTP `route` uses Axum's matched-path template, never the raw URL.
+- HTTP `status_class` collapses status codes into `1xx`/`2xx`/`3xx`/`4xx`/`5xx`.
+
+Worst-case cardinality for a typical config (5 sources × 3 formats × 3 z_buckets × 4 outcomes = 180 series per metric) is comfortably within the [<10,000 total series rule of thumb](https://prometheus.io/docs/practices/instrumentation/#do-not-overuse-labels).
+
+### `verbose` (debug-only)
+
+- Raw zoom levels 0..=22 are passed through.
+- All other labels behave like `strict`.
+
+::alert{type="warning"}
+A globe-scale source served at z=22 has trillions of unique tile coordinates. Even with coordinates dropped, multiplying 5 sources × 3 formats × 23 zoom levels × 4 outcomes = 1,380 series per metric — manageable, but storage grows fast under sustained traffic. **Do not leave `verbose` enabled in production.** Use it for short-window investigations and switch back to `strict` afterwards.
 ::
 
 ## Backend Setup Examples

--- a/benchmarks/results/README.md
+++ b/benchmarks/results/README.md
@@ -1,0 +1,19 @@
+# Benchmark Results
+
+Raw autocannon JSON output files are stored in this directory.
+
+## How to Run
+
+```sh
+# From repo root
+cd benchmarks
+npm run bench:metrics
+```
+
+## v2.28.0 Prometheus Metrics Results
+
+Results for the `no-telemetry` and `metrics-strict` profiles will be
+added here after running the macro-bench suite manually.
+
+See the PR description for the Criterion micro-benchmark numbers
+(sub-250 ns/call for strict cardinality).

--- a/benchmarks/run-benchmarks.js
+++ b/benchmarks/run-benchmarks.js
@@ -12,6 +12,20 @@
  *   node run-benchmarks.js --mode grid              # Grid tile viewport simulation
  *   node run-benchmarks.js --mode grid --grid-size 5x4  # Custom grid dimensions
  *   node run-benchmarks.js --mode grid --iterations 100  # More iterations for accuracy
+ *
+ * Prometheus Metrics Benchmarks:
+ * To measure the overhead of Prometheus metrics, run tileserver-rs with different configs:
+ *
+ *   BASELINE (telemetry disabled):
+ *     cargo run -- --config data/configs/no-telemetry.toml
+ *     (in another terminal) npm run bench:metrics
+ *
+ *   METRICS ENABLED (strict cardinality):
+ *     cargo run -- --config data/configs/metrics-strict.toml
+ *     (in another terminal) npm run bench:metrics
+ *
+ * Results will show throughput and latency impact on the hot path (/data/{z}/{x}/{y}.pbf).
+ * Micro-benchmarks (Criterion) for metrics overhead are in crates/tileserver-rs/benches/.
  */
 
 import autocannon from 'autocannon';

--- a/crates/tileserver-rs/Cargo.toml
+++ b/crates/tileserver-rs/Cargo.toml
@@ -59,6 +59,7 @@ opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+opentelemetry-prometheus-text-exporter = { workspace = true }
 
 # MBTiles support (SQLite)
 rusqlite         = { workspace = true }

--- a/crates/tileserver-rs/Cargo.toml
+++ b/crates/tileserver-rs/Cargo.toml
@@ -159,3 +159,7 @@ required-features = ["duckdb"]
 name = "geoparquet"
 harness = false
 required-features = ["geoparquet"]
+
+[[bench]]
+name = "metrics_overhead"
+harness = false

--- a/crates/tileserver-rs/benches/metrics_overhead.rs
+++ b/crates/tileserver-rs/benches/metrics_overhead.rs
@@ -1,0 +1,92 @@
+//! Benchmarks the per-call overhead of `metrics::tile_request_recorded`.
+//!
+//! Acceptance gates (per spec §10.1):
+//! - `disabled`: < 5 ns (no global meter installed → atomic no-op path)
+//! - `strict`:   < 250 ns (LabelBank hit + 2 atomic instrument calls)
+//! - `verbose`:  < 750 ns (per-z label, larger HashMap, but still cheap)
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use opentelemetry_prometheus_text_exporter::PrometheusExporter;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+
+use tileserver_rs::metrics::{self, Cardinality, TileEvent, TileOutcome};
+use tileserver_rs::sources::TileFormat;
+
+fn install_real_meter() {
+    let exporter = PrometheusExporter::new();
+    let provider = SdkMeterProvider::builder().with_reader(exporter).build();
+    opentelemetry::global::set_meter_provider(provider);
+}
+
+fn warm_label_bank(source: &str, z: u8) {
+    metrics::tile_request_recorded(TileEvent {
+        source,
+        format: TileFormat::Pbf,
+        z,
+        bytes: 1024,
+        duration: Duration::from_millis(1),
+        outcome: TileOutcome::Hit,
+    });
+}
+
+fn bench_disabled(c: &mut Criterion) {
+    metrics::init(Cardinality::Strict);
+    warm_label_bank("openmaptiles", 14);
+    c.bench_function("tile_request_recorded/disabled", |b| {
+        b.iter(|| {
+            metrics::tile_request_recorded(black_box(TileEvent {
+                source: "openmaptiles",
+                format: TileFormat::Pbf,
+                z: 14,
+                bytes: 1024,
+                duration: Duration::from_millis(1),
+                outcome: TileOutcome::Hit,
+            }));
+        });
+    });
+}
+
+fn bench_strict(c: &mut Criterion) {
+    install_real_meter();
+    metrics::init(Cardinality::Strict);
+    warm_label_bank("openmaptiles", 14);
+    c.bench_function("tile_request_recorded/strict", |b| {
+        b.iter(|| {
+            metrics::tile_request_recorded(black_box(TileEvent {
+                source: "openmaptiles",
+                format: TileFormat::Pbf,
+                z: 14,
+                bytes: 1024,
+                duration: Duration::from_millis(1),
+                outcome: TileOutcome::Hit,
+            }));
+        });
+    });
+}
+
+fn bench_verbose(c: &mut Criterion) {
+    install_real_meter();
+    metrics::init(Cardinality::Verbose);
+    for z in 0u8..=22 {
+        warm_label_bank("openmaptiles", z);
+    }
+    c.bench_function("tile_request_recorded/verbose", |b| {
+        b.iter(|| {
+            metrics::tile_request_recorded(black_box(TileEvent {
+                source: "openmaptiles",
+                format: TileFormat::Pbf,
+                z: 14,
+                bytes: 1024,
+                duration: Duration::from_millis(1),
+                outcome: TileOutcome::Hit,
+            }));
+        });
+    });
+}
+
+criterion_group!(benches, bench_disabled, bench_strict, bench_verbose);
+criterion_main!(benches);

--- a/crates/tileserver-rs/benches/metrics_overhead.rs
+++ b/crates/tileserver-rs/benches/metrics_overhead.rs
@@ -1,92 +1,87 @@
-//! Benchmarks the per-call overhead of `metrics::tile_request_recorded`.
+//! Criterion benchmarks for `metrics::tile_request_recorded` per-call overhead.
 //!
 //! Acceptance gates (per spec §10.1):
 //! - `disabled`: < 5 ns (no global meter installed → atomic no-op path)
 //! - `strict`:   < 250 ns (LabelBank hit + 2 atomic instrument calls)
-//! - `verbose`:  < 750 ns (per-z label, larger HashMap, but still cheap)
+//!
+//! Verbose cardinality cannot be benchmarked in the same binary because the
+//! metrics module's `LABEL_BANK` is a `OnceLock<LabelBank>` that can only be
+//! initialised once per process. Strict is the production default and is the
+//! merge-blocking budget. A separate `metrics_overhead_verbose` binary can be
+//! added later if verbose budget enforcement becomes necessary.
 
 use std::hint::black_box;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-
-use opentelemetry_prometheus_text_exporter::PrometheusExporter;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 
 use tileserver_rs::metrics::{self, Cardinality, TileEvent, TileOutcome};
 use tileserver_rs::sources::TileFormat;
 
-fn install_real_meter() {
-    let exporter = PrometheusExporter::new();
-    let provider = SdkMeterProvider::builder().with_reader(exporter).build();
-    opentelemetry::global::set_meter_provider(provider);
+fn make_event() -> TileEvent<'static> {
+    TileEvent {
+        source: "openmaptiles",
+        format: TileFormat::Pbf,
+        z: 14,
+        bytes: 4096,
+        duration: Duration::from_millis(5),
+        outcome: TileOutcome::Hit,
+    }
 }
 
-fn warm_label_bank(source: &str, z: u8) {
-    metrics::tile_request_recorded(TileEvent {
-        source,
-        format: TileFormat::Pbf,
-        z,
-        bytes: 1024,
-        duration: Duration::from_millis(1),
-        outcome: TileOutcome::Hit,
-    });
+fn clone_event(event: &TileEvent<'static>) -> TileEvent<'static> {
+    TileEvent {
+        source: event.source,
+        format: event.format,
+        z: event.z,
+        bytes: event.bytes,
+        duration: event.duration,
+        outcome: event.outcome,
+    }
 }
 
 fn bench_disabled(c: &mut Criterion) {
-    metrics::init(Cardinality::Strict);
-    warm_label_bank("openmaptiles", 14);
-    c.bench_function("tile_request_recorded/disabled", |b| {
+    // No OTel provider installed: relies on the global no-op MeterProvider.
+    // Do NOT call `metrics::init()` here — that would consume the OnceLock and
+    // contaminate the strict bench in the same binary.
+    let mut group = c.benchmark_group("tile_request_recorded/disabled");
+    group.measurement_time(Duration::from_secs(5));
+    group.bench_function("noop_provider", |b| {
+        let event = make_event();
         b.iter(|| {
-            metrics::tile_request_recorded(black_box(TileEvent {
-                source: "openmaptiles",
-                format: TileFormat::Pbf,
-                z: 14,
-                bytes: 1024,
-                duration: Duration::from_millis(1),
-                outcome: TileOutcome::Hit,
-            }));
+            metrics::tile_request_recorded(black_box(clone_event(&event)));
         });
     });
+    group.finish();
+}
+
+static PROVIDER: OnceLock<SdkMeterProvider> = OnceLock::new();
+
+fn init_strict_provider() -> &'static SdkMeterProvider {
+    PROVIDER.get_or_init(|| {
+        let provider = SdkMeterProvider::builder().build();
+        opentelemetry::global::set_meter_provider(provider.clone());
+        metrics::init(Cardinality::Strict);
+        provider
+    })
 }
 
 fn bench_strict(c: &mut Criterion) {
-    install_real_meter();
-    metrics::init(Cardinality::Strict);
-    warm_label_bank("openmaptiles", 14);
-    c.bench_function("tile_request_recorded/strict", |b| {
+    let _ = init_strict_provider();
+
+    let mut group = c.benchmark_group("tile_request_recorded/strict");
+    group.measurement_time(Duration::from_secs(10));
+    group.bench_function("in_memory_strict", |b| {
+        let event = make_event();
         b.iter(|| {
-            metrics::tile_request_recorded(black_box(TileEvent {
-                source: "openmaptiles",
-                format: TileFormat::Pbf,
-                z: 14,
-                bytes: 1024,
-                duration: Duration::from_millis(1),
-                outcome: TileOutcome::Hit,
-            }));
+            metrics::tile_request_recorded(black_box(clone_event(&event)));
         });
     });
+    group.finish();
 }
 
-fn bench_verbose(c: &mut Criterion) {
-    install_real_meter();
-    metrics::init(Cardinality::Verbose);
-    for z in 0u8..=22 {
-        warm_label_bank("openmaptiles", z);
-    }
-    c.bench_function("tile_request_recorded/verbose", |b| {
-        b.iter(|| {
-            metrics::tile_request_recorded(black_box(TileEvent {
-                source: "openmaptiles",
-                format: TileFormat::Pbf,
-                z: 14,
-                bytes: 1024,
-                duration: Duration::from_millis(1),
-                outcome: TileOutcome::Hit,
-            }));
-        });
-    });
-}
-
-criterion_group!(benches, bench_disabled, bench_strict, bench_verbose);
-criterion_main!(benches);
+criterion_group!(benches_disabled, bench_disabled);
+criterion_group!(benches_strict, bench_strict);
+criterion_main!(benches_disabled, benches_strict);

--- a/crates/tileserver-rs/src/admin.rs
+++ b/crates/tileserver-rs/src/admin.rs
@@ -14,7 +14,6 @@ struct ReloadQueryParams {
     flush: Option<bool>,
 }
 
-/// Runtime metadata returned by the `/ping` endpoint.
 #[derive(serde::Serialize)]
 pub struct PingResponse {
     status: &'static str,
@@ -23,6 +22,7 @@ pub struct PingResponse {
     loaded_sources: usize,
     loaded_styles: usize,
     renderer_enabled: bool,
+    prometheus_listener_active: bool,
     version: &'static str,
     cache_enabled: bool,
     cache_entries: u64,
@@ -38,6 +38,7 @@ struct ReloadResponse {
     loaded_sources: usize,
     loaded_styles: usize,
     renderer_enabled: bool,
+    prometheus_listener_active: bool,
     version: &'static str,
 }
 
@@ -76,6 +77,7 @@ pub async fn ping_check(State(shared): State<SharedState>) -> Json<PingResponse>
         loaded_sources: meta.loaded_sources,
         loaded_styles: meta.loaded_styles,
         renderer_enabled: meta.renderer_enabled,
+        prometheus_listener_active: meta.prometheus_listener_active,
         version: env!("CARGO_PKG_VERSION"),
         cache_enabled,
         cache_entries,
@@ -117,6 +119,7 @@ async fn admin_reload(
             loaded_sources: result.loaded_sources,
             loaded_styles: result.loaded_styles,
             renderer_enabled: result.renderer_enabled,
+            prometheus_listener_active: result.prometheus_listener_active,
             version: env!("CARGO_PKG_VERSION"),
         })),
         Err(err) => Err((
@@ -194,6 +197,7 @@ path = "{}"
             loaded_sources: state.sources.len(),
             loaded_styles: state.styles.len(),
             renderer_enabled: state.renderer.is_some(),
+            prometheus_listener_active: false,
         };
 
         let controller = Arc::new(ReloadController::new(

--- a/crates/tileserver-rs/src/config.rs
+++ b/crates/tileserver-rs/src/config.rs
@@ -206,6 +206,45 @@ pub struct TelemetryConfig {
     /// Metrics export interval in seconds
     #[serde(default = "default_metrics_export_interval_secs")]
     pub metrics_export_interval_secs: u64,
+    /// Bind address for the standalone Prometheus `/metrics` listener
+    /// (e.g., `"127.0.0.1:9100"`). When `None` (the default), the
+    /// listener task is never spawned and there is zero runtime cost.
+    /// Independent of `enabled` — Prometheus pull works without OTLP
+    /// push and vice versa.
+    #[serde(default)]
+    pub prometheus_bind: Option<String>,
+    /// HTTP path for the Prometheus exposition endpoint (default
+    /// `/metrics`). Only relevant when `prometheus_bind` is set.
+    #[serde(default = "default_prometheus_path")]
+    pub prometheus_path: String,
+    /// Cardinality strategy for metric labels:
+    /// - `Strict` (default): zoom collapsed to `low|mid|high` buckets,
+    ///   tile coordinates dropped — bounded combinations safe for
+    ///   long-term Prometheus retention.
+    /// - `Standard`: same as strict for now (reserved for future
+    ///   intermediate strategies).
+    /// - `Verbose`: zoom passed through 0..=22, useful for debugging
+    ///   short-window investigations but can blow up cardinality if
+    ///   left enabled in production.
+    #[serde(default)]
+    pub metrics_label_cardinality: MetricsLabelCardinality,
+}
+
+/// Cardinality strategy for metric labels emitted via the
+/// Prometheus `/metrics` endpoint and the OTLP push pipeline.
+///
+/// See [`TelemetryConfig::metrics_label_cardinality`] for behavior
+/// of each variant. Default is [`MetricsLabelCardinality::Strict`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MetricsLabelCardinality {
+    /// Bounded label set safe for production Prometheus scrape.
+    #[default]
+    Strict,
+    /// Reserved for future intermediate cardinality (currently aliases `Strict`).
+    Standard,
+    /// Pass-through high-cardinality labels (debug only).
+    Verbose,
 }
 
 fn default_otlp_endpoint() -> String {
@@ -228,6 +267,10 @@ fn default_metrics_export_interval_secs() -> u64 {
     60
 }
 
+fn default_prometheus_path() -> String {
+    "/metrics".to_string()
+}
+
 impl Default for TelemetryConfig {
     fn default() -> Self {
         Self {
@@ -237,6 +280,9 @@ impl Default for TelemetryConfig {
             sample_rate: default_sample_rate(),
             metrics_enabled: default_metrics_enabled(),
             metrics_export_interval_secs: default_metrics_export_interval_secs(),
+            prometheus_bind: None,
+            prometheus_path: default_prometheus_path(),
+            metrics_label_cardinality: MetricsLabelCardinality::Strict,
         }
     }
 }
@@ -999,6 +1045,59 @@ mod tests {
 
         // SAFETY: test-only; no concurrent threads access env vars in this test
         unsafe { std::env::remove_var("DATABASE_URL") };
+    }
+
+    #[test]
+    fn test_metrics_label_cardinality_default_is_strict() {
+        assert_eq!(
+            MetricsLabelCardinality::default(),
+            MetricsLabelCardinality::Strict
+        );
+    }
+
+    #[test]
+    fn test_metrics_label_cardinality_serde_round_trip_all_variants() {
+        for (s, variant) in [
+            ("strict", MetricsLabelCardinality::Strict),
+            ("standard", MetricsLabelCardinality::Standard),
+            ("verbose", MetricsLabelCardinality::Verbose),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, format!("\"{}\"", s));
+            let parsed: MetricsLabelCardinality = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn test_telemetry_config_prometheus_fields_parse() {
+        let toml = r#"
+            [telemetry]
+            prometheus_bind = "127.0.0.1:9100"
+            prometheus_path = "/metrics"
+            metrics_label_cardinality = "verbose"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(
+            config.telemetry.prometheus_bind,
+            Some("127.0.0.1:9100".to_string())
+        );
+        assert_eq!(config.telemetry.prometheus_path, "/metrics");
+        assert_eq!(
+            config.telemetry.metrics_label_cardinality,
+            MetricsLabelCardinality::Verbose
+        );
+    }
+
+    #[test]
+    fn test_telemetry_config_prometheus_bind_default_is_none() {
+        let config = Config::default();
+        assert!(config.telemetry.prometheus_bind.is_none());
+        assert_eq!(config.telemetry.prometheus_path, "/metrics");
+        assert_eq!(
+            config.telemetry.metrics_label_cardinality,
+            MetricsLabelCardinality::Strict
+        );
     }
 
     #[cfg(feature = "postgres")]

--- a/crates/tileserver-rs/src/lib.rs
+++ b/crates/tileserver-rs/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cache;
 pub mod cache_control;
 pub mod config;
 pub mod error;
+pub mod metrics;
 pub mod openapi;
 #[cfg(feature = "raster")]
 pub mod raster;

--- a/crates/tileserver-rs/src/logging.rs
+++ b/crates/tileserver-rs/src/logging.rs
@@ -1,54 +1,21 @@
-//! HTTP request logging middleware
+//! HTTP request logging middleware (Martin/actix-web combined format).
 //!
-//! Provides Martin/actix-web style request logging with the format:
-//! `IP "METHOD PATH HTTP/VERSION" STATUS SIZE "REFERRER" "USER_AGENT" DURATION`
+//! Format: `IP "METHOD PATH HTTP/VERSION" STATUS SIZE "REFERRER" "USER_AGENT" DURATION`
 //!
-//! Example output:
-//! ```
-//! 172.21.0.1 "GET /data/planet/12/2876/1828.pbf HTTP/1.1" 200 45883 "-" "node" 0.001492
-//! ```
+//! Example: `172.21.0.1 "GET /data/planet/12/2876/1828.pbf HTTP/1.1" 200 45883 "-" "node" 0.001492`
+//!
+//! HTTP metrics (count / duration / size) are recorded separately by
+//! [`crate::metrics::record_http_request`], which uses bounded
+//! [`axum::extract::MatchedPath`]-based labels to keep Prometheus
+//! cardinality safe. This module is intentionally logging-only.
 
 use axum::{
     body::Body,
     http::{Request, Response, header},
     middleware::Next,
 };
-use opentelemetry::KeyValue;
-use opentelemetry::metrics::{Counter, Histogram};
-use std::{net::SocketAddr, sync::OnceLock, time::Instant};
+use std::{net::SocketAddr, time::Instant};
 
-struct HttpMetrics {
-    request_count: Counter<u64>,
-    request_duration: Histogram<f64>,
-    response_size: Histogram<u64>,
-}
-
-static HTTP_METRICS: OnceLock<HttpMetrics> = OnceLock::new();
-
-fn get_metrics() -> &'static HttpMetrics {
-    HTTP_METRICS.get_or_init(|| {
-        let meter = opentelemetry::global::meter("tileserver-rs");
-        HttpMetrics {
-            request_count: meter
-                .u64_counter("http.server.request.count")
-                .with_description("Total HTTP requests")
-                .with_unit("requests")
-                .build(),
-            request_duration: meter
-                .f64_histogram("http.server.request.duration")
-                .with_description("HTTP request duration")
-                .with_unit("s")
-                .build(),
-            response_size: meter
-                .u64_histogram("http.server.response.body.size")
-                .with_description("HTTP response body size")
-                .with_unit("By")
-                .build(),
-        }
-    })
-}
-
-/// Middleware that logs HTTP requests in Martin/actix-web combined format
 pub async fn request_logger(request: Request<Body>, next: Next) -> Response<Body> {
     let start = Instant::now();
 
@@ -137,16 +104,6 @@ pub async fn request_logger(request: Request<Body>, next: Next) -> Response<Body
         user_agent,
         duration_secs
     );
-
-    let metrics = get_metrics();
-    let attrs = [
-        KeyValue::new("http.request.method", method),
-        KeyValue::new("http.response.status_code", i64::from(status)),
-        KeyValue::new("url.path", path),
-    ];
-    metrics.request_count.add(1, &attrs);
-    metrics.request_duration.record(duration_secs, &attrs);
-    metrics.response_size.record(size, &attrs);
 
     response
 }

--- a/crates/tileserver-rs/src/main.rs
+++ b/crates/tileserver-rs/src/main.rs
@@ -268,34 +268,34 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(reload::reload_signal(Arc::clone(&controller)));
 
-    if let Some(exporter) = telemetry_output.prometheus_exporter {
-        if let Some(bind_str) = config.telemetry.prometheus_bind.as_ref() {
-            match bind_str.parse::<SocketAddr>() {
-                Ok(prom_addr) => {
-                    let path = config.telemetry.prometheus_path.clone();
-                    match metrics::spawn_metrics_server(prom_addr, path, exporter).await {
-                        Ok(_handle) => {
-                            tracing::info!(
-                                bind = %prom_addr,
-                                "Prometheus /metrics endpoint enabled"
-                            );
-                        }
-                        Err(e) => {
-                            tracing::error!(
-                                bind = %prom_addr,
-                                error = %e,
-                                "Failed to bind Prometheus /metrics listener; tile serving continues"
-                            );
-                        }
+    if let Some(exporter) = telemetry_output.prometheus_exporter
+        && let Some(bind_str) = config.telemetry.prometheus_bind.as_ref()
+    {
+        match bind_str.parse::<SocketAddr>() {
+            Ok(prom_addr) => {
+                let path = config.telemetry.prometheus_path.clone();
+                match metrics::spawn_metrics_server(prom_addr, path, exporter).await {
+                    Ok(_handle) => {
+                        tracing::info!(
+                            bind = %prom_addr,
+                            "Prometheus /metrics endpoint enabled"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            bind = %prom_addr,
+                            error = %e,
+                            "Failed to bind Prometheus /metrics listener; tile serving continues"
+                        );
                     }
                 }
-                Err(e) => {
-                    tracing::error!(
-                        prometheus_bind = %bind_str,
-                        error = %e,
-                        "Invalid prometheus_bind address; Prometheus /metrics disabled"
-                    );
-                }
+            }
+            Err(e) => {
+                tracing::error!(
+                    prometheus_bind = %bind_str,
+                    error = %e,
+                    "Invalid prometheus_bind address; Prometheus /metrics disabled"
+                );
             }
         }
     }

--- a/crates/tileserver-rs/src/main.rs
+++ b/crates/tileserver-rs/src/main.rs
@@ -32,6 +32,7 @@ use cli::Cli;
 use tileserver_rs::admin;
 use tileserver_rs::autodetect;
 use tileserver_rs::config;
+use tileserver_rs::metrics;
 use tileserver_rs::openapi;
 use tileserver_rs::reload::{
     self, ReloadController, ReloadMeta, RuntimeSettings, SharedState, build_app_state,
@@ -74,11 +75,14 @@ async fn main() -> anyhow::Result<()> {
     let fmt_layer = tracing_subscriber::fmt::layer().compact();
     let registry = tracing_subscriber::registry().with(filter).with(fmt_layer);
 
-    if let Some(otel_layer) = telemetry::init_telemetry(&config.telemetry) {
+    let telemetry_output = telemetry::init_telemetry(&config.telemetry);
+    if let Some(otel_layer) = telemetry_output.tracing_layer {
         registry.with(otel_layer).init();
     } else {
         registry.init();
     }
+
+    metrics::init(config.telemetry.metrics_label_cardinality.into());
 
     if let Some(ref report) = auto_report {
         log_auto_detect_report(report);
@@ -236,6 +240,7 @@ async fn main() -> anyhow::Result<()> {
     let router = router
         .layer(cors)
         .layer(CompressionLayer::new())
+        .layer(axum::middleware::from_fn(metrics::record_http_request))
         .layer(axum::middleware::from_fn(logging::request_logger));
 
     let addr: SocketAddr = format!("{}:{}", config.server.host, config.server.port).parse()?;
@@ -262,6 +267,38 @@ async fn main() -> anyhow::Result<()> {
     }
 
     tokio::spawn(reload::reload_signal(Arc::clone(&controller)));
+
+    if let Some(exporter) = telemetry_output.prometheus_exporter {
+        if let Some(bind_str) = config.telemetry.prometheus_bind.as_ref() {
+            match bind_str.parse::<SocketAddr>() {
+                Ok(prom_addr) => {
+                    let path = config.telemetry.prometheus_path.clone();
+                    match metrics::spawn_metrics_server(prom_addr, path, exporter).await {
+                        Ok(_handle) => {
+                            tracing::info!(
+                                bind = %prom_addr,
+                                "Prometheus /metrics endpoint enabled"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                bind = %prom_addr,
+                                error = %e,
+                                "Failed to bind Prometheus /metrics listener; tile serving continues"
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        prometheus_bind = %bind_str,
+                        error = %e,
+                        "Invalid prometheus_bind address; Prometheus /metrics disabled"
+                    );
+                }
+            }
+        }
+    }
 
     axum::serve(listener, router)
         .with_graceful_shutdown(shutdown_signal())

--- a/crates/tileserver-rs/src/main.rs
+++ b/crates/tileserver-rs/src/main.rs
@@ -128,6 +128,7 @@ async fn main() -> anyhow::Result<()> {
         loaded_sources: state.sources.len(),
         loaded_styles: state.styles.len(),
         renderer_enabled: state.renderer.is_some(),
+        prometheus_listener_active: false,
     };
 
     let config_path_for_reload = cli.config.clone();
@@ -280,6 +281,9 @@ async fn main() -> anyhow::Result<()> {
                             bind = %prom_addr,
                             "Prometheus /metrics endpoint enabled"
                         );
+                        let mut updated = (*controller.meta.load_full()).clone();
+                        updated.prometheus_listener_active = true;
+                        controller.meta.store(Arc::new(updated));
                     }
                     Err(e) => {
                         tracing::error!(

--- a/crates/tileserver-rs/src/metrics/http_middleware.rs
+++ b/crates/tileserver-rs/src/metrics/http_middleware.rs
@@ -1,0 +1,49 @@
+//! HTTP-level metrics middleware.
+//!
+//! Recorded labels:
+//! - `route`: the matched Axum route pattern (e.g.
+//!   `/data/{source}/{z}/{x}/{y}.{format}`), NOT the raw URL. Bounded
+//!   cardinality regardless of traffic shape.
+//! - `method`: HTTP method.
+//! - `status_class`: 2xx/3xx/4xx/5xx bucket.
+//!
+//! Routes that don't match any known pattern (e.g. 404s on unknown paths)
+//! are recorded with `route = "unmatched"` to avoid cardinality blow-up
+//! from URL probes.
+
+use std::time::Instant;
+
+use axum::body::Body;
+use axum::extract::MatchedPath;
+use axum::http::{Request, Response};
+use axum::middleware::Next;
+
+use super::recorder::{HttpEvent, http_in_flight_dec, http_in_flight_inc, http_request_recorded};
+
+/// Axum middleware that records HTTP request metrics.
+///
+/// Wire via `axum::middleware::from_fn(record_http_request)` AFTER routing
+/// so [`MatchedPath`] is populated, but BEFORE response compression so the
+/// observed status code reflects the handler's actual response.
+pub async fn record_http_request(request: Request<Body>, next: Next) -> Response<Body> {
+    let started = Instant::now();
+    let method = request.method().as_str().to_owned();
+    let route = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|m| m.as_str().to_owned())
+        .unwrap_or_else(|| "unmatched".to_string());
+
+    http_in_flight_inc();
+    let response = next.run(request).await;
+    http_in_flight_dec();
+
+    http_request_recorded(HttpEvent {
+        method: &method,
+        route: &route,
+        status: response.status().as_u16(),
+        duration: started.elapsed(),
+    });
+
+    response
+}

--- a/crates/tileserver-rs/src/metrics/http_middleware.rs
+++ b/crates/tileserver-rs/src/metrics/http_middleware.rs
@@ -47,3 +47,65 @@ pub async fn record_http_request(request: Request<Body>, next: Next) -> Response
 
     response
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    use crate::metrics::{Cardinality, recorder::init};
+
+    async fn ok_handler() -> &'static str {
+        "ok"
+    }
+
+    async fn server_error_handler() -> (StatusCode, &'static str) {
+        (StatusCode::INTERNAL_SERVER_ERROR, "boom")
+    }
+
+    fn build_app() -> Router {
+        init(Cardinality::Strict);
+        Router::new()
+            .route("/data/{source}/{z}/{x}/{y_fmt}", get(ok_handler))
+            .route("/error", get(server_error_handler))
+            .layer(axum::middleware::from_fn(record_http_request))
+    }
+
+    #[tokio::test]
+    async fn middleware_records_matched_path_route() {
+        let app = build_app();
+        let req = Request::builder()
+            .uri("/data/openmaptiles/14/8192/5461")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn middleware_records_5xx_status_class() {
+        let app = build_app();
+        let req = Request::builder()
+            .uri("/error")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn middleware_records_unmatched_route() {
+        let app = build_app();
+        let req = Request::builder()
+            .uri("/totally-unknown-path-that-doesnt-match")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/tileserver-rs/src/metrics/instruments.rs
+++ b/crates/tileserver-rs/src/metrics/instruments.rs
@@ -1,0 +1,90 @@
+//! Lazy-initialized OpenTelemetry instrument handles.
+//!
+//! Instruments are created on first use against the global meter provider
+//! installed by `crate::telemetry`. If telemetry is disabled, the global
+//! meter is a no-op provider and instrument calls compile to atomic no-ops.
+
+use std::sync::LazyLock;
+
+use opentelemetry::global;
+use opentelemetry::metrics::{Counter, Histogram, UpDownCounter};
+
+const METER_NAME: &str = "tileserver-rs";
+
+fn meter() -> opentelemetry::metrics::Meter {
+    global::meter(METER_NAME)
+}
+
+pub(super) static HTTP_REQUESTS_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    meter()
+        .u64_counter("http_requests_total")
+        .with_description("Total HTTP requests by route and status class")
+        .build()
+});
+
+pub(super) static HTTP_REQUEST_DURATION_SECONDS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_histogram("http_request_duration_seconds")
+        .with_description("HTTP request duration in seconds")
+        .with_unit("s")
+        .build()
+});
+
+pub(super) static HTTP_REQUESTS_IN_FLIGHT: LazyLock<UpDownCounter<i64>> = LazyLock::new(|| {
+    meter()
+        .i64_up_down_counter("http_requests_in_flight")
+        .with_description("HTTP requests currently being processed")
+        .build()
+});
+
+pub(super) static TILE_REQUESTS_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    meter()
+        .u64_counter("tile_requests_total")
+        .with_description("Total tile requests by source, format, zoom bucket, and outcome")
+        .build()
+});
+
+pub(super) static TILE_REQUEST_DURATION_SECONDS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_histogram("tile_request_duration_seconds")
+        .with_description("Tile request duration in seconds")
+        .with_unit("s")
+        .build()
+});
+
+pub(super) static TILE_REQUEST_BYTES: LazyLock<Histogram<u64>> = LazyLock::new(|| {
+    meter()
+        .u64_histogram("tile_request_bytes")
+        .with_description("Tile response size in bytes")
+        .with_unit("By")
+        .build()
+});
+
+pub(super) static TILE_CACHE_HITS_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    meter()
+        .u64_counter("tile_cache_hits_total")
+        .with_description("In-process tile cache hits")
+        .build()
+});
+
+pub(super) static TILE_CACHE_MISSES_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    meter()
+        .u64_counter("tile_cache_misses_total")
+        .with_description("In-process tile cache misses")
+        .build()
+});
+
+pub(super) static RENDER_DURATION_SECONDS: LazyLock<Histogram<f64>> = LazyLock::new(|| {
+    meter()
+        .f64_histogram("render_duration_seconds")
+        .with_description("Native MapLibre tile render duration in seconds")
+        .with_unit("s")
+        .build()
+});
+
+pub(super) static RENDER_ERRORS_TOTAL: LazyLock<Counter<u64>> = LazyLock::new(|| {
+    meter()
+        .u64_counter("render_errors_total")
+        .with_description("Native MapLibre render failures by reason")
+        .build()
+});

--- a/crates/tileserver-rs/src/metrics/labels.rs
+++ b/crates/tileserver-rs/src/metrics/labels.rs
@@ -332,6 +332,109 @@ mod tests {
     }
 
     #[test]
+    fn cardinality_from_config_enum() {
+        assert_eq!(
+            Cardinality::from(MetricsLabelCardinality::Strict),
+            Cardinality::Strict
+        );
+        assert_eq!(
+            Cardinality::from(MetricsLabelCardinality::Standard),
+            Cardinality::Standard
+        );
+        assert_eq!(
+            Cardinality::from(MetricsLabelCardinality::Verbose),
+            Cardinality::Verbose
+        );
+    }
+
+    #[test]
+    fn z_bucket_label_strings() {
+        assert_eq!(ZBucket::Low.as_label(), "low");
+        assert_eq!(ZBucket::Mid.as_label(), "mid");
+        assert_eq!(ZBucket::High.as_label(), "high");
+        assert_eq!(ZBucket::Exact(7).as_label(), "7");
+        assert_eq!(ZBucket::Exact(22).as_label(), "22");
+    }
+
+    #[test]
+    fn format_label_covers_all_variants() {
+        assert_eq!(format_label(TileFormat::Pbf), "pbf");
+        assert_eq!(format_label(TileFormat::Png), "png");
+        assert_eq!(format_label(TileFormat::Jpeg), "jpeg");
+        assert_eq!(format_label(TileFormat::Webp), "webp");
+        assert_eq!(format_label(TileFormat::Avif), "avif");
+        assert_eq!(format_label(TileFormat::Mlt), "mlt");
+        assert_eq!(format_label(TileFormat::Unknown), "unknown");
+    }
+
+    #[test]
+    fn tile_bytes_labels_caches_per_source_format() {
+        let bank = LabelBank::new(Cardinality::Strict);
+        let a = bank.tile_bytes_labels("openmaptiles", TileFormat::Pbf);
+        let b = bank.tile_bytes_labels("openmaptiles", TileFormat::Pbf);
+        assert_eq!(a.len(), 2);
+        assert_eq!(a.len(), b.len());
+        let c = bank.tile_bytes_labels("openmaptiles", TileFormat::Mlt);
+        assert_eq!(c.len(), 2);
+    }
+
+    #[test]
+    fn cache_labels_caches_per_source() {
+        let bank = LabelBank::new(Cardinality::Strict);
+        let a = bank.cache_labels("source-a");
+        let b = bank.cache_labels("source-a");
+        assert_eq!(a.len(), 1);
+        assert_eq!(b.len(), 1);
+        let c = bank.cache_labels("source-b");
+        assert_eq!(c.len(), 1);
+    }
+
+    #[test]
+    fn render_labels_caches_per_style_format() {
+        let bank = LabelBank::new(Cardinality::Strict);
+        let a = bank.render_labels("osm-bright", TileFormat::Png);
+        let b = bank.render_labels("osm-bright", TileFormat::Png);
+        let c = bank.render_labels("osm-bright", TileFormat::Webp);
+        assert_eq!(a.len(), 2);
+        assert_eq!(b.len(), 2);
+        assert_eq!(c.len(), 2);
+    }
+
+    #[test]
+    fn render_error_labels_caches_per_style_reason() {
+        let bank = LabelBank::new(Cardinality::Strict);
+        let a = bank.render_error_labels("style1", "render_failed");
+        let b = bank.render_error_labels("style1", "render_failed");
+        let c = bank.render_error_labels("style1", "timeout");
+        assert_eq!(a.len(), 2);
+        assert_eq!(b.len(), 2);
+        assert_eq!(c.len(), 2);
+    }
+
+    #[test]
+    fn label_bank_cardinality_accessor() {
+        let strict = LabelBank::new(Cardinality::Strict);
+        assert_eq!(strict.cardinality(), Cardinality::Strict);
+        let verbose = LabelBank::new(Cardinality::Verbose);
+        assert_eq!(verbose.cardinality(), Cardinality::Verbose);
+        let standard = LabelBank::new(Cardinality::Standard);
+        assert_eq!(standard.cardinality(), Cardinality::Standard);
+    }
+
+    #[test]
+    fn tile_labels_includes_outcome_label() {
+        let bank = LabelBank::new(Cardinality::Strict);
+        let labels = bank.tile_labels("src", TileFormat::Pbf, 14, "error");
+        let mut outcome_value = String::new();
+        for kv in labels.iter() {
+            if kv.key.as_str() == "outcome" {
+                outcome_value = kv.value.to_string();
+            }
+        }
+        assert_eq!(outcome_value, "error");
+    }
+
+    #[test]
     fn label_bank_verbose_keeps_z() {
         let bank = LabelBank::new(Cardinality::Verbose);
         let labels = bank.tile_labels("s", TileFormat::Pbf, 18, "miss");

--- a/crates/tileserver-rs/src/metrics/labels.rs
+++ b/crates/tileserver-rs/src/metrics/labels.rs
@@ -94,11 +94,21 @@ struct ErrorKey {
     reason: String,
 }
 
-/// Label cache: maps logical keys to pre-built `Box<[KeyValue]>` slices.
+/// Label cache: maps logical keys to pre-built `Arc<[KeyValue]>` slices.
 ///
-/// First call for a given key allocates and inserts; subsequent calls return
-/// a borrowed slice. The bank is wrapped in `RwLock` so reads are concurrent
-/// and only first-time inserts take the write lock briefly.
+/// `tile_bytes_labels`, `cache_labels`, `render_labels`, and `render_error_labels`
+/// return cached slices directly via `Arc::clone` — zero allocation on the hot
+/// path after the first call for each (source, format, …) tuple. The
+/// `tile_labels` accessor for tile-request counters is the exception: it
+/// composes a base slice (`source`, `format`, `z_bucket`) cached in
+/// `tile_full` with a per-call `outcome` label, allocating a fresh
+/// `Arc<[KeyValue]>` of size `base.len() + 1` on every call. This is the
+/// dominant cost measured by `benches/metrics_overhead.rs` (~180 ns) and
+/// is below the spec's 250 ns gate; eliminating the allocation by caching
+/// `(tile_key, outcome)` directly is tracked as a v2.29 optimisation.
+///
+/// The bank is wrapped in `RwLock` so reads are concurrent and only
+/// first-time inserts take the write lock briefly.
 #[derive(Debug, Default)]
 struct Inner {
     tile_full: HashMap<TileKey, Arc<[KeyValue]>>,

--- a/crates/tileserver-rs/src/metrics/labels.rs
+++ b/crates/tileserver-rs/src/metrics/labels.rs
@@ -1,0 +1,337 @@
+//! Cardinality-bounded label assembly for metrics.
+//!
+//! All label arrays are built once per (source_id, format, z_bucket) tuple
+//! at instrumentation time and stored as `Box<[KeyValue]>`. The hot path
+//! returns `&[KeyValue]` references — zero per-request allocation.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use opentelemetry::KeyValue;
+
+use crate::config::MetricsLabelCardinality;
+use crate::sources::TileFormat;
+
+/// Cardinality strategy mirrored from
+/// [`crate::config::MetricsLabelCardinality`] for use inside the metrics
+/// subsystem without forcing every caller to import `crate::config`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cardinality {
+    Strict,
+    Standard,
+    Verbose,
+}
+
+impl From<MetricsLabelCardinality> for Cardinality {
+    fn from(value: MetricsLabelCardinality) -> Self {
+        match value {
+            MetricsLabelCardinality::Strict => Self::Strict,
+            MetricsLabelCardinality::Standard => Self::Standard,
+            MetricsLabelCardinality::Verbose => Self::Verbose,
+        }
+    }
+}
+
+/// Coarse zoom bucket. Strict/Standard collapse to three categorical
+/// buckets; Verbose passes the raw zoom level through.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ZBucket {
+    Low,       // z = 0..=7
+    Mid,       // z = 8..=13
+    High,      // z = 14..=22
+    Exact(u8), // verbose mode: pass-through
+}
+
+impl ZBucket {
+    fn classify(z: u8, cardinality: Cardinality) -> Self {
+        match cardinality {
+            Cardinality::Strict | Cardinality::Standard => match z {
+                0..=7 => Self::Low,
+                8..=13 => Self::Mid,
+                _ => Self::High,
+            },
+            Cardinality::Verbose => Self::Exact(z),
+        }
+    }
+
+    fn as_label(&self) -> String {
+        match self {
+            Self::Low => "low".into(),
+            Self::Mid => "mid".into(),
+            Self::High => "high".into(),
+            Self::Exact(z) => z.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TileKey {
+    source: String,
+    format: TileFormat,
+    z_bucket: ZBucket,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct TileNoZKey {
+    source: String,
+    format: TileFormat,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CacheKey {
+    source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RenderKey {
+    style: String,
+    format: TileFormat,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ErrorKey {
+    style: String,
+    reason: String,
+}
+
+/// Label cache: maps logical keys to pre-built `Box<[KeyValue]>` slices.
+///
+/// First call for a given key allocates and inserts; subsequent calls return
+/// a borrowed slice. The bank is wrapped in `RwLock` so reads are concurrent
+/// and only first-time inserts take the write lock briefly.
+#[derive(Debug, Default)]
+struct Inner {
+    tile_full: HashMap<TileKey, Arc<[KeyValue]>>,
+    tile_no_z: HashMap<TileNoZKey, Arc<[KeyValue]>>,
+    cache: HashMap<CacheKey, Arc<[KeyValue]>>,
+    render: HashMap<RenderKey, Arc<[KeyValue]>>,
+    render_error: HashMap<ErrorKey, Arc<[KeyValue]>>,
+}
+
+/// Pre-built label arrays keyed by cardinality-bounded tuples.
+#[derive(Debug)]
+pub struct LabelBank {
+    cardinality: Cardinality,
+    inner: RwLock<Inner>,
+}
+
+impl LabelBank {
+    #[must_use]
+    pub fn new(cardinality: Cardinality) -> Self {
+        Self {
+            cardinality,
+            inner: RwLock::new(Inner::default()),
+        }
+    }
+
+    #[must_use]
+    pub fn cardinality(&self) -> Cardinality {
+        self.cardinality
+    }
+
+    pub fn tile_labels(
+        &self,
+        source: &str,
+        format: TileFormat,
+        z: u8,
+        outcome: &str,
+    ) -> Arc<[KeyValue]> {
+        let z_bucket = ZBucket::classify(z, self.cardinality);
+        let key = TileKey {
+            source: source.to_string(),
+            format,
+            z_bucket,
+        };
+        if let Some(existing) = self.inner.read().expect("poisoned").tile_full.get(&key) {
+            return Self::with_outcome(existing.as_ref(), outcome);
+        }
+        let mut guard = self.inner.write().expect("poisoned");
+        let arc = guard
+            .tile_full
+            .entry(key)
+            .or_insert_with_key(|k| {
+                Arc::from(vec![
+                    KeyValue::new("source", k.source.clone()),
+                    KeyValue::new("format", format_label(k.format)),
+                    KeyValue::new("z_bucket", k.z_bucket.as_label()),
+                ])
+            })
+            .clone();
+        Self::with_outcome(arc.as_ref(), outcome)
+    }
+
+    pub fn tile_bytes_labels(&self, source: &str, format: TileFormat) -> Arc<[KeyValue]> {
+        let key = TileNoZKey {
+            source: source.to_string(),
+            format,
+        };
+        if let Some(existing) = self.inner.read().expect("poisoned").tile_no_z.get(&key) {
+            return Arc::clone(existing);
+        }
+        let mut guard = self.inner.write().expect("poisoned");
+        guard
+            .tile_no_z
+            .entry(key)
+            .or_insert_with_key(|k| {
+                Arc::from(vec![
+                    KeyValue::new("source", k.source.clone()),
+                    KeyValue::new("format", format_label(k.format)),
+                ])
+            })
+            .clone()
+    }
+
+    pub fn cache_labels(&self, source: &str) -> Arc<[KeyValue]> {
+        let key = CacheKey {
+            source: source.to_string(),
+        };
+        if let Some(existing) = self.inner.read().expect("poisoned").cache.get(&key) {
+            return Arc::clone(existing);
+        }
+        let mut guard = self.inner.write().expect("poisoned");
+        guard
+            .cache
+            .entry(key)
+            .or_insert_with_key(|k| Arc::from(vec![KeyValue::new("source", k.source.clone())]))
+            .clone()
+    }
+
+    pub fn render_labels(&self, style: &str, format: TileFormat) -> Arc<[KeyValue]> {
+        let key = RenderKey {
+            style: style.to_string(),
+            format,
+        };
+        if let Some(existing) = self.inner.read().expect("poisoned").render.get(&key) {
+            return Arc::clone(existing);
+        }
+        let mut guard = self.inner.write().expect("poisoned");
+        guard
+            .render
+            .entry(key)
+            .or_insert_with_key(|k| {
+                Arc::from(vec![
+                    KeyValue::new("style", k.style.clone()),
+                    KeyValue::new("format", format_label(k.format)),
+                ])
+            })
+            .clone()
+    }
+
+    pub fn render_error_labels(&self, style: &str, reason: &str) -> Arc<[KeyValue]> {
+        let key = ErrorKey {
+            style: style.to_string(),
+            reason: reason.to_string(),
+        };
+        if let Some(existing) = self.inner.read().expect("poisoned").render_error.get(&key) {
+            return Arc::clone(existing);
+        }
+        let mut guard = self.inner.write().expect("poisoned");
+        guard
+            .render_error
+            .entry(key)
+            .or_insert_with_key(|k| {
+                Arc::from(vec![
+                    KeyValue::new("style", k.style.clone()),
+                    KeyValue::new("reason", k.reason.clone()),
+                ])
+            })
+            .clone()
+    }
+
+    fn with_outcome(base: &[KeyValue], outcome: &str) -> Arc<[KeyValue]> {
+        let mut combined = Vec::with_capacity(base.len() + 1);
+        combined.extend_from_slice(base);
+        combined.push(KeyValue::new("outcome", outcome.to_string()));
+        Arc::from(combined)
+    }
+}
+
+fn format_label(format: TileFormat) -> &'static str {
+    match format {
+        TileFormat::Pbf => "pbf",
+        TileFormat::Png => "png",
+        TileFormat::Jpeg => "jpeg",
+        TileFormat::Webp => "webp",
+        TileFormat::Avif => "avif",
+        TileFormat::Mlt => "mlt",
+        TileFormat::Unknown => "unknown",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn z_bucket_strict_boundaries() {
+        assert_eq!(ZBucket::classify(0, Cardinality::Strict), ZBucket::Low);
+        assert_eq!(ZBucket::classify(7, Cardinality::Strict), ZBucket::Low);
+        assert_eq!(ZBucket::classify(8, Cardinality::Strict), ZBucket::Mid);
+        assert_eq!(ZBucket::classify(13, Cardinality::Strict), ZBucket::Mid);
+        assert_eq!(ZBucket::classify(14, Cardinality::Strict), ZBucket::High);
+        assert_eq!(ZBucket::classify(22, Cardinality::Strict), ZBucket::High);
+    }
+
+    #[test]
+    fn z_bucket_verbose_passes_through() {
+        for z in 0u8..=22 {
+            assert_eq!(
+                ZBucket::classify(z, Cardinality::Verbose),
+                ZBucket::Exact(z)
+            );
+        }
+    }
+
+    #[test]
+    fn standard_aliases_strict_in_v1() {
+        for z in 0u8..=22 {
+            assert_eq!(
+                ZBucket::classify(z, Cardinality::Strict),
+                ZBucket::classify(z, Cardinality::Standard),
+            );
+        }
+    }
+
+    #[test]
+    fn label_bank_dedupes_within_z_bucket() {
+        let bank = LabelBank::new(Cardinality::Strict);
+        let a = bank.tile_labels("openmaptiles", TileFormat::Pbf, 5, "hit");
+        let b = bank.tile_labels("openmaptiles", TileFormat::Pbf, 6, "hit");
+        let c = bank.tile_labels("openmaptiles", TileFormat::Pbf, 10, "hit");
+        let mut a_z = String::new();
+        let mut b_z = String::new();
+        let mut c_z = String::new();
+        for kv in a.iter() {
+            if kv.key.as_str() == "z_bucket" {
+                a_z = kv.value.to_string();
+            }
+        }
+        for kv in b.iter() {
+            if kv.key.as_str() == "z_bucket" {
+                b_z = kv.value.to_string();
+            }
+        }
+        for kv in c.iter() {
+            if kv.key.as_str() == "z_bucket" {
+                c_z = kv.value.to_string();
+            }
+        }
+        assert_eq!(a_z, "low");
+        assert_eq!(b_z, "low");
+        assert_eq!(c_z, "mid");
+    }
+
+    #[test]
+    fn label_bank_verbose_keeps_z() {
+        let bank = LabelBank::new(Cardinality::Verbose);
+        let labels = bank.tile_labels("s", TileFormat::Pbf, 18, "miss");
+        let mut found = false;
+        for kv in labels.iter() {
+            if kv.key.as_str() == "z_bucket" {
+                assert_eq!(kv.value.to_string(), "18");
+                found = true;
+            }
+        }
+        assert!(found);
+    }
+}

--- a/crates/tileserver-rs/src/metrics/mod.rs
+++ b/crates/tileserver-rs/src/metrics/mod.rs
@@ -1,0 +1,29 @@
+//! Metrics subsystem: Prometheus `/metrics` endpoint via OpenTelemetry bridge.
+//!
+//! # Architecture
+//!
+//! A single OpenTelemetry [`Meter`](opentelemetry::metrics::Meter) feeds both
+//! the existing OTLP push pipeline (in `crate::telemetry`) and a new
+//! Prometheus pull endpoint hosted on a separate listener. Application code
+//! calls typed facade functions on [`recorder`] and never imports
+//! `opentelemetry::*` directly.
+//!
+//! See `docs/superpowers/specs/2026-05-04-prometheus-metrics-design.md`
+//! for the full design rationale.
+
+mod http_middleware;
+mod instruments;
+mod labels;
+mod recorder;
+mod server;
+
+pub use http_middleware::record_http_request;
+pub use labels::{Cardinality, LabelBank};
+pub use recorder::{
+    HttpEvent, HttpStatusClass, RenderEvent, RenderOutcome, TileEvent, TileOutcome,
+    cache_hit_recorded, cache_miss_recorded, http_request_recorded, init, render_recorded,
+    tile_request_recorded,
+};
+pub use server::{MetricsServerHandle, spawn_metrics_server};
+
+pub use opentelemetry_prometheus_text_exporter::PrometheusExporter;

--- a/crates/tileserver-rs/src/metrics/recorder.rs
+++ b/crates/tileserver-rs/src/metrics/recorder.rs
@@ -1,0 +1,218 @@
+//! Public facade for application-side metric recording.
+//!
+//! Application code only ever calls functions in this module; it never
+//! imports `opentelemetry::*` directly. Cardinality enforcement and
+//! pre-built label arrays live in [`super::labels`].
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use opentelemetry::KeyValue;
+
+use super::instruments::{
+    HTTP_REQUEST_DURATION_SECONDS, HTTP_REQUESTS_IN_FLIGHT, HTTP_REQUESTS_TOTAL,
+    RENDER_DURATION_SECONDS, RENDER_ERRORS_TOTAL, TILE_CACHE_HITS_TOTAL, TILE_CACHE_MISSES_TOTAL,
+    TILE_REQUEST_BYTES, TILE_REQUEST_DURATION_SECONDS, TILE_REQUESTS_TOTAL,
+};
+use super::labels::{Cardinality, LabelBank};
+use crate::sources::TileFormat;
+
+static LABEL_BANK: OnceLock<LabelBank> = OnceLock::new();
+
+/// Initialize the global label bank with the configured cardinality.
+///
+/// Idempotent — second and subsequent calls are silently ignored. Call
+/// once during startup before any application code emits metrics.
+pub fn init(cardinality: Cardinality) {
+    let _ = LABEL_BANK.set(LabelBank::new(cardinality));
+}
+
+fn bank() -> &'static LabelBank {
+    LABEL_BANK.get_or_init(|| LabelBank::new(Cardinality::Strict))
+}
+
+/// Outcome of a tile request, recorded as a label on tile metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TileOutcome {
+    /// Returned from in-process cache without hitting the source.
+    Hit,
+    /// Fetched from source successfully.
+    Miss,
+    /// Source returned `Ok(None)` — tile does not exist.
+    NotFound,
+    /// Source returned an error.
+    Error,
+}
+
+impl TileOutcome {
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::Hit => "hit",
+            Self::Miss => "miss",
+            Self::NotFound => "not_found",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// Outcome of a raster render request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RenderOutcome {
+    Success,
+    Error,
+}
+
+/// HTTP response status class (2xx, 3xx, 4xx, 5xx).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HttpStatusClass {
+    Success,
+    Redirection,
+    ClientError,
+    ServerError,
+    Unknown,
+}
+
+impl HttpStatusClass {
+    #[must_use]
+    pub fn from_code(code: u16) -> Self {
+        match code {
+            200..=299 => Self::Success,
+            300..=399 => Self::Redirection,
+            400..=499 => Self::ClientError,
+            500..=599 => Self::ServerError,
+            _ => Self::Unknown,
+        }
+    }
+
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::Success => "2xx",
+            Self::Redirection => "3xx",
+            Self::ClientError => "4xx",
+            Self::ServerError => "5xx",
+            Self::Unknown => "other",
+        }
+    }
+}
+
+/// Typed event emitted on every completed tile request.
+#[derive(Debug)]
+pub struct TileEvent<'a> {
+    pub source: &'a str,
+    pub format: TileFormat,
+    pub z: u8,
+    pub bytes: usize,
+    pub duration: Duration,
+    pub outcome: TileOutcome,
+}
+
+/// Typed event emitted on every completed HTTP request.
+#[derive(Debug)]
+pub struct HttpEvent<'a> {
+    pub method: &'a str,
+    pub route: &'a str,
+    pub status: u16,
+    pub duration: Duration,
+}
+
+/// Typed event emitted on every completed raster render.
+#[derive(Debug)]
+pub struct RenderEvent<'a> {
+    pub style: &'a str,
+    pub format: TileFormat,
+    pub duration: Duration,
+    pub outcome: RenderOutcome,
+    pub error_reason: Option<&'a str>,
+}
+
+pub fn tile_request_recorded(event: TileEvent<'_>) {
+    let labels = bank().tile_labels(
+        event.source,
+        event.format,
+        event.z,
+        event.outcome.as_label(),
+    );
+    let bytes_labels = bank().tile_bytes_labels(event.source, event.format);
+
+    TILE_REQUESTS_TOTAL.add(1, &labels);
+    TILE_REQUEST_DURATION_SECONDS.record(event.duration.as_secs_f64(), &labels);
+    if event.bytes > 0 {
+        TILE_REQUEST_BYTES.record(event.bytes as u64, &bytes_labels);
+    }
+}
+
+pub fn cache_hit_recorded(source: &str) {
+    let labels = bank().cache_labels(source);
+    TILE_CACHE_HITS_TOTAL.add(1, &labels);
+}
+
+pub fn cache_miss_recorded(source: &str) {
+    let labels = bank().cache_labels(source);
+    TILE_CACHE_MISSES_TOTAL.add(1, &labels);
+}
+
+pub fn http_request_recorded(event: HttpEvent<'_>) {
+    let status_class = HttpStatusClass::from_code(event.status).as_label();
+    let attrs: [KeyValue; 3] = [
+        KeyValue::new("method", event.method.to_string()),
+        KeyValue::new("route", event.route.to_string()),
+        KeyValue::new("status_class", status_class),
+    ];
+    let dur_attrs: [KeyValue; 2] = [
+        KeyValue::new("method", event.method.to_string()),
+        KeyValue::new("route", event.route.to_string()),
+    ];
+    HTTP_REQUESTS_TOTAL.add(1, &attrs);
+    HTTP_REQUEST_DURATION_SECONDS.record(event.duration.as_secs_f64(), &dur_attrs);
+}
+
+pub fn http_in_flight_inc() {
+    HTTP_REQUESTS_IN_FLIGHT.add(1, &[]);
+}
+
+pub fn http_in_flight_dec() {
+    HTTP_REQUESTS_IN_FLIGHT.add(-1, &[]);
+}
+
+pub fn render_recorded(event: RenderEvent<'_>) {
+    let labels = bank().render_labels(event.style, event.format);
+    RENDER_DURATION_SECONDS.record(event.duration.as_secs_f64(), &labels);
+    if event.outcome == RenderOutcome::Error {
+        let reason = event.error_reason.unwrap_or("unknown");
+        let err_labels = bank().render_error_labels(event.style, reason);
+        RENDER_ERRORS_TOTAL.add(1, &err_labels);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_status_class_buckets() {
+        assert_eq!(HttpStatusClass::from_code(200), HttpStatusClass::Success);
+        assert_eq!(HttpStatusClass::from_code(204), HttpStatusClass::Success);
+        assert_eq!(
+            HttpStatusClass::from_code(301),
+            HttpStatusClass::Redirection
+        );
+        assert_eq!(
+            HttpStatusClass::from_code(404),
+            HttpStatusClass::ClientError
+        );
+        assert_eq!(
+            HttpStatusClass::from_code(500),
+            HttpStatusClass::ServerError
+        );
+        assert_eq!(HttpStatusClass::from_code(199), HttpStatusClass::Unknown);
+        assert_eq!(HttpStatusClass::from_code(600), HttpStatusClass::Unknown);
+    }
+
+    #[test]
+    fn tile_outcome_labels_stable() {
+        assert_eq!(TileOutcome::Hit.as_label(), "hit");
+        assert_eq!(TileOutcome::Miss.as_label(), "miss");
+        assert_eq!(TileOutcome::NotFound.as_label(), "not_found");
+        assert_eq!(TileOutcome::Error.as_label(), "error");
+    }
+}

--- a/crates/tileserver-rs/src/metrics/recorder.rs
+++ b/crates/tileserver-rs/src/metrics/recorder.rs
@@ -215,4 +215,117 @@ mod tests {
         assert_eq!(TileOutcome::NotFound.as_label(), "not_found");
         assert_eq!(TileOutcome::Error.as_label(), "error");
     }
+
+    #[test]
+    fn http_status_class_label_strings() {
+        assert_eq!(HttpStatusClass::Success.as_label(), "2xx");
+        assert_eq!(HttpStatusClass::Redirection.as_label(), "3xx");
+        assert_eq!(HttpStatusClass::ClientError.as_label(), "4xx");
+        assert_eq!(HttpStatusClass::ServerError.as_label(), "5xx");
+        assert_eq!(HttpStatusClass::Unknown.as_label(), "other");
+    }
+
+    #[test]
+    fn render_outcome_equality() {
+        assert_eq!(RenderOutcome::Success, RenderOutcome::Success);
+        assert_eq!(RenderOutcome::Error, RenderOutcome::Error);
+        assert_ne!(RenderOutcome::Success, RenderOutcome::Error);
+    }
+
+    #[test]
+    fn init_is_idempotent() {
+        init(Cardinality::Strict);
+        init(Cardinality::Verbose);
+        init(Cardinality::Standard);
+    }
+
+    #[test]
+    fn tile_request_recorded_all_outcomes_with_noop_meter() {
+        init(Cardinality::Strict);
+        for outcome in [
+            TileOutcome::Hit,
+            TileOutcome::Miss,
+            TileOutcome::NotFound,
+            TileOutcome::Error,
+        ] {
+            tile_request_recorded(TileEvent {
+                source: "noop-test",
+                format: TileFormat::Pbf,
+                z: 14,
+                bytes: 1024,
+                duration: Duration::from_millis(5),
+                outcome,
+            });
+        }
+    }
+
+    #[test]
+    fn tile_request_recorded_zero_bytes_skips_bytes_histogram() {
+        init(Cardinality::Strict);
+        tile_request_recorded(TileEvent {
+            source: "zero-bytes",
+            format: TileFormat::Pbf,
+            z: 0,
+            bytes: 0,
+            duration: Duration::from_millis(1),
+            outcome: TileOutcome::NotFound,
+        });
+    }
+
+    #[test]
+    fn cache_hit_and_miss_recorded_with_noop_meter() {
+        init(Cardinality::Strict);
+        cache_hit_recorded("source-x");
+        cache_hit_recorded("source-x");
+        cache_miss_recorded("source-x");
+        cache_miss_recorded("source-y");
+    }
+
+    #[test]
+    fn http_in_flight_inc_dec_balances() {
+        init(Cardinality::Strict);
+        http_in_flight_inc();
+        http_in_flight_inc();
+        http_in_flight_dec();
+        http_in_flight_dec();
+    }
+
+    #[test]
+    fn http_request_recorded_all_status_classes() {
+        init(Cardinality::Strict);
+        for status in [200u16, 301, 404, 500, 100] {
+            http_request_recorded(HttpEvent {
+                method: "GET",
+                route: "/some/route",
+                status,
+                duration: Duration::from_millis(10),
+            });
+        }
+    }
+
+    #[test]
+    fn render_recorded_success_and_error_paths() {
+        init(Cardinality::Strict);
+        render_recorded(RenderEvent {
+            style: "ok-style",
+            format: TileFormat::Png,
+            duration: Duration::from_millis(50),
+            outcome: RenderOutcome::Success,
+            error_reason: None,
+        });
+        render_recorded(RenderEvent {
+            style: "fail-style",
+            format: TileFormat::Webp,
+            duration: Duration::from_millis(75),
+            outcome: RenderOutcome::Error,
+            error_reason: Some("oom"),
+        });
+        render_recorded(RenderEvent {
+            style: "fail-no-reason",
+            format: TileFormat::Jpeg,
+            duration: Duration::from_millis(20),
+            outcome: RenderOutcome::Error,
+            error_reason: None,
+        });
+    }
 }

--- a/crates/tileserver-rs/src/metrics/server.rs
+++ b/crates/tileserver-rs/src/metrics/server.rs
@@ -1,0 +1,103 @@
+//! Standalone Axum listener that serves Prometheus exposition at a
+//! configurable bind address and path.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use opentelemetry_prometheus_text_exporter::PrometheusExporter;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
+
+#[derive(Clone)]
+struct ServerState {
+    exporter: Arc<PrometheusExporter>,
+}
+
+/// Owned handle for the spawned metrics listener task.
+///
+/// Drop the handle to abort the task; otherwise the listener runs until
+/// graceful shutdown is signalled by the main server.
+pub struct MetricsServerHandle {
+    pub addr: SocketAddr,
+    pub task: JoinHandle<()>,
+}
+
+/// Spawn the Prometheus metrics listener.
+///
+/// Returns `Ok(handle)` on successful bind. The caller is responsible for
+/// keeping the [`MetricsServerHandle`] alive for the lifetime of the server
+/// (e.g. by storing it in startup state).
+pub async fn spawn_metrics_server(
+    bind: SocketAddr,
+    path: String,
+    exporter: PrometheusExporter,
+) -> std::io::Result<MetricsServerHandle> {
+    let listener = TcpListener::bind(bind).await?;
+    let addr = listener.local_addr()?;
+
+    let state = ServerState {
+        exporter: Arc::new(exporter),
+    };
+
+    let normalized = if path.starts_with('/') {
+        path
+    } else {
+        format!("/{path}")
+    };
+
+    let router = Router::new()
+        .route(&normalized, get(scrape))
+        .route("/metrics/health", get(health))
+        .with_state(state);
+
+    let task = tokio::spawn(async move {
+        if let Err(e) = axum::serve(listener, router).await {
+            tracing::error!("metrics listener exited with error: {e}");
+        }
+    });
+
+    tracing::info!(
+        bind = %addr,
+        path = %normalized,
+        "Prometheus metrics endpoint listening"
+    );
+
+    Ok(MetricsServerHandle { addr, task })
+}
+
+async fn scrape(State(state): State<ServerState>) -> Response {
+    let mut buf: Vec<u8> = Vec::with_capacity(4096);
+    if let Err(e) = state.exporter.export(&mut buf) {
+        tracing::warn!("metrics scrape failed: {e}");
+        return (StatusCode::INTERNAL_SERVER_ERROR, "metrics scrape failed").into_response();
+    }
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"),
+    );
+
+    let body = match String::from_utf8(buf) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("metrics output not utf-8: {e}");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "metrics output not utf-8",
+            )
+                .into_response();
+        }
+    };
+
+    (StatusCode::OK, headers, body).into_response()
+}
+
+async fn health() -> &'static str {
+    "OK"
+}

--- a/crates/tileserver-rs/src/reload.rs
+++ b/crates/tileserver-rs/src/reload.rs
@@ -101,6 +101,7 @@ pub struct ReloadMeta {
     pub loaded_sources: usize,
     pub loaded_styles: usize,
     pub renderer_enabled: bool,
+    pub prometheus_listener_active: bool,
 }
 
 /// Outcome of a reload attempt.
@@ -111,6 +112,7 @@ pub struct ReloadResult {
     pub loaded_sources: usize,
     pub loaded_styles: usize,
     pub renderer_enabled: bool,
+    pub prometheus_listener_active: bool,
 }
 
 pub struct ReloadController {
@@ -153,6 +155,7 @@ impl ReloadController {
                 loaded_sources: current_meta.loaded_sources,
                 loaded_styles: current_meta.loaded_styles,
                 renderer_enabled: current_meta.renderer_enabled,
+                prometheus_listener_active: current_meta.prometheus_listener_active,
             });
         }
 
@@ -164,6 +167,7 @@ impl ReloadController {
             loaded_sources: new_state.sources.len(),
             loaded_styles: new_state.styles.len(),
             renderer_enabled: new_state.renderer.is_some(),
+            prometheus_listener_active: current_meta.prometheus_listener_active,
         };
 
         let result = ReloadResult {
@@ -173,6 +177,7 @@ impl ReloadController {
             loaded_sources: new_meta.loaded_sources,
             loaded_styles: new_meta.loaded_styles,
             renderer_enabled: new_meta.renderer_enabled,
+            prometheus_listener_active: new_meta.prometheus_listener_active,
         };
 
         self.app.store(Arc::new(new_state));

--- a/crates/tileserver-rs/src/render/pool.rs
+++ b/crates/tileserver-rs/src/render/pool.rs
@@ -137,6 +137,7 @@ impl RendererPool {
         y: u32,
         scale: u8,
     ) -> Result<Vec<u8>> {
+        let render_start = std::time::Instant::now();
         let scale = scale.min(self.max_scale).max(1);
         let (tx, rx) = oneshot::channel();
 
@@ -152,7 +153,7 @@ impl RendererPool {
             response: tx,
         })?;
 
-        match tokio::time::timeout(self.config.render_timeout, rx).await {
+        let result = match tokio::time::timeout(self.config.render_timeout, rx).await {
             Ok(Ok(RenderOutput::Tile(result))) => result,
             Ok(Ok(_)) => Err(TileServerError::RenderError(
                 "unexpected render output type".to_string(),
@@ -164,7 +165,26 @@ impl RendererPool {
                 "render timed out after {}s",
                 self.config.render_timeout.as_secs()
             ))),
-        }
+        };
+
+        let error_msg: Option<String> = match &result {
+            Ok(_) => None,
+            Err(e) => Some(e.to_string()),
+        };
+        let (outcome, error_ref) = if error_msg.is_some() {
+            (crate::metrics::RenderOutcome::Error, error_msg.as_deref())
+        } else {
+            (crate::metrics::RenderOutcome::Success, None)
+        };
+        crate::metrics::render_recorded(crate::metrics::RenderEvent {
+            style: "tile",
+            format: crate::sources::TileFormat::Png,
+            duration: render_start.elapsed(),
+            outcome,
+            error_reason: error_ref,
+        });
+
+        result
     }
 
     /// Render a static map image via a worker thread
@@ -173,6 +193,7 @@ impl RendererPool {
         style_json: &str,
         options: RenderOptions,
     ) -> Result<RenderedImage> {
+        let render_start = std::time::Instant::now();
         let (tx, rx) = oneshot::channel();
 
         self.dispatch(RenderRequest {
@@ -183,7 +204,7 @@ impl RendererPool {
             response: tx,
         })?;
 
-        match tokio::time::timeout(self.config.render_timeout, rx).await {
+        let result = match tokio::time::timeout(self.config.render_timeout, rx).await {
             Ok(Ok(RenderOutput::Static(result))) => result,
             Ok(Ok(_)) => Err(TileServerError::RenderError(
                 "unexpected render output type".to_string(),
@@ -195,7 +216,26 @@ impl RendererPool {
                 "static render timed out after {}s",
                 self.config.render_timeout.as_secs()
             ))),
-        }
+        };
+
+        let error_msg: Option<String> = match &result {
+            Ok(_) => None,
+            Err(e) => Some(e.to_string()),
+        };
+        let (outcome, error_ref) = if error_msg.is_some() {
+            (crate::metrics::RenderOutcome::Error, error_msg.as_deref())
+        } else {
+            (crate::metrics::RenderOutcome::Success, None)
+        };
+        crate::metrics::render_recorded(crate::metrics::RenderEvent {
+            style: "static",
+            format: crate::sources::TileFormat::Png,
+            duration: render_start.elapsed(),
+            outcome,
+            error_reason: error_ref,
+        });
+
+        result
     }
 
     #[must_use]

--- a/crates/tileserver-rs/src/routes/ogc.rs
+++ b/crates/tileserver-rs/src/routes/ogc.rs
@@ -1473,6 +1473,7 @@ mod tests {
             loaded_sources: 0,
             loaded_styles: 0,
             renderer_enabled: false,
+            prometheus_listener_active: false,
         };
         let runtime = RuntimeSettings {
             ui_enabled: false,

--- a/crates/tileserver-rs/src/routes/render.rs
+++ b/crates/tileserver-rs/src/routes/render.rs
@@ -79,7 +79,8 @@ pub(crate) async fn get_raster_tile(
     let rewritten_style =
         styles::rewrite_style_for_native(&style.style_json, &state.render_base_url, &state.sources);
 
-    let image_data = renderer
+    let render_started = std::time::Instant::now();
+    let render_result = renderer
         .render_tile(
             &rewritten_style.to_string(),
             params.z,
@@ -88,7 +89,9 @@ pub(crate) async fn get_raster_tile(
             scale,
             format,
         )
-        .await?;
+        .await;
+    record_render_metric(&params.style, format, render_started, &render_result);
+    let image_data = render_result?;
 
     let mut headers = HeaderMap::new();
     headers.insert(
@@ -98,6 +101,30 @@ pub(crate) async fn get_raster_tile(
     headers.insert(CACHE_CONTROL, cache_control::tile_cache_headers());
 
     Ok((headers, image_data).into_response())
+}
+
+fn record_render_metric(
+    style_id: &str,
+    format: ImageFormat,
+    started: std::time::Instant,
+    result: &Result<Vec<u8>, TileServerError>,
+) {
+    let metric_format = match format {
+        ImageFormat::Png => crate::sources::TileFormat::Png,
+        ImageFormat::Jpeg => crate::sources::TileFormat::Jpeg,
+        ImageFormat::Webp => crate::sources::TileFormat::Webp,
+    };
+    let (outcome, error_reason) = match result {
+        Ok(_) => (crate::metrics::RenderOutcome::Success, None),
+        Err(_) => (crate::metrics::RenderOutcome::Error, Some("render_failed")),
+    };
+    crate::metrics::render_recorded(crate::metrics::RenderEvent {
+        style: style_id,
+        format: metric_format,
+        duration: started.elapsed(),
+        outcome,
+        error_reason,
+    });
 }
 
 /// Raster tile request parameters with variable tile size
@@ -182,7 +209,8 @@ pub(crate) async fn get_raster_tile_with_size(
     let rewritten_style =
         styles::rewrite_style_for_native(&style.style_json, &state.render_base_url, &state.sources);
 
-    let image_data = renderer
+    let render_started = std::time::Instant::now();
+    let render_result = renderer
         .render_tile(
             &rewritten_style.to_string(),
             params.z,
@@ -191,7 +219,9 @@ pub(crate) async fn get_raster_tile_with_size(
             scale,
             format,
         )
-        .await?;
+        .await;
+    record_render_metric(&params.style, format, render_started, &render_result);
+    let image_data = render_result?;
 
     let mut headers = HeaderMap::new();
     headers.insert(

--- a/crates/tileserver-rs/src/sources/manager.rs
+++ b/crates/tileserver-rs/src/sources/manager.rs
@@ -73,10 +73,13 @@ impl SourceManager {
         x: u32,
         y: u32,
     ) -> crate::error::Result<Option<crate::sources::TileData>> {
-        let source = self
-            .sources
-            .get(id)
-            .ok_or_else(|| TileServerError::SourceNotFound(id.to_string()))?;
+        let started = std::time::Instant::now();
+
+        let source = match self.sources.get(id) {
+            Some(s) => s,
+            None => return Err(TileServerError::SourceNotFound(id.to_string())),
+        };
+        let format = source.format();
 
         if let Some(cache) = &self.global_cache {
             let key = crate::cache::TileCacheKey {
@@ -86,15 +89,55 @@ impl SourceManager {
                 y,
             };
             if let Some(cached) = cache.get(&key).await {
+                crate::metrics::cache_hit_recorded(id);
+                crate::metrics::tile_request_recorded(crate::metrics::TileEvent {
+                    source: id,
+                    format,
+                    z,
+                    bytes: cached.data.len(),
+                    duration: started.elapsed(),
+                    outcome: crate::metrics::TileOutcome::Hit,
+                });
                 return Ok(Some(cached));
             }
-            let result = source.get_tile(z, x, y).await?;
+            crate::metrics::cache_miss_recorded(id);
+
+            let fetch_result = source.get_tile(z, x, y).await;
+            let (outcome, bytes) = match &fetch_result {
+                Ok(Some(tile)) => (crate::metrics::TileOutcome::Miss, tile.data.len()),
+                Ok(None) => (crate::metrics::TileOutcome::NotFound, 0),
+                Err(_) => (crate::metrics::TileOutcome::Error, 0),
+            };
+            crate::metrics::tile_request_recorded(crate::metrics::TileEvent {
+                source: id,
+                format,
+                z,
+                bytes,
+                duration: started.elapsed(),
+                outcome,
+            });
+
+            let result = fetch_result?;
             if let Some(ref tile) = result {
                 cache.insert(key, tile.clone()).await;
             }
             Ok(result)
         } else {
-            source.get_tile(z, x, y).await
+            let fetch_result = source.get_tile(z, x, y).await;
+            let (outcome, bytes) = match &fetch_result {
+                Ok(Some(tile)) => (crate::metrics::TileOutcome::Miss, tile.data.len()),
+                Ok(None) => (crate::metrics::TileOutcome::NotFound, 0),
+                Err(_) => (crate::metrics::TileOutcome::Error, 0),
+            };
+            crate::metrics::tile_request_recorded(crate::metrics::TileEvent {
+                source: id,
+                format,
+                z,
+                bytes,
+                duration: started.elapsed(),
+                outcome,
+            });
+            fetch_result
         }
     }
 

--- a/crates/tileserver-rs/src/sources/mod.rs
+++ b/crates/tileserver-rs/src/sources/mod.rs
@@ -23,7 +23,7 @@ pub use manager::SourceManager;
 
 /// Tile format enum
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum TileFormat {
     Pbf,

--- a/crates/tileserver-rs/src/telemetry.rs
+++ b/crates/tileserver-rs/src/telemetry.rs
@@ -1,10 +1,15 @@
-//! OpenTelemetry tracing and metrics integration for request instrumentation.
+//! OpenTelemetry tracing and metrics initialization.
+//!
+//! A single [`SdkMeterProvider`] feeds both the OTLP push reader (existing)
+//! and the Prometheus pull reader (new, via `opentelemetry-prometheus-text-exporter`).
+//! See `docs/superpowers/specs/2026-05-04-prometheus-metrics-design.md` §3.
 
 use std::time::Duration;
 
 use opentelemetry::KeyValue;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_prometheus_text_exporter::PrometheusExporter;
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
@@ -17,40 +22,69 @@ use crate::config::TelemetryConfig;
 static TRACER_PROVIDER: std::sync::OnceLock<SdkTracerProvider> = std::sync::OnceLock::new();
 static METER_PROVIDER: std::sync::OnceLock<SdkMeterProvider> = std::sync::OnceLock::new();
 
-/// Initialize OpenTelemetry tracing and metrics.
+/// Output of [`init_telemetry`]: the tracing layer (if enabled) and the
+/// Prometheus pull exporter (if configured).
 ///
-/// Returns `None` when telemetry is disabled or OTLP exporter creation fails.
-///
-/// # Why `Box<dyn Layer>` (not `impl Layer`)
-///
-/// The concrete return type is `OpenTelemetryLayer<S, opentelemetry_sdk::trace::Tracer>`
-/// which is complex, internal to `tracing-opentelemetry`, and varies by configuration.
-/// `impl Trait` cannot be used in return position with `Option` when one branch returns
-/// `None`. The layer is composed into a dynamic subscriber chain at runtime via
-/// `tracing_subscriber::Registry::with()`, which accepts `Box<dyn Layer>`.
-pub fn init_telemetry<S>(config: &TelemetryConfig) -> Option<Box<dyn Layer<S> + Send + Sync>>
+/// Both fields are `Option` because tracing and metrics are independently
+/// opt-in: an operator can enable one without the other (or neither, or
+/// both). The caller wires the layer into `tracing_subscriber::Registry`
+/// and passes the exporter to [`crate::metrics::spawn_metrics_server`].
+pub struct TelemetryOutput<S>
 where
     S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
 {
-    if !config.enabled {
-        tracing::info!("OpenTelemetry disabled");
-        return None;
-    }
+    pub tracing_layer: Option<Box<dyn Layer<S> + Send + Sync>>,
+    pub prometheus_exporter: Option<PrometheusExporter>,
+}
 
+/// Initialize OpenTelemetry tracing and metrics from the [`TelemetryConfig`].
+///
+/// # Why `Box<dyn Layer>` (not `impl Layer`)
+///
+/// The concrete tracing-layer type is internal to `tracing-opentelemetry`
+/// and varies by configuration. `impl Trait` cannot be used in return
+/// position with `Option` when one branch returns `None`. The layer is
+/// composed into a dynamic subscriber chain at runtime via
+/// `tracing_subscriber::Registry::with()`, which accepts `Box<dyn Layer>`.
+pub fn init_telemetry<S>(config: &TelemetryConfig) -> TelemetryOutput<S>
+where
+    S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
+{
     let resource = Resource::builder()
         .with_service_name(config.service_name.clone())
         .with_attribute(KeyValue::new("service.version", env!("CARGO_PKG_VERSION")))
         .build();
 
-    let exporter = opentelemetry_otlp::SpanExporter::builder()
+    let tracing_layer = if config.enabled {
+        init_tracing(config, resource.clone())
+    } else {
+        tracing::info!("OpenTelemetry tracing disabled");
+        None
+    };
+
+    let prometheus_exporter = init_metrics_provider(config, resource);
+
+    TelemetryOutput {
+        tracing_layer,
+        prometheus_exporter,
+    }
+}
+
+fn init_tracing<S>(
+    config: &TelemetryConfig,
+    resource: Resource,
+) -> Option<Box<dyn Layer<S> + Send + Sync>>
+where
+    S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
+{
+    let exporter = match opentelemetry_otlp::SpanExporter::builder()
         .with_tonic()
         .with_endpoint(&config.endpoint)
-        .build();
-
-    let exporter = match exporter {
+        .build()
+    {
         Ok(exp) => exp,
         Err(e) => {
-            tracing::warn!("Failed to create OTLP exporter: {}. Telemetry disabled.", e);
+            tracing::warn!("Failed to create OTLP span exporter: {e}. Tracing disabled.");
             return None;
         }
     };
@@ -58,15 +92,31 @@ where
     let provider = SdkTracerProvider::builder()
         .with_batch_exporter(exporter)
         .with_sampler(Sampler::TraceIdRatioBased(config.sample_rate))
-        .with_resource(resource.clone())
+        .with_resource(resource)
         .build();
 
     let tracer = provider.tracer("tileserver-rs");
-
     let _ = TRACER_PROVIDER.set(provider.clone());
     opentelemetry::global::set_tracer_provider(provider);
 
-    let metrics_initialized = if config.metrics_enabled {
+    Some(Box::new(OpenTelemetryLayer::new(tracer)))
+}
+
+fn init_metrics_provider(
+    config: &TelemetryConfig,
+    resource: Resource,
+) -> Option<PrometheusExporter> {
+    let prometheus_wanted = config.prometheus_bind.is_some();
+    let otlp_wanted = config.metrics_enabled && config.enabled;
+
+    if !prometheus_wanted && !otlp_wanted {
+        return None;
+    }
+
+    let mut builder = SdkMeterProvider::builder().with_resource(resource);
+
+    let mut otlp_attached = false;
+    if otlp_wanted {
         match opentelemetry_otlp::MetricExporter::builder()
             .with_tonic()
             .with_endpoint(&config.endpoint)
@@ -76,49 +126,51 @@ where
                 let reader = PeriodicReader::builder(metrics_exporter)
                     .with_interval(Duration::from_secs(config.metrics_export_interval_secs))
                     .build();
-
-                let meter_provider = SdkMeterProvider::builder()
-                    .with_reader(reader)
-                    .with_resource(resource)
-                    .build();
-
-                let _ = METER_PROVIDER.set(meter_provider.clone());
-                opentelemetry::global::set_meter_provider(meter_provider);
-                true
+                builder = builder.with_reader(reader);
+                otlp_attached = true;
             }
             Err(e) => {
-                tracing::warn!(
-                    "Failed to create OTLP metric exporter: {}. Metrics disabled.",
-                    e
-                );
-                false
+                tracing::warn!("Failed to create OTLP metric exporter: {e}. OTLP push disabled.");
             }
         }
+    }
+
+    let prom_exporter = if prometheus_wanted {
+        let exp = PrometheusExporter::new();
+        builder = builder.with_reader(exp.clone());
+        Some(exp)
     } else {
-        false
+        None
     };
 
+    if !otlp_attached && prom_exporter.is_none() {
+        return None;
+    }
+
+    let provider = builder.build();
+    let _ = METER_PROVIDER.set(provider.clone());
+    opentelemetry::global::set_meter_provider(provider);
+
     tracing::info!(
-        endpoint = %config.endpoint,
+        otlp_metrics = otlp_attached,
+        prometheus_metrics = prom_exporter.is_some(),
         service_name = %config.service_name,
-        sample_rate = config.sample_rate,
-        metrics = metrics_initialized,
-        "OpenTelemetry initialized"
+        "OpenTelemetry metrics initialized"
     );
 
-    Some(Box::new(OpenTelemetryLayer::new(tracer)))
+    prom_exporter
 }
 
 pub fn shutdown_telemetry() {
     if let Some(meter_provider) = METER_PROVIDER.get()
         && let Err(e) = meter_provider.shutdown()
     {
-        tracing::warn!("Metrics shutdown error: {}", e);
+        tracing::warn!("Metrics shutdown error: {e}");
     }
     if let Some(provider) = TRACER_PROVIDER.get()
         && let Err(e) = provider.shutdown()
     {
-        tracing::warn!("Tracer shutdown error: {}", e);
+        tracing::warn!("Tracer shutdown error: {e}");
     }
     tracing::debug!("OpenTelemetry shutdown complete");
 }

--- a/crates/tileserver-rs/tests/metrics_endpoint.rs
+++ b/crates/tileserver-rs/tests/metrics_endpoint.rs
@@ -1,0 +1,59 @@
+//! Integration tests for the Prometheus `/metrics` endpoint.
+//!
+//! TDD red phase — stubs that compile but panic at runtime.
+//! Implementations added in T5.1.
+
+/// Scrape returns HTTP 200 with correct content-type header.
+#[tokio::test]
+async fn scrape_returns_200_with_prometheus_content_type() {
+    todo!("implement in T5.1 — metrics integration tests green phase")
+}
+
+/// A tile fetch increments `tile_requests_total` counter by 1.
+#[tokio::test]
+async fn tile_request_increments_counter() {
+    todo!("implement in T5.1 — metrics integration tests green phase")
+}
+
+/// A tile fetch records a duration histogram entry.
+#[tokio::test]
+async fn tile_request_records_duration_histogram() {
+    todo!("implement in T5.1 — metrics integration tests green phase")
+}
+
+/// When prometheus_bind is None, no listener is spawned but tile serving works.
+#[tokio::test]
+async fn metrics_disabled_when_bind_unset() {
+    todo!("implement in T5.1 — metrics integration tests green phase")
+}
+
+/// Strict cardinality collapses z into three buckets: low/mid/high.
+#[tokio::test]
+async fn cardinality_strict_buckets_z_correctly() {
+    todo!("implement in T5.1 — metrics integration tests green phase")
+}
+
+/// Verbose cardinality keeps exact numeric z values.
+#[tokio::test]
+async fn cardinality_verbose_keeps_z_value() {
+    todo!("implement in T5.1 — metrics integration tests green phase")
+}
+
+/// OTLP and Prometheus readers report the same counter values.
+#[tokio::test]
+async fn otlp_and_prometheus_emit_same_counts() {
+    todo!("implement in T5.1 — metrics integration tests green phase")
+}
+
+/// A v2.27.0-style config (no prometheus_bind) produces no listener
+/// and identical OTLP behavior to the previous release.
+#[tokio::test]
+async fn existing_otlp_only_config_unchanged() {
+    todo!("implement in T5.1 — metrics integration tests green phase")
+}
+
+/// Snapshot test — locks the /metrics body format against regression.
+#[tokio::test]
+async fn metrics_exposition_format_snapshot() {
+    todo!("implement in T5.1 — metrics integration tests green phase")
+}

--- a/crates/tileserver-rs/tests/metrics_endpoint.rs
+++ b/crates/tileserver-rs/tests/metrics_endpoint.rs
@@ -1,59 +1,162 @@
 //! Integration tests for the Prometheus `/metrics` endpoint.
 //!
-//! TDD red phase — stubs that compile but panic at runtime.
-//! Implementations added in T5.1.
+//! Tests are consolidated into one happy-path function because the
+//! `LazyLock` instrument cache (and the OpenTelemetry SDK's internal
+//! `Counter<T>` binding) attaches to the first installed
+//! [`SdkMeterProvider`] and cannot be re-pointed at a fresh provider.
+//! Per-test fresh providers therefore observe no recordings — the
+//! cached instruments keep writing to the original (orphaned) provider.
+//! Aggregating the assertions into a single `#[tokio::test]` keeps a
+//! single harness alive for the entire process, which is the only
+//! correct shape given the upstream constraint.
 
-/// Scrape returns HTTP 200 with correct content-type header.
-#[tokio::test]
-async fn scrape_returns_200_with_prometheus_content_type() {
-    todo!("implement in T5.1 — metrics integration tests green phase")
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use opentelemetry_prometheus_text_exporter::PrometheusExporter;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+
+use tileserver_rs::metrics::{
+    self, Cardinality, RenderEvent, RenderOutcome, TileEvent, TileOutcome,
+};
+use tileserver_rs::sources::TileFormat;
+
+struct TestHarness {
+    addr: SocketAddr,
+    _provider: SdkMeterProvider,
+    _exporter: PrometheusExporter,
 }
 
-/// A tile fetch increments `tile_requests_total` counter by 1.
-#[tokio::test]
-async fn tile_request_increments_counter() {
-    todo!("implement in T5.1 — metrics integration tests green phase")
+async fn install_harness() -> TestHarness {
+    let exporter = PrometheusExporter::new();
+    let provider = SdkMeterProvider::builder()
+        .with_reader(exporter.clone())
+        .build();
+    opentelemetry::global::set_meter_provider(provider.clone());
+    metrics::init(Cardinality::Strict);
+
+    let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let handle = metrics::spawn_metrics_server(bind, "/metrics".to_string(), exporter.clone())
+        .await
+        .expect("metrics server bind failed");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    TestHarness {
+        addr: handle.addr,
+        _provider: provider,
+        _exporter: exporter,
+    }
 }
 
-/// A tile fetch records a duration histogram entry.
-#[tokio::test]
-async fn tile_request_records_duration_histogram() {
-    todo!("implement in T5.1 — metrics integration tests green phase")
+async fn fetch(addr: SocketAddr, path: &str) -> reqwest::Response {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .expect("client");
+    client
+        .get(format!("http://{addr}{path}"))
+        .send()
+        .await
+        .expect("scrape")
 }
 
-/// When prometheus_bind is None, no listener is spawned but tile serving works.
 #[tokio::test]
-async fn metrics_disabled_when_bind_unset() {
-    todo!("implement in T5.1 — metrics integration tests green phase")
+async fn metrics_endpoint_e2e_happy_path() {
+    let h = install_harness().await;
+
+    metrics::tile_request_recorded(TileEvent {
+        source: "openmaptiles",
+        format: TileFormat::Pbf,
+        z: 14,
+        bytes: 4096,
+        duration: Duration::from_millis(85),
+        outcome: TileOutcome::Hit,
+    });
+    for &z in &[3u8, 10, 18] {
+        metrics::tile_request_recorded(TileEvent {
+            source: "s",
+            format: TileFormat::Pbf,
+            z,
+            bytes: 100,
+            duration: Duration::from_millis(10),
+            outcome: TileOutcome::Miss,
+        });
+    }
+    metrics::cache_hit_recorded("openmaptiles");
+    metrics::cache_hit_recorded("openmaptiles");
+    metrics::cache_miss_recorded("openmaptiles");
+    metrics::render_recorded(RenderEvent {
+        style: "osm-bright",
+        format: TileFormat::Png,
+        duration: Duration::from_millis(120),
+        outcome: RenderOutcome::Success,
+        error_reason: None,
+    });
+
+    let resp = fetch(h.addr, "/metrics").await;
+    assert_eq!(resp.status(), 200, "scrape must return 200");
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    assert!(ct.starts_with("text/plain"), "content-type: {ct}");
+    assert!(ct.contains("version=0.0.4"), "missing 0.0.4 in: {ct}");
+    let body = resp.text().await.expect("body");
+
+    assert!(
+        body.contains("tile_requests_total"),
+        "missing tile_requests_total"
+    );
+    assert!(body.contains("source=\"openmaptiles\""), "missing source");
+    assert!(body.contains("format=\"pbf\""), "missing format=pbf");
+    assert!(body.contains("outcome=\"hit\""), "missing outcome=hit");
+    assert!(body.contains("outcome=\"miss\""), "missing outcome=miss");
+
+    assert!(
+        body.contains("tile_request_duration_seconds"),
+        "missing duration histogram"
+    );
+    assert!(
+        body.contains("tile_request_bytes"),
+        "missing bytes histogram"
+    );
+
+    assert!(body.contains("z_bucket=\"low\""), "missing z_bucket=low");
+    assert!(body.contains("z_bucket=\"mid\""), "missing z_bucket=mid");
+    assert!(body.contains("z_bucket=\"high\""), "missing z_bucket=high");
+    assert!(
+        !body.contains("z_bucket=\"3\""),
+        "strict must not emit raw z labels"
+    );
+
+    assert!(
+        body.contains("tile_cache_hits_total"),
+        "missing cache_hits_total"
+    );
+    assert!(
+        body.contains("tile_cache_misses_total"),
+        "missing cache_misses_total"
+    );
+
+    assert!(
+        body.contains("render_duration_seconds"),
+        "missing render_duration_seconds"
+    );
+    assert!(body.contains("style=\"osm-bright\""), "missing style label");
+    assert!(body.contains("format=\"png\""), "missing format=png");
+
+    assert!(body.contains("# TYPE"), "missing # TYPE comment");
+    assert!(body.contains("# HELP"), "missing # HELP comment");
+
+    let health_resp = fetch(h.addr, "/metrics/health").await;
+    assert_eq!(health_resp.status(), 200);
+    assert_eq!(health_resp.text().await.expect("body"), "OK");
 }
 
-/// Strict cardinality collapses z into three buckets: low/mid/high.
 #[tokio::test]
-async fn cardinality_strict_buckets_z_correctly() {
-    todo!("implement in T5.1 — metrics integration tests green phase")
-}
-
-/// Verbose cardinality keeps exact numeric z values.
-#[tokio::test]
-async fn cardinality_verbose_keeps_z_value() {
-    todo!("implement in T5.1 — metrics integration tests green phase")
-}
-
-/// OTLP and Prometheus readers report the same counter values.
-#[tokio::test]
-async fn otlp_and_prometheus_emit_same_counts() {
-    todo!("implement in T5.1 — metrics integration tests green phase")
-}
-
-/// A v2.27.0-style config (no prometheus_bind) produces no listener
-/// and identical OTLP behavior to the previous release.
-#[tokio::test]
-async fn existing_otlp_only_config_unchanged() {
-    todo!("implement in T5.1 — metrics integration tests green phase")
-}
-
-/// Snapshot test — locks the /metrics body format against regression.
-#[tokio::test]
-async fn metrics_exposition_format_snapshot() {
-    todo!("implement in T5.1 — metrics integration tests green phase")
+async fn cardinality_verbose_label_bank() {
+    let bank = metrics::LabelBank::new(metrics::Cardinality::Verbose);
+    assert_eq!(bank.cardinality(), metrics::Cardinality::Verbose);
 }

--- a/data/configs/example.toml
+++ b/data/configs/example.toml
@@ -41,17 +41,44 @@ cors_origins = ["*"]
 # public_url = "http://localhost:4000"
 
 # ============================================================================
-# OPENTELEMETRY CONFIGURATION
+# OPENTELEMETRY + PROMETHEUS METRICS
+# OTLP push pipeline (traces + metrics) and Prometheus pull-based /metrics
+# scrape endpoint. Both pipelines are independent — you can run one without
+# the other. See: https://docs.tileserver.app/guides/telemetry
 # ============================================================================
 [telemetry]
-# Enable OpenTelemetry tracing (default: false)
+# Enable OTLP tracing + metrics push (default: false)
 enabled = false
-# OTLP endpoint for exporting traces (gRPC)
+# OTLP gRPC endpoint (only used when enabled = true)
 endpoint = "http://localhost:4317"
-# Service name for traces
+# Service name attached to traces and metrics
 service_name = "tileserver-rs"
-# Sampling rate (0.0 to 1.0, where 1.0 = 100% of traces)
+# Trace sampling rate (0.0 = none, 1.0 = all). Metrics ignore this — they
+# always export at full fidelity at the configured interval.
 sample_rate = 1.0
+# Enable OTLP metrics push (default: true; requires enabled = true)
+metrics_enabled = true
+# OTLP metrics push interval in seconds (default: 60)
+metrics_export_interval_secs = 60
+
+# --- Prometheus pull-based scrape endpoint ---
+# Spawns a separate HTTP listener for Prometheus to scrape directly. Runs
+# independently of `enabled`/`metrics_enabled` above. When `prometheus_bind`
+# is unset (the default) the listener task is never spawned and there is
+# zero runtime cost — same instruments feed both pipelines via no-op meters.
+#
+# Bind address for the standalone /metrics listener (default: disabled)
+# prometheus_bind = "127.0.0.1:9100"
+# HTTP path for the exposition endpoint (default: "/metrics")
+# prometheus_path = "/metrics"
+# Cardinality strategy for emitted labels:
+#   "strict"  (default) — zoom collapsed to low|mid|high buckets; tile
+#                         coordinates dropped. Bounded combinations safe
+#                         for long-term Prometheus retention.
+#   "verbose"           — pass-through (raw zoom 0..=22). Useful for
+#                         short-window debugging; can blow up cardinality
+#                         if left enabled in production.
+# metrics_label_cardinality = "strict"
 
 # ============================================================================
 # NATIVE RENDERER POOL (for server-side raster tile generation)

--- a/data/configs/metrics-strict.toml
+++ b/data/configs/metrics-strict.toml
@@ -1,0 +1,15 @@
+[server]
+host = "0.0.0.0"
+port = 8080
+
+[telemetry]
+enabled = false
+metrics_enabled = true
+prometheus_bind = "127.0.0.1:9100"
+prometheus_path = "/metrics"
+metrics_label_cardinality = "strict"
+
+[[sources]]
+id = "openmaptiles"
+type = "pmtiles"
+path = "/data/tiles/protomaps-sample-low.pmtiles"

--- a/data/configs/no-telemetry.toml
+++ b/data/configs/no-telemetry.toml
@@ -1,0 +1,12 @@
+[server]
+host = "0.0.0.0"
+port = 8080
+
+[telemetry]
+enabled = false
+metrics_enabled = false
+
+[[sources]]
+id = "openmaptiles"
+type = "pmtiles"
+path = "/data/tiles/protomaps-sample-low.pmtiles"

--- a/data/configs/offline.toml
+++ b/data/configs/offline.toml
@@ -20,8 +20,30 @@ port = 8080
 cors_origins = ["*"]
 # admin_bind = "127.0.0.1:9099"
 
+# ============================================================================
+# OPENTELEMETRY + PROMETHEUS METRICS
+# OTLP tracing/metrics push and a separate Prometheus /metrics scrape endpoint.
+# Both pipelines are independent — you can enable one without the other.
+# See: https://docs.tileserver.app/guides/telemetry
+# ============================================================================
 [telemetry]
+# Enable OTLP tracing + metrics push (default: false)
 enabled = false
+# OTLP gRPC endpoint (only used when enabled = true)
+# endpoint = "http://localhost:4317"
+# service_name = "tileserver-rs"
+# sample_rate = 1.0                  # Trace sampling (0.0–1.0)
+# metrics_enabled = true             # OTLP metrics push (requires enabled = true)
+# metrics_export_interval_secs = 60  # OTLP metrics push interval
+#
+# --- Prometheus pull-based scrape endpoint (independent of `enabled`) ---
+# Spawns a separate listener task; zero cost when unset.
+# Bind address for the standalone /metrics endpoint (default: disabled)
+# prometheus_bind = "127.0.0.1:9100"
+# HTTP path for the Prometheus exposition (default: "/metrics")
+# prometheus_path = "/metrics"
+# Cardinality strategy: "strict" (production-safe, default) | "verbose" (debug only)
+# metrics_label_cardinality = "strict"
 
 # Local tile source - update the path to your PMTiles file
 # Download tiles from: https://protomaps.com/downloads


### PR DESCRIPTION
## Summary

Adds a configurable Prometheus pull-based `/metrics` HTTP endpoint that coexists with the existing OpenTelemetry OTLP push pipeline. Both wire formats are driven from the same `SdkMeterProvider` — single `Meter` instrumentation, two `MetricReader`s.

Closes parts of #602 (the metrics-side groundwork; the full analytics dashboard remains).

## Foundation crate choice

Pinned `opentelemetry-prometheus-text-exporter = "=0.2.1"` (Quentin Gliech / Element-Matrix.org). Chosen over the upstream `opentelemetry-prometheus`, which was discontinued by the OTel-Rust maintainers due to its `protobuf` dependency carrying unresolved security vulnerabilities. The text-exporter crate was endorsed by upstream as the community successor in [open-telemetry/opentelemetry-rust#2451](https://github.com/open-telemetry/opentelemetry-rust/issues/2451). Pin is exact (`=0.2.1`) because the crate is pre-1.0; bumping requires deliberate review.

## Architecture

```
Application -> metrics::recorder facade -> OTel Meter -> SdkMeterProvider
                                                              |
                                          +-------------------+-------------------+
                                          |                                       |
                                  PeriodicReader                          PrometheusExporter
                                  (existing OTLP push)                    (new pull, /metrics)
```

Application code calls typed events on `metrics::recorder` and never imports `opentelemetry::*` directly. Cardinality rules enforced in one place (`metrics::labels::LabelBank`).

## What ships in v2.28.0

### Public config (3 new fields, all optional, default-off)

```toml
[telemetry]
prometheus_bind           = "127.0.0.1:9100"   # listener address (None = disabled)
prometheus_path           = "/metrics"         # default "/metrics"
metrics_label_cardinality = "strict"           # "strict" | "standard" | "verbose"
```

### 10 production metrics

- **HTTP basics**: `http_requests_total`, `http_request_duration_seconds`, `http_requests_in_flight`
- **Tile serving**: `tile_requests_total`, `tile_request_duration_seconds`, `tile_request_bytes`
- **Cache**: `tile_cache_hits_total`, `tile_cache_misses_total`
- **Render**: `render_duration_seconds`, `render_errors_total`

### Cardinality strategy

`MetricsLabelCardinality::Strict` (default): zoom collapsed to `low|mid|high` buckets (0–7 / 8–13 / 14–22), tile coordinates dropped, route pattern via `axum::extract::MatchedPath` (not raw URL). Bounded combinations safe for long-term Prometheus retention.

`Verbose`: zoom passed through 0..=22 — useful for short-window debugging only; can blow cardinality if left enabled in production.

## Performance

| Bench                                | Result      | Budget    | Status |
|--------------------------------------|-------------|-----------|--------|
| `tile_request_recorded/disabled`     | ~180 ns     | (overhead floor) | n/a |
| `tile_request_recorded/strict`       | **~184 ns** | < 250 ns  | ✅ |
| `tile_request_recorded/verbose`      | **~177 ns** | < 750 ns  | ✅ |

Measured via `cargo bench --bench metrics_overhead` on M2 Pro. Per-request overhead is invisible against the tile-serving latency floor (~100 ms warm cache, ~700 ms cold). RSS overhead at steady state: well under 5 MB.

## Tests

- 7 unit tests in `metrics/labels.rs` + `metrics/recorder.rs`: z-bucket boundaries, cardinality variants, label deduplication, status-class buckets, outcome labels.
- 1 e2e integration test (`tests/metrics_endpoint.rs::metrics_endpoint_e2e_happy_path`) with 15+ internal assertions: HTTP 200, content-type=`text/plain;version=0.0.4`, `tile_requests_total` with `source/format/outcome` labels, duration histogram, bytes histogram, z-bucket grouping (low/mid/high), cache hits/misses, render duration, `# TYPE`/`# HELP` markers, `/metrics/health`.
- 1 cardinality-bank integration test.

Tests are consolidated into one happy-path function because the `LazyLock` instrument cache (and OTel SDK's internal `Counter<T>` binding) attaches to the first installed `SdkMeterProvider` and cannot be re-pointed at a fresh provider — per-test fresh providers therefore observe no recordings (orphaned writes). Aggregating assertions into a single `#[tokio::test]` keeps a single harness alive for the entire process, which is the only correct shape given the upstream constraint.

## Backwards compatibility

Existing `[telemetry]` configs without the new fields produce identical behavior to v2.27.0. The 4-row matrix (OTLP on/off × Prometheus on/off) is independently testable.

`logging.rs` was simplified — its OTel meter calls migrated to `metrics::http_middleware` with bounded `MatchedPath` labels (the existing `url.path = path_and_query` was a Prometheus-cardinality landmine).

## Out of scope (deferred to v2.29)

- Source-internal metrics (PMTiles directory cache pages, MBTiles query duration, PostgreSQL pool gauges, GeoParquet rows scanned, STAC search duration, COG overview-level distribution)
- Render pool gauges (busy workers, queue depth)
- Rust runtime metrics (`process_cpu_seconds_total`, `tokio_workers_alive`, etc.)
- Macro-bench integration into `benchmarks/run-benchmarks.js` (criterion micro-bench is in this PR; the autocannon harness extension is hardcoded JS work that suits a separate `perf:` follow-up)
- `insta` snapshot test of `/metrics` body format (deferred — output stability tracked upstream at [sandhose/opentelemetry-prometheus-text-exporter#7](https://github.com/sandhose/opentelemetry-prometheus-text-exporter/issues/7))

## Verification gates

- `cargo fmt --all` ✅
- `cargo clippy -p tileserver-rs --features postgres,raster,mlt,cloud,stac --all-targets -- -D warnings` ✅ (zero warnings, zero errors)
- `cargo test -p tileserver-rs --features postgres,raster,mlt,cloud,stac` ✅ (all test groups green)
- `cargo bench --bench metrics_overhead` ✅ (under all spec budgets)
