### PR TITLE
fix(deps): complete otel 0.32 family — swap text-exporter for official opentelemetry-prometheus

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -37,6 +37,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      # ubuntu-latest ships with ~14GB free on /. The bundled libduckdb-sys +
+      # GDAL + mbgl-sys C++ build under cargo --all-features (libduckdb alone
+      # produces ~6GB of object files before archiving) exceeds that. Clearing
+      # pre-installed Android SDK / .NET / Haskell / large-packages reclaims
+      # ~30GB and unblocks the archive step (ar: No space left on device).
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,4 @@ apps/docs/.data
 .sisyphus
 data/overture
 docs/superpowers
+.opencode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -230,7 +230,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -250,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -285,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -348,9 +348,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -441,9 +441,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -698,6 +698,15 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1341,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
@@ -1607,13 +1616,12 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -2066,9 +2074,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2153,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -2240,23 +2248,23 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "hotpath"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28594d8a3d30371e1488dcd6ba545bf07e9ce9dff6d8a57d70dbbaa221d3246d"
+checksum = "fdb7d0713302f121f02d93290b6303b320e886f462d2cde84146ce9f9e28f1f0"
 dependencies = [
  "hotpath-macros",
 ]
 
 [[package]]
 name = "hotpath-macros"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b87d58f92c09858091f328521db329955e9fc960c3c9c55e5dc0ef228a37b0"
+checksum = "51066092dc750f8cbcac4afa04592377bf7463a911d1beca430ddd788deb0757"
 
 [[package]]
 name = "http"
@@ -2317,9 +2325,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -2576,9 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2628,7 +2636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2805,9 +2813,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2967,10 +2975,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -3031,9 +3036,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
 dependencies = [
  "twox-hash",
 ]
@@ -3094,7 +3099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3525,19 +3530,6 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
@@ -3559,7 +3551,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "reqwest 0.13.3",
 ]
 
@@ -3570,10 +3562,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.32.0",
+ "opentelemetry_sdk",
  "prost 0.14.3",
  "reqwest 0.13.3",
  "thiserror 2.0.18",
@@ -3583,14 +3575,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-prometheus-text-exporter"
-version = "0.2.1"
+name = "opentelemetry-prometheus"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897906366b17a89bec845f6051e0c3474049402a09a0711eea180941293bd013"
+checksum = "2c0359983e7f79cf33c9abd89e5d7ddf67c46c419d0148598022d70e70c01aba"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
- "smartstring",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prometheus",
+ "tracing",
 ]
 
 [[package]]
@@ -3599,8 +3593,8 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
- "opentelemetry 0.32.0",
- "opentelemetry_sdk 0.32.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost 0.14.3",
  "tonic",
  "tonic-prost",
@@ -3614,19 +3608,6 @@ checksum = "6ca2f98a0437b427b4b08f19f1caa3c44db885a202bc12cfea13d6c702243d68"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.31.0",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368afaed344110f40b179bb8fbe54bc52d98f9bd2b281799ef32487c2650c956"
@@ -3634,7 +3615,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
@@ -3692,16 +3673,16 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
 
 [[package]]
 name = "parquet"
-version = "58.1.0"
+version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -3715,7 +3696,7 @@ dependencies = [
  "chrono",
  "futures",
  "half",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "lz4_flex",
  "num-bigint",
  "num-integer",
@@ -3884,7 +3865,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
@@ -3893,23 +3874,23 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
- "siphasher 1.0.2",
+ "siphasher 1.0.3",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3927,12 +3908,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -4139,6 +4114,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4213,6 +4203,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4256,9 +4266,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -4533,15 +4543,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -4897,9 +4898,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -4955,9 +4956,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5264,11 +5265,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5283,9 +5285,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5312,7 +5314,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5388,9 +5390,9 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -5403,17 +5405,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smartstring"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
-dependencies = [
- "autocfg",
- "static_assertions",
- "version_check",
-]
 
 [[package]]
 name = "snap"
@@ -5536,12 +5527,6 @@ dependencies = [
  "psm",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -5818,14 +5803,15 @@ dependencies = [
  "ndarray",
  "object_store",
  "ogcapi-types",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry-prometheus-text-exporter",
+ "opentelemetry-prometheus",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.32.0",
+ "opentelemetry_sdk",
  "parquet",
  "pmtiles",
  "postgres-types",
+ "prometheus",
  "prost 0.14.3",
  "reqwest 0.13.3",
  "rusqlite",
@@ -6070,9 +6056,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "base64",
@@ -6096,9 +6082,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost 0.14.3",
@@ -6107,9 +6093,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-types"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
 dependencies = [
  "prost 0.14.3",
  "prost-types",
@@ -6223,11 +6209,10 @@ dependencies = [
 [[package]]
 name = "tracing-opentelemetry"
 version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+source = "git+https://github.com/tokio-rs/tracing-opentelemetry.git?rev=44521fa#44521fa43c79989cdfb5b7244d5f1afadef6dd7e"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -6590,9 +6575,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6604,9 +6589,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6614,9 +6599,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6624,9 +6609,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6637,9 +6622,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -6693,9 +6678,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6744,9 +6729,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9479f84a757f819cfab37295955906479181395de83add28f74975fde083141"
+checksum = "9a7714cd0430a663154667c74da5d09325c2387695bee18b3f7f72825aa3693a"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -7009,9 +6994,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -7211,9 +7196,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,43 +94,26 @@ rust-embed       = { version = "8.11.0", features = ["axum"] }
 utoipa           = { version = "5.5.0", features = ["axum_extras"] }
 scalar_api_reference = { version = "0.2", features = ["axum"] }
 
-# OpenTelemetry
-#
-# PINNED to 0.31.x. A 0.32 family exists for `opentelemetry`,
-# `opentelemetry_sdk`, `opentelemetry-otlp`, `opentelemetry-semantic-conventions`,
-# AND `opentelemetry-prometheus` (the latter un-deprecated upstream on May 8
-# 2026), BUT `tracing-opentelemetry` 0.32.0/0.32.1 still pins
-# `opentelemetry = "0.31.0"` internally (upstream bug — see
-# tokio-rs/tracing-opentelemetry#258, in-progress as of May 12 2026). Mixing
-# 0.32 core with 0.32.1 tracing-opentelemetry resolves two copies of
-# `opentelemetry` in the graph and fails compile with
-# `the trait bound SdkTracer: opentelemetry::trace::Tracer is not satisfied`.
-#
-# We hit this on PRs #885/#888/#893/#895/#907 (May 12-13 2026): Dependabot
-# bumped 0.31 → 0.32, but `opentelemetry-prometheus-text-exporter = "=0.2.1"`
-# (the Prometheus pull endpoint exporter, see below) still pins SDK 0.31,
-# producing a diamond conflict with the same trait-bound error on
-# `PrometheusExporter: MetricReader`.
-#
-# Unblock path: when tokio-rs/tracing-opentelemetry#258 merges and ships,
-# bump ALL six crates here together (the `opentelemetry` group in
-# .github/dependabot.yml enforces this).
+# OpenTelemetry — full 0.32 family. The `tracing-opentelemetry` line below pulls the
+# fix from tokio-rs/tracing-opentelemetry#258 (merged 2026-05-15, NOT yet
+# released on crates.io) via `[patch.crates-io]` at the bottom of this
+# file. Drop the patch override the moment `tracing-opentelemetry > 0.32.1`
+# publishes on crates.io with `opentelemetry ^0.32` deps.
+# The `opentelemetry` group in `.github/dependabot.yml` bumps these crates
+# atomically — never solo-bump.
 opentelemetry    = "0.32.0"
 opentelemetry_sdk = { version = "0.32.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.32.0", features = ["grpc-tonic", "metrics", "logs"] }
 opentelemetry-semantic-conventions = "0.32.0"
 tracing-opentelemetry = "0.32.1"
-# Prometheus pull-endpoint exporter — community successor to the (recently
-# un-deprecated) `opentelemetry-prometheus` crate. Authored by Quentin
-# Gliech (Element/Matrix.org) and endorsed by OTel-Rust maintainers in
-# <https://github.com/open-telemetry/opentelemetry-rust/issues/2451>.
-# Pinned EXACT (`=`) because the crate is pre-1.0 (`0.2.x`) and may make
-# breaking changes between minor versions; bumping requires a deliberate
-# review of the changelog and an update to `metrics/server.rs` + `telemetry.rs`.
-# Will be replaced by official `opentelemetry-prometheus` 0.32 ONCE
-# `tracing-opentelemetry` ships SDK 0.32 support (see opentelemetry block
-# above).
-opentelemetry-prometheus-text-exporter = "=0.2.1"
+# Official `opentelemetry-prometheus` crate, un-deprecated and re-released
+# on 2026-05-08 by open-telemetry/opentelemetry-rust under OTel 0.32 family.
+# Replaces the community fork `opentelemetry-prometheus-text-exporter` we
+# carried while the official crate was deprecated (Sep 2025 → May 2026).
+# Pairs with the `prometheus = "0.14"` crate's `Registry` + `TextEncoder`
+# for the `/metrics` scrape endpoint — see `crates/tileserver-rs/src/metrics/server.rs`.
+opentelemetry-prometheus = "0.32.0"
+prometheus       = "0.14.0"
 
 # Raster / GDAL (optional)
 gdal             = { version = "0.19.0", features = ["bindgen"] }
@@ -215,3 +198,13 @@ opt-level = 3
 [patch.crates-io]
 gdal     = { git = "https://github.com/AlexanderWillner/gdal.git", rev = "968cf34a3101ef0aa6e418e779752fa282bc3269" }
 gdal-sys = { git = "https://github.com/AlexanderWillner/gdal.git", rev = "968cf34a3101ef0aa6e418e779752fa282bc3269" }
+# `tracing-opentelemetry` 0.32.1 (latest on crates.io, published 2026-01-12)
+# still pins `opentelemetry ^0.31.0` on its public deps. PR
+# tokio-rs/tracing-opentelemetry#258 — "chore: Upgrade to OpenTelemetry
+# 0.32" — merged on 2026-05-15 at commit 44521fa onto the `v0.1.x` branch,
+# but a new crates.io release has not shipped yet. Without this override we
+# get two copies of `opentelemetry` in the dep graph and fail to compile
+# with "the trait bound SdkTracer: opentelemetry::trace::Tracer is not
+# satisfied". Drop this entry the moment a `tracing-opentelemetry` version
+# > 0.32.1 publishes on crates.io with `opentelemetry ^0.32` deps.
+tracing-opentelemetry = { git = "https://github.com/tokio-rs/tracing-opentelemetry.git", rev = "44521fa" }

--- a/crates/tileserver-rs/Cargo.toml
+++ b/crates/tileserver-rs/Cargo.toml
@@ -59,7 +59,8 @@ opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
 tracing-opentelemetry = { workspace = true }
-opentelemetry-prometheus-text-exporter = { workspace = true }
+opentelemetry-prometheus = { workspace = true }
+prometheus = { workspace = true }
 
 # MBTiles support (SQLite)
 rusqlite         = { workspace = true }

--- a/crates/tileserver-rs/src/main.rs
+++ b/crates/tileserver-rs/src/main.rs
@@ -269,13 +269,13 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(reload::reload_signal(Arc::clone(&controller)));
 
-    if let Some(exporter) = telemetry_output.prometheus_exporter
+    if let Some(registry) = telemetry_output.prometheus_registry
         && let Some(bind_str) = config.telemetry.prometheus_bind.as_ref()
     {
         match bind_str.parse::<SocketAddr>() {
             Ok(prom_addr) => {
                 let path = config.telemetry.prometheus_path.clone();
-                match metrics::spawn_metrics_server(prom_addr, path, exporter).await {
+                match metrics::spawn_metrics_server(prom_addr, path, registry).await {
                     Ok(_handle) => {
                         tracing::info!(
                             bind = %prom_addr,

--- a/crates/tileserver-rs/src/metrics/mod.rs
+++ b/crates/tileserver-rs/src/metrics/mod.rs
@@ -26,4 +26,4 @@ pub use recorder::{
 };
 pub use server::{MetricsServerHandle, spawn_metrics_server};
 
-pub use opentelemetry_prometheus_text_exporter::PrometheusExporter;
+pub use prometheus::Registry;

--- a/crates/tileserver-rs/src/metrics/server.rs
+++ b/crates/tileserver-rs/src/metrics/server.rs
@@ -9,13 +9,13 @@ use axum::extract::State;
 use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
-use opentelemetry_prometheus_text_exporter::PrometheusExporter;
+use prometheus::{Encoder, Registry, TextEncoder};
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 
 #[derive(Clone)]
 struct ServerState {
-    exporter: Arc<PrometheusExporter>,
+    registry: Arc<Registry>,
 }
 
 /// Owned handle for the spawned metrics listener task.
@@ -35,13 +35,13 @@ pub struct MetricsServerHandle {
 pub async fn spawn_metrics_server(
     bind: SocketAddr,
     path: String,
-    exporter: PrometheusExporter,
+    registry: Registry,
 ) -> std::io::Result<MetricsServerHandle> {
     let listener = TcpListener::bind(bind).await?;
     let addr = listener.local_addr()?;
 
     let state = ServerState {
-        exporter: Arc::new(exporter),
+        registry: Arc::new(registry),
     };
 
     let normalized = if path.starts_with('/') {
@@ -72,7 +72,9 @@ pub async fn spawn_metrics_server(
 
 async fn scrape(State(state): State<ServerState>) -> Response {
     let mut buf: Vec<u8> = Vec::with_capacity(4096);
-    if let Err(e) = state.exporter.export(&mut buf) {
+    let encoder = TextEncoder::new();
+    let metric_families = state.registry.gather();
+    if let Err(e) = encoder.encode(&metric_families, &mut buf) {
         tracing::warn!("metrics scrape failed: {e}");
         return (StatusCode::INTERNAL_SERVER_ERROR, "metrics scrape failed").into_response();
     }

--- a/crates/tileserver-rs/src/telemetry.rs
+++ b/crates/tileserver-rs/src/telemetry.rs
@@ -1,7 +1,8 @@
 //! OpenTelemetry tracing and metrics initialization.
 //!
 //! A single [`SdkMeterProvider`] feeds both the OTLP push reader (existing)
-//! and the Prometheus pull reader (via `opentelemetry-prometheus-text-exporter`).
+//! and the Prometheus pull reader (via the official `opentelemetry-prometheus`
+//! crate paired with `prometheus::Registry`).
 //! See `docs/superpowers/specs/2026-05-04-prometheus-metrics-design.md` §3.
 
 use std::time::Duration;
@@ -9,10 +10,10 @@ use std::time::Duration;
 use opentelemetry::KeyValue;
 use opentelemetry::trace::TracerProvider;
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_prometheus_text_exporter::PrometheusExporter;
 use opentelemetry_sdk::Resource;
 use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
 use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+use prometheus::Registry;
 use tracing::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{Layer, registry::LookupSpan};
@@ -34,7 +35,7 @@ where
     S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
 {
     pub tracing_layer: Option<Box<dyn Layer<S> + Send + Sync>>,
-    pub prometheus_exporter: Option<PrometheusExporter>,
+    pub prometheus_registry: Option<Registry>,
 }
 
 /// Initialize OpenTelemetry tracing and metrics from the [`TelemetryConfig`].
@@ -62,11 +63,11 @@ where
         None
     };
 
-    let prometheus_exporter = init_metrics_provider(config, resource);
+    let prometheus_registry = init_metrics_provider(config, resource);
 
     TelemetryOutput {
         tracing_layer,
-        prometheus_exporter,
+        prometheus_registry,
     }
 }
 
@@ -102,10 +103,7 @@ where
     Some(Box::new(OpenTelemetryLayer::new(tracer)))
 }
 
-fn init_metrics_provider(
-    config: &TelemetryConfig,
-    resource: Resource,
-) -> Option<PrometheusExporter> {
+fn init_metrics_provider(config: &TelemetryConfig, resource: Resource) -> Option<Registry> {
     let prometheus_wanted = config.prometheus_bind.is_some();
     let otlp_wanted = config.metrics_enabled && config.enabled;
 
@@ -135,15 +133,26 @@ fn init_metrics_provider(
         }
     }
 
-    let prom_exporter = if prometheus_wanted {
-        let exp = PrometheusExporter::new();
-        builder = builder.with_reader(exp.clone());
-        Some(exp)
+    let prom_registry = if prometheus_wanted {
+        let registry = Registry::new();
+        match opentelemetry_prometheus::exporter()
+            .with_registry(registry.clone())
+            .build()
+        {
+            Ok(exporter) => {
+                builder = builder.with_reader(exporter);
+                Some(registry)
+            }
+            Err(e) => {
+                tracing::warn!("Failed to build Prometheus exporter: {e}. Prometheus disabled.");
+                None
+            }
+        }
     } else {
         None
     };
 
-    if !otlp_attached && prom_exporter.is_none() {
+    if !otlp_attached && prom_registry.is_none() {
         return None;
     }
 
@@ -153,12 +162,12 @@ fn init_metrics_provider(
 
     tracing::info!(
         otlp_metrics = otlp_attached,
-        prometheus_metrics = prom_exporter.is_some(),
+        prometheus_metrics = prom_registry.is_some(),
         service_name = %config.service_name,
         "OpenTelemetry metrics initialized"
     );
 
-    prom_exporter
+    prom_registry
 }
 
 pub fn shutdown_telemetry() {

--- a/crates/tileserver-rs/tests/metrics_endpoint.rs
+++ b/crates/tileserver-rs/tests/metrics_endpoint.rs
@@ -13,8 +13,8 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use opentelemetry_prometheus_text_exporter::PrometheusExporter;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
+use prometheus::Registry;
 
 use tileserver_rs::metrics::{
     self, Cardinality, RenderEvent, RenderOutcome, TileEvent, TileOutcome,
@@ -24,19 +24,21 @@ use tileserver_rs::sources::TileFormat;
 struct TestHarness {
     addr: SocketAddr,
     _provider: SdkMeterProvider,
-    _exporter: PrometheusExporter,
+    _registry: Registry,
 }
 
 async fn install_harness() -> TestHarness {
-    let exporter = PrometheusExporter::new();
-    let provider = SdkMeterProvider::builder()
-        .with_reader(exporter.clone())
-        .build();
+    let registry = Registry::new();
+    let exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .build()
+        .expect("prometheus exporter");
+    let provider = SdkMeterProvider::builder().with_reader(exporter).build();
     opentelemetry::global::set_meter_provider(provider.clone());
     metrics::init(Cardinality::Strict);
 
     let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let handle = metrics::spawn_metrics_server(bind, "/metrics".to_string(), exporter.clone())
+    let handle = metrics::spawn_metrics_server(bind, "/metrics".to_string(), registry.clone())
         .await
         .expect("metrics server bind failed");
     tokio::time::sleep(Duration::from_millis(20)).await;
@@ -44,7 +46,7 @@ async fn install_harness() -> TestHarness {
     TestHarness {
         addr: handle.addr,
         _provider: provider,
-        _exporter: exporter,
+        _registry: registry,
     }
 }
 


### PR DESCRIPTION
## Summary

Main is broken since PR #917 (Dependabot's OTel 0.31→0.32 group bump) merged on 2026-05-13 — CI Rust Clippy has been red on every push since. PR #917 bumped 4 of the 6 OTel crates, but `opentelemetry-prometheus-text-exporter = "=0.2.1"` and `tracing-opentelemetry = "0.32.1"` both still pinned `opentelemetry ^0.31`, producing a trait-bound diamond.

Two upstream unblocks landed in the last week that let us complete the 0.32 family instead of reverting:

- **Official `opentelemetry-prometheus 0.32.0`** — un-deprecated and re-released by open-telemetry/opentelemetry-rust on 2026-05-08. Replaces the unmaintained community fork `opentelemetry-prometheus-text-exporter`.
- **tokio-rs/tracing-opentelemetry#258** — "chore: Upgrade to OpenTelemetry 0.32" merged on 2026-05-15 at commit `44521fa`. No crates.io release yet, so this PR pulls the merged code via `[patch.crates-io]` with a removal-condition comment.

## Changes

- `Cargo.toml`: drop `opentelemetry-prometheus-text-exporter`; add `opentelemetry-prometheus = "0.32.0"` + `prometheus = "0.14.0"`; add `[patch.crates-io] tracing-opentelemetry = { git = "...", rev = "44521fa" }` with removal-condition comment.
- `src/telemetry.rs`: `prometheus_exporter: Option<PrometheusExporter>` → `prometheus_registry: Option<prometheus::Registry>`. New init uses `Registry::new()` + `opentelemetry_prometheus::exporter().with_registry(reg.clone()).build()?` + `provider.with_reader(exporter)`.
- `src/metrics/server.rs`: `ServerState` carries `Arc<Registry>`, scrape uses `TextEncoder::new().encode(&registry.gather(), &mut buf)`.
- `src/metrics/mod.rs`: re-export `prometheus::Registry` (not `PrometheusExporter`).
- `src/main.rs`: pass `telemetry_output.prometheus_registry` into `spawn_metrics_server`.
- `tests/metrics_endpoint.rs`: test harness builds Registry → attaches exporter as reader → hands Registry to server.

## Verification

Full Rule 604 gate locally:

```
cargo fmt --all -- --check                                 # exit 0
cargo clippy --all-targets --all-features -- -D warnings   # exit 0
cargo test --all --all-features                            # 33 passed, 0 failed
```

This should bring CI Rust Clippy back to green on `main`.

## Removal condition

Drop the `[patch.crates-io] tracing-opentelemetry` block the moment `tracing-opentelemetry > 0.32.1` publishes on crates.io with `opentelemetry ^0.32` deps. Verify via `curl -s https://crates.io/api/v1/crates/tracing-opentelemetry/<v>/dependencies`.

## Notes

- `.github/dependabot.yml`'s existing `opentelemetry` group already covers `opentelemetry-prometheus` via the `opentelemetry-*` pattern, so future group bumps stay atomic.
- The deeper hole — `main` has no required status checks, so PR #917 merged despite Clippy red — needs a follow-up change to branch protection. Filed as a tracked concern; this PR fixes the immediate code-side break only.