### PR TITLE
chore(deps): sweep + migrate lucide-vue-next to @lucide/vue

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -76,7 +76,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/release-linux-binaries.yml
+++ b/.github/workflows/release-linux-binaries.yml
@@ -55,7 +55,6 @@ jobs:
         if: matrix.variant == 'full'
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js

--- a/.github/workflows/release-macos-binaries.yml
+++ b/.github/workflows/release-macos-binaries.yml
@@ -40,7 +40,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.1.1
           run_install: false
 
       - name: Setup Node.js

--- a/apps/client/app/components/data/LayersPanel.vue
+++ b/apps/client/app/components/data/LayersPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Eye, EyeOff } from 'lucide-vue-next';
+  import { Eye, EyeOff } from '@lucide/vue';
   import { motion, AnimatePresence } from 'motion-v';
   import type { LayerColor } from '~/types/data';
 

--- a/apps/client/app/components/home/ApiLink.vue
+++ b/apps/client/app/components/home/ApiLink.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ChevronRight, ExternalLink } from 'lucide-vue-next';
+  import { ChevronRight, ExternalLink } from '@lucide/vue';
   import { motion } from 'motion-v';
 </script>
 

--- a/apps/client/app/components/home/DataCard.vue
+++ b/apps/client/app/components/home/DataCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Layers } from 'lucide-vue-next';
+  import { Layers } from '@lucide/vue';
   import { motion } from 'motion-v';
   import type { Data } from '~/types/data';
 

--- a/apps/client/app/components/home/DataCardServices.vue
+++ b/apps/client/app/components/home/DataCardServices.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Check, Copy } from 'lucide-vue-next';
+  import { Check, Copy } from '@lucide/vue';
   import type { Data } from '~/types/data';
 
   const props = defineProps<{

--- a/apps/client/app/components/home/DataList.vue
+++ b/apps/client/app/components/home/DataList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ChevronRight, Database } from 'lucide-vue-next';
+  import { ChevronRight, Database } from '@lucide/vue';
   import { motion } from 'motion-v';
   import type { Data } from '~/types/data';
 

--- a/apps/client/app/components/home/DataListContent.vue
+++ b/apps/client/app/components/home/DataListContent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Database } from 'lucide-vue-next';
+  import { Database } from '@lucide/vue';
   import type { Data } from '~/types/data';
 
   defineProps<{

--- a/apps/client/app/components/home/DataSection.vue
+++ b/apps/client/app/components/home/DataSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ChevronRight, Database } from 'lucide-vue-next';
+  import { ChevronRight, Database } from '@lucide/vue';
   import type { Data } from '~/types/data';
 
   defineProps<{

--- a/apps/client/app/components/home/Header.vue
+++ b/apps/client/app/components/home/Header.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Globe, Moon, Sun } from 'lucide-vue-next';
+  import { Globe, Moon, Sun } from '@lucide/vue';
 
   defineProps<{
     isDark: boolean;

--- a/apps/client/app/components/home/Hero.vue
+++ b/apps/client/app/components/home/Hero.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Globe, Moon, Sun } from 'lucide-vue-next';
+  import { Globe, Moon, Sun } from '@lucide/vue';
   import { motion } from 'motion-v';
 
   defineProps<{

--- a/apps/client/app/components/home/SearchBar.vue
+++ b/apps/client/app/components/home/SearchBar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Search } from 'lucide-vue-next';
+  import { Search } from '@lucide/vue';
   import { motion } from 'motion-v';
 
   defineProps<{

--- a/apps/client/app/components/home/StyleCard.vue
+++ b/apps/client/app/components/home/StyleCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Map } from 'lucide-vue-next';
+  import { Map } from '@lucide/vue';
   import { motion } from 'motion-v';
   import type { Style } from '~/types/style';
 

--- a/apps/client/app/components/home/StyleCardServices.vue
+++ b/apps/client/app/components/home/StyleCardServices.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Check, Copy, Grid3x3, Image } from 'lucide-vue-next';
+  import { Check, Copy, Grid3x3, Image } from '@lucide/vue';
   import type { Style } from '~/types/style';
 
   const props = defineProps<{

--- a/apps/client/app/components/home/StyleList.vue
+++ b/apps/client/app/components/home/StyleList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ChevronRight, Palette } from 'lucide-vue-next';
+  import { ChevronRight, Palette } from '@lucide/vue';
   import { motion } from 'motion-v';
   import type { Style } from '~/types/style';
 

--- a/apps/client/app/components/home/StyleListContent.vue
+++ b/apps/client/app/components/home/StyleListContent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Palette } from 'lucide-vue-next';
+  import { Palette } from '@lucide/vue';
   import type { Style } from '~/types/style';
 
   defineProps<{

--- a/apps/client/app/components/home/StylesSection.vue
+++ b/apps/client/app/components/home/StylesSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ChevronRight, Palette } from 'lucide-vue-next';
+  import { ChevronRight, Palette } from '@lucide/vue';
   import type { Style } from '~/types/style';
 
   defineProps<{

--- a/apps/client/app/components/llm/Input.vue
+++ b/apps/client/app/components/llm/Input.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Send, Square } from 'lucide-vue-next';
+  import { Send, Square } from '@lucide/vue';
 
   const props = defineProps<{
     modelValue: string;

--- a/apps/client/app/components/llm/LoadingState.vue
+++ b/apps/client/app/components/llm/LoadingState.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { BrainCircuit } from 'lucide-vue-next';
+  import { BrainCircuit } from '@lucide/vue';
 
   defineProps<{
     stageText: string;

--- a/apps/client/app/components/llm/Message.vue
+++ b/apps/client/app/components/llm/Message.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Bot, User } from 'lucide-vue-next';
+  import { Bot, User } from '@lucide/vue';
   import type { ReadonlyUIMessage } from '~/types/llm';
   import {
     getTextContent,

--- a/apps/client/app/components/llm/MessageList.vue
+++ b/apps/client/app/components/llm/MessageList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Bot } from 'lucide-vue-next';
+  import { Bot } from '@lucide/vue';
   import type { ReadonlyUIMessage } from '~/types/llm';
 
   defineProps<{

--- a/apps/client/app/components/llm/PaletteExpandedHeader.vue
+++ b/apps/client/app/components/llm/PaletteExpandedHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { GripHorizontal, Bot, Minimize2, X } from 'lucide-vue-next';
+  import { GripHorizontal, Bot, Minimize2, X } from '@lucide/vue';
   import type { LlmEngineStatus, LlmModelConfig } from '~/types/llm';
 
   defineProps<{

--- a/apps/client/app/components/llm/PaletteMinimized.vue
+++ b/apps/client/app/components/llm/PaletteMinimized.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { GripHorizontal, Bot, Maximize2, X } from 'lucide-vue-next';
+  import { GripHorizontal, Bot, Maximize2, X } from '@lucide/vue';
   import type { LlmEngineStatus } from '~/types/llm';
 
   defineProps<{

--- a/apps/client/app/components/llm/PanelHeader.vue
+++ b/apps/client/app/components/llm/PanelHeader.vue
@@ -4,7 +4,7 @@
     SheetTitle as UiSheetTitle,
     SheetDescription as UiSheetDescription,
   } from '~/components/ui/sheet';
-  import { Bot } from 'lucide-vue-next';
+  import { Bot } from '@lucide/vue';
   import type { LlmEngineStatus, LlmModelConfig } from '~/types/llm';
 
   defineProps<{

--- a/apps/client/app/components/map/DropOverlay.vue
+++ b/apps/client/app/components/map/DropOverlay.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Upload, Loader2 } from 'lucide-vue-next';
+  import { Upload, Loader2 } from '@lucide/vue';
   import type {
     FileDropError,
     FileDropSuccess,

--- a/apps/client/app/components/map/DropOverlayToasts.vue
+++ b/apps/client/app/components/map/DropOverlayToasts.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { AlertCircle, CheckCircle2 } from 'lucide-vue-next';
+  import { AlertCircle, CheckCircle2 } from '@lucide/vue';
   import type { FileDropError, FileDropSuccess } from '~/types/file-upload';
 
   defineProps<{

--- a/apps/client/app/components/map/OverlayPanel.vue
+++ b/apps/client/app/components/map/OverlayPanel.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Layers } from 'lucide-vue-next';
+  import { Layers } from '@lucide/vue';
   import type { OverlayLayer } from '~/types/file-upload';
 
   defineProps<{

--- a/apps/client/app/components/map/OverlayPanelList.vue
+++ b/apps/client/app/components/map/OverlayPanelList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Eye, EyeOff, Trash2, X } from 'lucide-vue-next';
+  import { Eye, EyeOff, Trash2, X } from '@lucide/vue';
   import type { OverlayLayer } from '~/types/file-upload';
 
   defineProps<{

--- a/apps/client/app/components/styles/ViewerToolbar.vue
+++ b/apps/client/app/components/styles/ViewerToolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ArrowLeft, Palette, Sparkles } from 'lucide-vue-next';
+  import { ArrowLeft, Palette, Sparkles } from '@lucide/vue';
 
   defineProps<{
     styleId: string;

--- a/apps/client/app/components/ui/select/SelectItem.vue
+++ b/apps/client/app/components/ui/select/SelectItem.vue
@@ -2,7 +2,7 @@
   import type { SelectItemProps } from 'reka-ui';
   import type { HTMLAttributes } from 'vue';
   import { reactiveOmit } from '@vueuse/core';
-  import { Check } from 'lucide-vue-next';
+  import { Check } from '@lucide/vue';
   import {
     SelectItem,
     SelectItemIndicator,

--- a/apps/client/app/components/ui/select/SelectScrollDownButton.vue
+++ b/apps/client/app/components/ui/select/SelectScrollDownButton.vue
@@ -2,7 +2,7 @@
   import type { SelectScrollDownButtonProps } from 'reka-ui';
   import type { HTMLAttributes } from 'vue';
   import { reactiveOmit } from '@vueuse/core';
-  import { ChevronDown } from 'lucide-vue-next';
+  import { ChevronDown } from '@lucide/vue';
   import { SelectScrollDownButton, useForwardProps } from 'reka-ui';
   import { cn } from '@/lib/utils';
 

--- a/apps/client/app/components/ui/select/SelectScrollUpButton.vue
+++ b/apps/client/app/components/ui/select/SelectScrollUpButton.vue
@@ -2,7 +2,7 @@
   import type { SelectScrollUpButtonProps } from 'reka-ui';
   import type { HTMLAttributes } from 'vue';
   import { reactiveOmit } from '@vueuse/core';
-  import { ChevronUp } from 'lucide-vue-next';
+  import { ChevronUp } from '@lucide/vue';
   import { SelectScrollUpButton, useForwardProps } from 'reka-ui';
   import { cn } from '@/lib/utils';
 

--- a/apps/client/app/components/ui/select/SelectTrigger.vue
+++ b/apps/client/app/components/ui/select/SelectTrigger.vue
@@ -2,7 +2,7 @@
   import type { SelectTriggerProps } from 'reka-ui';
   import type { HTMLAttributes } from 'vue';
   import { reactiveOmit } from '@vueuse/core';
-  import { ChevronDown } from 'lucide-vue-next';
+  import { ChevronDown } from '@lucide/vue';
   import { SelectIcon, SelectTrigger, useForwardProps } from 'reka-ui';
   import { cn } from '@/lib/utils';
 

--- a/apps/client/app/components/ui/sheet/SheetContent.vue
+++ b/apps/client/app/components/ui/sheet/SheetContent.vue
@@ -3,7 +3,7 @@
   import type { HTMLAttributes } from 'vue';
   import type { SheetVariants } from '.';
   import { reactiveOmit } from '@vueuse/core';
-  import { X } from 'lucide-vue-next';
+  import { X } from '@lucide/vue';
   import {
     DialogClose,
     DialogContent,

--- a/apps/client/app/composables/use-llm-panel.ts
+++ b/apps/client/app/composables/use-llm-panel.ts
@@ -7,7 +7,7 @@
  * @see https://tanstack.com/ai/latest
  */
 
-import { Map, Layers, Search, Globe } from 'lucide-vue-next';
+import { Map, Layers, Search, Globe } from '@lucide/vue';
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import type { OverlayLayer } from '~/types/file-upload';
 import type { MessagePart } from '@tanstack/ai';

--- a/apps/client/app/pages/data/[data].vue
+++ b/apps/client/app/pages/data/[data].vue
@@ -5,7 +5,7 @@
     Layers,
     PanelRightClose,
     PanelRightOpen,
-  } from 'lucide-vue-next';
+  } from '@lucide/vue';
 
   const route = useRoute('data-data');
   const dataId = computed(() => String(route.params.data));

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -44,7 +44,7 @@
     "class-variance-authority": "catalog:default",
     "clsx": "catalog:default",
     "destr": "catalog:client",
-    "lucide-vue-next": "catalog:default",
+    "@lucide/vue": "catalog:default",
     "maplibre-gl": "catalog:default",
     "maplibre-gl-inspect": "catalog:client",
     "motion-v": "catalog:default",

--- a/apps/docs/app/components/content/Alert.vue
+++ b/apps/docs/app/components/content/Alert.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Info, AlertTriangle, Lightbulb, CheckCircle } from 'lucide-vue-next';
+  import { Info, AlertTriangle, Lightbulb, CheckCircle } from '@lucide/vue';
   import { computed } from 'vue';
 
   const props = withDefaults(

--- a/apps/docs/app/components/content/Callout.vue
+++ b/apps/docs/app/components/content/Callout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Info, AlertTriangle, Lightbulb } from 'lucide-vue-next';
+  import { Info, AlertTriangle, Lightbulb } from '@lucide/vue';
   import { computed } from 'vue';
 
   const props = withDefaults(

--- a/apps/docs/app/components/content/Card.vue
+++ b/apps/docs/app/components/content/Card.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ArrowRight } from 'lucide-vue-next';
+  import { ArrowRight } from '@lucide/vue';
 
   defineProps<{
     title?: string;

--- a/apps/docs/app/components/content/ProsePre.vue
+++ b/apps/docs/app/components/content/ProsePre.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Check, Copy } from 'lucide-vue-next';
+  import { Check, Copy } from '@lucide/vue';
 
   defineProps<{
     code?: string;

--- a/apps/docs/app/components/docs/PageFooter.vue
+++ b/apps/docs/app/components/docs/PageFooter.vue
@@ -5,7 +5,7 @@
     ArrowLeft,
     ArrowRight,
     FileText,
-  } from 'lucide-vue-next';
+  } from '@lucide/vue';
   import type { NavItem } from '~/types';
 
   defineProps<{

--- a/apps/docs/app/layouts/default.vue
+++ b/apps/docs/app/layouts/default.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Github, Globe, Menu, Moon, Sun, X } from 'lucide-vue-next';
+  import { Globe, Menu, Moon, Sun, X } from '@lucide/vue';
 
   const {
     sections,
@@ -123,7 +123,10 @@
           external
           class="hidden items-center justify-center border-l border-border text-muted-foreground transition-colors hover:text-foreground lg:flex"
         >
-          <Github class="size-5" />
+          <Icon
+            name="simple-icons:github"
+            class="size-5"
+          />
         </NuxtLink>
       </div>
     </nav>

--- a/apps/docs/app/pages/[...slug].vue
+++ b/apps/docs/app/pages/[...slug].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ArrowLeft } from 'lucide-vue-next';
+  import { ArrowLeft } from '@lucide/vue';
   import { useDocsNavigation } from '~/composables/use-docs-navigation';
 
   const route = useRoute();

--- a/apps/docs/app/pages/index.vue
+++ b/apps/docs/app/pages/index.vue
@@ -7,7 +7,6 @@
     Database,
     Image,
     RefreshCw,
-    Github,
     ExternalLink,
     Map,
     Camera,
@@ -17,7 +16,7 @@
     RotateCw,
     Server,
     FileSpreadsheet,
-  } from 'lucide-vue-next';
+  } from '@lucide/vue';
 
   definePageMeta({ layout: false });
 
@@ -227,7 +226,10 @@
           external
           class="hidden items-center justify-center border-l border-border text-muted-foreground transition-colors hover:text-foreground lg:flex"
         >
-          <Github class="size-5" />
+          <Icon
+            name="simple-icons:github"
+            class="size-5"
+          />
         </NuxtLink>
       </div>
     </header>
@@ -302,7 +304,10 @@
               external
               class="inline-flex items-center gap-2 border border-border px-5 py-2.5 font-mono text-xs uppercase tracking-wider text-muted-foreground transition-colors hover:border-foreground/20 hover:text-foreground"
             >
-              <Github class="size-3.5" />
+              <Icon
+                name="simple-icons:github"
+                class="size-3.5"
+              />
               View Source
             </NuxtLink>
             <NuxtLink

--- a/apps/docs/nuxt.config.ts
+++ b/apps/docs/nuxt.config.ts
@@ -4,6 +4,7 @@ export default defineNuxtConfig({
   modules: [
     '@nuxt/content',
     '@nuxt/fonts',
+    '@nuxt/icon',
     '@nuxt/eslint',
     '@nuxtjs/color-mode',
     '@vueuse/nuxt',

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -18,13 +18,14 @@
   "dependencies": {
     "@nuxt/content": "catalog:docs",
     "@nuxt/fonts": "catalog:default",
+    "@nuxt/icon": "catalog:default",
     "@nuxtjs/color-mode": "catalog:default",
     "@vueuse/core": "catalog:default",
     "@vueuse/nuxt": "catalog:default",
     "better-sqlite3": "catalog:docs",
     "class-variance-authority": "catalog:default",
     "clsx": "catalog:default",
-    "lucide-vue-next": "catalog:default",
+    "@lucide/vue": "catalog:default",
     "motion-v": "catalog:default",
     "nuxt": "catalog:default",
     "ogl": "catalog:marketing",
@@ -36,6 +37,7 @@
     "vue": "catalog:default"
   },
   "devDependencies": {
+    "@iconify-json/simple-icons": "catalog:default",
     "@nuxt/eslint": "catalog:default",
     "@nuxt/eslint-config": "catalog:default",
     "@nuxtjs/plausible": "catalog:marketing",

--- a/apps/marketing/app/components/marketing/AiSection.vue
+++ b/apps/marketing/app/components/marketing/AiSection.vue
@@ -4,7 +4,7 @@
     ExternalLink,
     BotMessageSquare,
     User,
-  } from 'lucide-vue-next';
+  } from '@lucide/vue';
 
   const { aiBenefits, aiChatExample } = useMarketingPage();
 </script>

--- a/apps/marketing/app/components/marketing/ApiSection.vue
+++ b/apps/marketing/app/components/marketing/ApiSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { FileJson2, ExternalLink } from 'lucide-vue-next';
+  import { FileJson2, ExternalLink } from '@lucide/vue';
 
   const { apiEndpoints } = useMarketingPage();
 </script>

--- a/apps/marketing/app/components/marketing/CtaSection.vue
+++ b/apps/marketing/app/components/marketing/CtaSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Github, ArrowRight } from 'lucide-vue-next';
+  import { ArrowRight } from '@lucide/vue';
 </script>
 
 <template>
@@ -59,7 +59,7 @@
             hover:border-foreground/20 hover:text-foreground
           "
         >
-          <Github class="size-3.5" />
+          <Icon name="simple-icons:github" class="size-3.5" />
           Star on GitHub
         </NuxtLink>
       </div>

--- a/apps/marketing/app/components/marketing/Footer.vue
+++ b/apps/marketing/app/components/marketing/Footer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Globe } from 'lucide-vue-next';
+  import { Globe } from '@lucide/vue';
 </script>
 
 <template>

--- a/apps/marketing/app/components/marketing/HeroSection.vue
+++ b/apps/marketing/app/components/marketing/HeroSection.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
   import {
-    Github,
     Sparkles,
     ArrowRight,
     ExternalLink,
@@ -8,7 +7,7 @@
     Copy,
     Check,
     BotMessageSquare,
-  } from 'lucide-vue-next';
+  } from '@lucide/vue';
 
   const { copied, installCommand, copyToClipboard } = useMarketingPage();
 </script>
@@ -141,7 +140,7 @@
               sm:w-auto
             "
           >
-            <Github class="size-4" />
+            <Icon name="simple-icons:github" class="size-4" />
             View on GitHub
           </Button>
           <GlareHover

--- a/apps/marketing/app/components/marketing/MobileNav.vue
+++ b/apps/marketing/app/components/marketing/MobileNav.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Github, Globe, Menu, Moon, Sun, X } from 'lucide-vue-next';
+  import { Globe, Menu, Moon, Sun, X } from '@lucide/vue';
 
   const { isDark, toggle } = useThemeToggle();
 
@@ -22,7 +22,7 @@
     {
       label: 'GitHub',
       href: 'https://github.com/vinayakkulkarni/tileserver-rs',
-      icon: Github,
+      iconName: 'simple-icons:github',
       external: true,
     },
   ];
@@ -100,7 +100,7 @@
                   "
                   @click="handleClose"
                 >
-                  <component :is="link.icon" v-if="link.icon" class="size-4" />
+                  <Icon v-if="link.iconName" :name="link.iconName" class="size-4" />
                   {{ link.label }}
                 </a>
               </li>

--- a/apps/marketing/app/components/marketing/Navigation.vue
+++ b/apps/marketing/app/components/marketing/Navigation.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Github, Globe, Menu, Moon, Sun, X } from 'lucide-vue-next';
+  import { Globe, Menu, Moon, Sun, X } from '@lucide/vue';
 
   const { isDark, toggle } = useThemeToggle();
   const mobileOpen = ref(false);
@@ -107,7 +107,7 @@
           lg:flex
         "
       >
-        <Github class="size-5" />
+        <Icon name="simple-icons:github" class="size-5" />
       </NuxtLink>
     </div>
   </header>

--- a/apps/marketing/app/components/marketing/PerformanceSection.vue
+++ b/apps/marketing/app/components/marketing/PerformanceSection.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { ArrowRight } from 'lucide-vue-next';
+  import { ArrowRight } from '@lucide/vue';
 
   const { performanceStats } = useMarketingPage();
 </script>

--- a/apps/marketing/app/components/ui/navigation-menu/NavigationMenuTrigger.vue
+++ b/apps/marketing/app/components/ui/navigation-menu/NavigationMenuTrigger.vue
@@ -2,7 +2,7 @@
   import type { NavigationMenuTriggerProps } from 'reka-ui';
   import type { HTMLAttributes } from 'vue';
   import { reactiveOmit } from '@vueuse/core';
-  import { ChevronDown } from 'lucide-vue-next';
+  import { ChevronDown } from '@lucide/vue';
   import { NavigationMenuTrigger, useForwardProps } from 'reka-ui';
   import { cn } from '@/lib/utils';
   import { navigationMenuTriggerStyle } from '.';

--- a/apps/marketing/app/composables/use-marketing-page.ts
+++ b/apps/marketing/app/composables/use-marketing-page.ts
@@ -23,7 +23,7 @@ import {
   Timer,
   Satellite,
   FileCode2,
-} from 'lucide-vue-next';
+} from '@lucide/vue';
 import type {
   Feature,
   FeatureCategory,

--- a/apps/marketing/nuxt.config.ts
+++ b/apps/marketing/nuxt.config.ts
@@ -6,6 +6,7 @@ export default defineNuxtConfig({
     '@vueuse/nuxt',
     '@nuxt/eslint',
     '@nuxt/fonts',
+    '@nuxt/icon',
     '@nuxtjs/color-mode',
     'motion-v/nuxt',
     [

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -20,12 +20,13 @@
   },
   "dependencies": {
     "@nuxt/fonts": "catalog:default",
+    "@nuxt/icon": "catalog:default",
     "@nuxtjs/color-mode": "catalog:default",
     "@vueuse/core": "catalog:default",
     "@vueuse/nuxt": "catalog:default",
     "class-variance-authority": "catalog:default",
     "clsx": "catalog:default",
-    "lucide-vue-next": "catalog:default",
+    "@lucide/vue": "catalog:default",
     "motion-v": "catalog:default",
     "nuxt": "catalog:default",
     "ogl": "catalog:marketing",
@@ -37,6 +38,7 @@
     "vue": "catalog:default"
   },
   "devDependencies": {
+    "@iconify-json/simple-icons": "catalog:default",
     "@nuxt/eslint": "catalog:default",
     "@nuxt/eslint-config": "catalog:default",
     "@nuxtjs/plausible": "catalog:marketing",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "description": "Tileserver for serving vector maps from data source(s)",
-  "packageManager": "pnpm@11.1.1",
+  "packageManager": "pnpm@11.1.2",
   "scripts": {
     "dev:client": "pnpm --filter @tileserver-rs/client run dev",
     "dev:docs": "pnpm --filter @tileserver-rs/docs run dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ catalogs:
       specifier: ^9.3.2
       version: 9.3.2
     '@geoql/v-maplibre':
-      specifier: ^1.8.0
-      version: 1.8.0
+      specifier: ^1.8.1
+      version: 1.8.1
     '@luma.gl/engine':
       specifier: ~9.3.3
       version: 9.3.3
@@ -104,6 +104,12 @@ catalogs:
     '@commitlint/config-conventional':
       specifier: ^21.0.1
       version: 21.0.1
+    '@iconify-json/simple-icons':
+      specifier: ^1.2.82
+      version: 1.2.82
+    '@lucide/vue':
+      specifier: ^1.16.0
+      version: 1.16.0
     '@nuxt/eslint':
       specifier: ^1.15.2
       version: 1.15.2
@@ -113,6 +119,9 @@ catalogs:
     '@nuxt/fonts':
       specifier: ^0.14.0
       version: 0.14.0
+    '@nuxt/icon':
+      specifier: ^2.2.2
+      version: 2.2.2
     '@nuxtjs/color-mode':
       specifier: ^4.0.0
       version: 4.0.0
@@ -152,9 +161,6 @@ catalogs:
     lint-staged:
       specifier: ^17.0.4
       version: 17.0.4
-    lucide-vue-next:
-      specifier: ^1.0.0
-      version: 1.0.0
     maplibre-gl:
       specifier: ^5.24.0
       version: 5.24.0
@@ -215,8 +221,8 @@ catalogs:
       specifier: ^1.0.11
       version: 1.0.11
     wrangler:
-      specifier: ^4.91.0
-      version: 4.91.0
+      specifier: ^4.92.0
+      version: 4.92.0
 
 overrides:
   vite: ^8.0.13
@@ -275,7 +281,10 @@ importers:
         version: 9.3.2(@deck.gl/core@9.3.2)(@loaders.gl/core@4.4.1)(@luma.gl/core@9.3.3)(@luma.gl/engine@9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3)))(@luma.gl/gltf@9.3.3(@luma.gl/core@9.3.3)(@luma.gl/engine@9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3)))(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3)))(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))
       '@geoql/v-maplibre':
         specifier: catalog:client
-        version: 1.8.0(1d7bae43a63b38c52016640fc86ff2f7)
+        version: 1.8.1(1d7bae43a63b38c52016640fc86ff2f7)
+      '@lucide/vue':
+        specifier: catalog:default
+        version: 1.16.0(vue@3.5.34(typescript@6.0.3))
       '@luma.gl/engine':
         specifier: catalog:client
         version: 9.3.3(@luma.gl/core@9.3.3)(@luma.gl/shadertools@9.3.3(@luma.gl/core@9.3.3))
@@ -324,9 +333,6 @@ importers:
       destr:
         specifier: catalog:client
         version: 2.0.5
-      lucide-vue-next:
-        specifier: catalog:default
-        version: 1.0.0(vue@3.5.34(typescript@6.0.3))
       maplibre-gl:
         specifier: catalog:default
         version: 5.24.0
@@ -424,12 +430,18 @@ importers:
 
   apps/docs:
     dependencies:
+      '@lucide/vue':
+        specifier: catalog:default
+        version: 1.16.0(vue@3.5.34(typescript@6.0.3))
       '@nuxt/content':
         specifier: catalog:docs
         version: 3.13.0(@valibot/to-json-schema@1.6.0(valibot@1.3.1(typescript@6.0.3)))(better-sqlite3@12.10.0)(magicast@0.5.2)(valibot@1.3.1(typescript@6.0.3))
       '@nuxt/fonts':
         specifier: catalog:default
         version: 0.14.0(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.4))
+      '@nuxt/icon':
+        specifier: catalog:default
+        version: 2.2.2(magicast@0.5.2)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))
       '@nuxtjs/color-mode':
         specifier: catalog:default
         version: 4.0.0(magicast@0.5.2)
@@ -448,9 +460,6 @@ importers:
       clsx:
         specifier: catalog:default
         version: 2.1.1
-      lucide-vue-next:
-        specifier: catalog:default
-        version: 1.0.0(vue@3.5.34(typescript@6.0.3))
       motion-v:
         specifier: catalog:default
         version: 2.2.1(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
@@ -479,6 +488,9 @@ importers:
         specifier: catalog:default
         version: 3.5.34(typescript@6.0.3)
     devDependencies:
+      '@iconify-json/simple-icons':
+        specifier: catalog:default
+        version: 1.2.82
       '@nuxt/eslint':
         specifier: catalog:default
         version: 1.15.2(@typescript-eslint/utils@8.59.0(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3))(@vue/compiler-sfc@3.5.34)(eslint@10.4.0(jiti@2.6.1))(magicast@0.5.2)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.4))
@@ -520,13 +532,19 @@ importers:
         version: 3.2.9(typescript@6.0.3)
       wrangler:
         specifier: catalog:marketing
-        version: 4.91.0
+        version: 4.92.0
 
   apps/marketing:
     dependencies:
+      '@lucide/vue':
+        specifier: catalog:default
+        version: 1.16.0(vue@3.5.34(typescript@6.0.3))
       '@nuxt/fonts':
         specifier: catalog:default
         version: 0.14.0(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.2)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.4))
+      '@nuxt/icon':
+        specifier: catalog:default
+        version: 2.2.2(magicast@0.5.2)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))
       '@nuxtjs/color-mode':
         specifier: catalog:default
         version: 4.0.0(magicast@0.5.2)
@@ -542,9 +560,6 @@ importers:
       clsx:
         specifier: catalog:default
         version: 2.1.1
-      lucide-vue-next:
-        specifier: catalog:default
-        version: 1.0.0(vue@3.5.34(typescript@6.0.3))
       motion-v:
         specifier: catalog:default
         version: 2.2.1(@vueuse/core@14.3.0(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))
@@ -573,6 +588,9 @@ importers:
         specifier: catalog:default
         version: 3.5.34(typescript@6.0.3)
     devDependencies:
+      '@iconify-json/simple-icons':
+        specifier: catalog:default
+        version: 1.2.82
       '@nuxt/eslint':
         specifier: catalog:default
         version: 1.15.2(@typescript-eslint/utils@8.59.0(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3))(@vue/compiler-sfc@3.5.34)(eslint@10.4.0(jiti@2.6.1))(magicast@0.5.2)(typescript@6.0.3)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.4))
@@ -620,7 +638,7 @@ importers:
         version: 3.2.9(typescript@6.0.3)
       wrangler:
         specifier: catalog:marketing
-        version: 4.91.0
+        version: 4.92.0
 
   benchmarks:
     dependencies:
@@ -813,32 +831,32 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260511.1':
-    resolution: {integrity: sha512-xQXYe0ILEGKyFFgZ9SlxZV2RkWXxp9mIA5mlqfdEmmSInMHlWRO4H/l6oCXZnQXNH6o3bvmGuNzl6Mac5+Omgg==}
+  '@cloudflare/workerd-darwin-64@1.20260515.1':
+    resolution: {integrity: sha512-Wtw44el2pNbzixvTkWdfeBDTrQwQbJRz7/JUvPKV27I0pQWXbhNJPpM8cstq/pbrU5AGcA/HjFH6yPMRTIRKig==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260511.1':
-    resolution: {integrity: sha512-QOaY4/BlQfDEZgTlrwCPreRIyenYmFWREVP79SSz6K6QBf7bf8ubaATN11NZbouEg19iTMtl5L7FLYdcz1tz7g==}
+  '@cloudflare/workerd-darwin-arm64@1.20260515.1':
+    resolution: {integrity: sha512-X8EqkZej6FfmhF9AVAQ3FhyQRr9acS4RcDunMU2YiuxKHF1IU8zzH3vY30/POaG+rUu9vGDp/VgUl49VPenHJQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-linux-64@1.20260511.1':
-    resolution: {integrity: sha512-5ZV6SHjU7WSsb9pRPSssckLJgDI5xemv7XpKWM023hMv9Q3jb4ZpkZEeIOGt2Q46E4/fcxfnXeQbL1nukDIpLg==}
+  '@cloudflare/workerd-linux-64@1.20260515.1':
+    resolution: {integrity: sha512-CDC89QxQ7Y7t7RG1Jd9vj/qolE1sQRkI2OSEuV5BMJi0vW/gV4OVG6xjpdK3b1OYnSWDzF7NpvlR5Yg86q7k4g==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260511.1':
-    resolution: {integrity: sha512-BG8rVZZCqTvnwOMPuh+cjt/VbZ3QchxXaBOlfromw+zLQoblSHJorMPZ/JY4/phV7RoP8gB2C84bBPcahvZUnQ==}
+  '@cloudflare/workerd-linux-arm64@1.20260515.1':
+    resolution: {integrity: sha512-WxbW/PToYES4fvHXzsr/5qOiETQs/Z9iZ0mjSZAiEwq5cMLZemzGN0COx+uFb9OvQwzh6Pg159qPFnw3+i9FuA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-windows-64@1.20260511.1':
-    resolution: {integrity: sha512-tGEyfKFArBL0NdqmABqzsIK1vmHdshkdFzCAUo1j6LqYsEpgJWCzvqwX9IpNHEc/AAm0UtPOLhLKhz1DA7HQLA==}
+  '@cloudflare/workerd-windows-64@1.20260515.1':
+    resolution: {integrity: sha512-WmV/iv+MHjYsvkcMVzpM2B5/mf06UUkdpVhZrtMfV9graWjBGPYFvE/eab8748RPVGKh1Xe1vXofLzDSwc08lA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -1579,8 +1597,8 @@ packages:
   '@floating-ui/vue@1.1.11':
     resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
 
-  '@geoql/v-maplibre@1.8.0':
-    resolution: {integrity: sha512-fGSIpTM6qP0eo8NZZ5UNweYg4PbR96MISdZxibXPY8m4MLsC7hIJbCwSZMJO4a0yAaMyAZfUoc3tJfOrEcvauw==}
+  '@geoql/v-maplibre@1.8.1':
+    resolution: {integrity: sha512-uMmt3r/WlcqOHmn0QyyQF66JDk0TWaMD6JdqSdKblfQlw5ayYMD6BVOkdbQ/Ajw6SVATaXRwVL5YHSPDA9qMLg==}
     peerDependencies:
       '@deck.gl/aggregation-layers': ^9.3.0
       '@deck.gl/core': ^9.3.0
@@ -1652,6 +1670,23 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify-json/simple-icons@1.2.82':
+    resolution: {integrity: sha512-4p978qHx8eD/QBOhgBzp/p7uS3OO2KCnVpFPJTUvuhuDXv1Hr4RcxcZ5MWc6ptkf/3Dlb1xb23068OtPyx10mA==}
+
+  '@iconify/collections@1.0.683':
+    resolution: {integrity: sha512-ZfrFEuExsdpcO2PCkbHBMja26eyPRZ+Bh7Af/lGAk5C8t740H9bYPyrJVQzQrxnPFcRwNq1Ehs+Q8aQJRYn/Iw==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
+  '@iconify/vue@5.0.1':
+    resolution: {integrity: sha512-aumwwooJlFJ5H5qYWB6ZTAyM0C8hpfcSVLB9/a3qnH1GGvIJ+FEbpEs4s/HfErYe/M5qZeLjwmESR5fFm3lXEw==}
+    peerDependencies:
+      vue: '>=3.0.0'
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -1950,6 +1985,11 @@ packages:
     peerDependencies:
       '@loaders.gl/core': ~4.4.0
 
+  '@lucide/vue@1.16.0':
+    resolution: {integrity: sha512-kiHx0fe49DMjQuvNaEOu9Jou6u9FwdqQ8xbZIKlD47sXrOI8g59kIeeQL42NBLI4AvO+UJsbaPX0hEK/4rHSBQ==}
+    peerDependencies:
+      vue: '>=3.0.1'
+
   '@luma.gl/core@9.3.3':
     resolution: {integrity: sha512-jCFm2htvrVpcXIy85TBTF1ROgMfknKnfw2OH+Vydr41hiCFd6nqr79gM3f2uhaNkal0BghFNqF3qDioKiUWtew==}
 
@@ -2164,6 +2204,9 @@ packages:
 
   '@nuxt/fonts@0.14.0':
     resolution: {integrity: sha512-4uXQl9fa5F4ibdgU8zomoOcyMdnwgdem+Pi8JEqeDYI5yPR32Kam6HnuRr47dTb97CstaepAvXPWQUUHMtjsFQ==}
+
+  '@nuxt/icon@2.2.2':
+    resolution: {integrity: sha512-K9wINW21M9x5GcKF5JEXzPKAT/Kfxl/vdnEyppw54hh5qoLcdi5HmsYoTfDP9gbJ6Z1T6IdH5JxBWk72HMe1Zg==}
 
   '@nuxt/kit@3.21.2':
     resolution: {integrity: sha512-Bd6m6mrDrqpBEbX+g0rc66/ALd1sxlgdx5nfK9MAYO0yKLTOSK7McSYz1KcOYn3LQFCXOWfvXwaqih/b+REI1g==}
@@ -5669,6 +5712,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   impound@1.1.5:
     resolution: {integrity: sha512-5AUn+QE0UofqNHu5f2Skf6Svukdg4ehOIq8O0EtqIx4jta0CDZYBPqpIHt0zrlUTiFVYlLpeH39DoikXBjPKpA==}
 
@@ -6099,12 +6145,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-vue-next@1.0.0:
-    resolution: {integrity: sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==}
-    deprecated: Package deprecated. Please use @lucide/vue instead.
-    peerDependencies:
-      vue: '>=3.0.1'
-
   lz4js@0.2.0:
     resolution: {integrity: sha512-gY2Ia9Lm7Ep8qMiuGRhvUq0Q7qUereeldZPP1PMEJxPtEWHJLqw9pgX68oHajBH0nzJK4MaZEA/YNV3jT8u8Bg==}
 
@@ -6331,8 +6371,8 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
-  miniflare@4.20260511.0:
-    resolution: {integrity: sha512-GjTfjtdrDb4LTUcA1S/iz/YKMvSxlbgAfgXpyhM1PQV/xzUYRpKWayq3R1vOQg53Y/g0epaBFaZLA2QbnS/meA==}
+  miniflare@4.20260515.0:
+    resolution: {integrity: sha512-2j0oQWizk1Eu4Cm8tDX7Z+Nsjd0nebIj1TQcQ+Oy1QKeo0Ay9+bdn8wfLAtOj9znDCybDCUlnS1+nYvKXEdfNg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -8122,17 +8162,17 @@ packages:
     resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
     engines: {node: '>=12.17'}
 
-  workerd@1.20260511.1:
-    resolution: {integrity: sha512-ecODCw4iWIuvuXdfy358zNpGPuO8k2WLMTaM1TKd+DuR6IF/oItVuvjf4BNhiKXlhIYBbD5GQ0gGHBY/IxSJVA==}
+  workerd@1.20260515.1:
+    resolution: {integrity: sha512-MjKOJLcvU45xXedQowvuiHtJTxu4WTHYQeIlF7YmjuqhiI6dImTFxWCEoRQHiskztxuVSNEmdO7/0UfDu6OMnQ==}
     engines: {node: '>=16'}
     hasBin: true
 
-  wrangler@4.91.0:
-    resolution: {integrity: sha512-dFzhAd2/DpaHGRrQMQkL8F6AKmjzK2hfbhyTJ+5dcZS6jdl9KG8oxO5oAflIdlsRYnrOzxRxQnvIqwewIq1FXA==}
+  wrangler@4.92.0:
+    resolution: {integrity: sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': ^4.20260511.1
+      '@cloudflare/workers-types': ^4.20260515.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -8480,25 +8520,25 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260511.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260511.1
+      workerd: 1.20260515.1
 
-  '@cloudflare/workerd-darwin-64@1.20260511.1':
+  '@cloudflare/workerd-darwin-64@1.20260515.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260511.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260515.1':
     optional: true
 
-  '@cloudflare/workerd-linux-64@1.20260511.1':
+  '@cloudflare/workerd-linux-64@1.20260515.1':
     optional: true
 
-  '@cloudflare/workerd-linux-arm64@1.20260511.1':
+  '@cloudflare/workerd-linux-arm64@1.20260515.1':
     optional: true
 
-  '@cloudflare/workerd-windows-64@1.20260511.1':
+  '@cloudflare/workerd-windows-64@1.20260515.1':
     optional: true
 
   '@colordx/core@5.4.3': {}
@@ -9119,7 +9159,7 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@geoql/v-maplibre@1.8.0(1d7bae43a63b38c52016640fc86ff2f7)':
+  '@geoql/v-maplibre@1.8.1(1d7bae43a63b38c52016640fc86ff2f7)':
     dependencies:
       maplibre-gl: 5.24.0
       pmtiles: 4.4.1
@@ -9147,6 +9187,27 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify-json/simple-icons@1.2.82':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/collections@1.0.683':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
+  '@iconify/vue@5.0.1(vue@3.5.34(typescript@6.0.3))':
+    dependencies:
+      '@iconify/types': 2.0.0
+      vue: 3.5.34(typescript@6.0.3)
 
   '@img/colour@1.1.0': {}
 
@@ -9526,6 +9587,10 @@ snapshots:
       md5: 2.3.0
     transitivePeerDependencies:
       - '@75lb/nature'
+
+  '@lucide/vue@1.16.0(vue@3.5.34(typescript@6.0.3))':
+    dependencies:
+      vue: 3.5.34(typescript@6.0.3)
 
   '@luma.gl/core@9.3.3':
     dependencies:
@@ -10086,6 +10151,27 @@ snapshots:
       - magicast
       - uploadthing
       - vite
+
+  '@nuxt/icon@2.2.2(magicast@0.5.2)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.4))(vue@3.5.34(typescript@6.0.3))':
+    dependencies:
+      '@iconify/collections': 1.0.683
+      '@iconify/types': 2.0.0
+      '@iconify/utils': 3.1.3
+      '@iconify/vue': 5.0.1(vue@3.5.34(typescript@6.0.3))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@8.0.13(@types/node@25.8.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.4))
+      '@nuxt/kit': 4.4.5(magicast@0.5.2)
+      consola: 3.4.2
+      local-pkg: 1.1.2
+      mlly: 1.8.2
+      ohash: 2.0.11
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinyglobby: 0.2.16
+    transitivePeerDependencies:
+      - magicast
+      - vite
+      - vue
 
   '@nuxt/kit@3.21.2(magicast@0.5.2)':
     dependencies:
@@ -13761,6 +13847,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   impound@1.1.5:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -14143,10 +14231,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lucide-vue-next@1.0.0(vue@3.5.34(typescript@6.0.3)):
-    dependencies:
-      vue: 3.5.34(typescript@6.0.3)
 
   lz4js@0.2.0:
     optional: true
@@ -14577,12 +14661,12 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
-  miniflare@4.20260511.0:
+  miniflare@4.20260515.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
       undici: 7.24.8
-      workerd: 1.20260511.1
+      workerd: 1.20260515.1
       ws: 8.18.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -17074,24 +17158,24 @@ snapshots:
 
   wordwrapjs@5.1.1: {}
 
-  workerd@1.20260511.1:
+  workerd@1.20260515.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260511.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260511.1
-      '@cloudflare/workerd-linux-64': 1.20260511.1
-      '@cloudflare/workerd-linux-arm64': 1.20260511.1
-      '@cloudflare/workerd-windows-64': 1.20260511.1
+      '@cloudflare/workerd-darwin-64': 1.20260515.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260515.1
+      '@cloudflare/workerd-linux-64': 1.20260515.1
+      '@cloudflare/workerd-linux-arm64': 1.20260515.1
+      '@cloudflare/workerd-windows-64': 1.20260515.1
 
-  wrangler@4.91.0:
+  wrangler@4.92.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260511.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260515.1)
       blake3-wasm: 2.1.5
       esbuild: 0.27.3
-      miniflare: 4.20260511.0
+      miniflare: 4.20260515.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260511.1
+      workerd: 1.20260515.1
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,9 +43,11 @@ catalogs:
   default:
     '@commitlint/cli': ^21.0.1
     '@commitlint/config-conventional': ^21.0.1
+    '@iconify-json/simple-icons': ^1.2.82
     '@nuxt/eslint': ^1.15.2
     '@nuxt/eslint-config': ^1.15.2
     '@nuxt/fonts': ^0.14.0
+    '@nuxt/icon': ^2.2.2
     '@nuxtjs/color-mode': ^4.0.0
     '@tailwindcss/vite': ^4.3.0
     '@types/node': ^25.8.0
@@ -59,7 +61,7 @@ catalogs:
     husky: ^9.1.7
     is-ci: ^4.1.0
     lint-staged: ^17.0.4
-    lucide-vue-next: ^1.0.0
+    '@lucide/vue': ^1.16.0
     maplibre-gl: ^5.24.0
     motion-v: ^2.2.1
     nuxt: ^4.4.5
@@ -84,7 +86,7 @@ catalogs:
     '@deck.gl/layers': ^9.3.2
     '@deck.gl/mapbox': ^9.3.2
     '@deck.gl/mesh-layers': ^9.3.2
-    '@geoql/v-maplibre': ^1.8.0
+    '@geoql/v-maplibre': ^1.8.1
     '@luma.gl/engine': ~9.3.3
     '@maplibre/mlt': ^1.1.9
     '@mlc-ai/web-llm': ^0.2.83
@@ -106,7 +108,7 @@ catalogs:
   marketing:
     '@nuxtjs/plausible': ^3.0.2
     ogl: ^1.0.11
-    wrangler: ^4.91.0
+    wrangler: ^4.92.0
   docs:
     '@nuxt/content': ^3.13.0
     better-sqlite3: ^12.10.0


### PR DESCRIPTION
## Summary

Routine dependency sweep + migration off the deprecated `lucide-vue-next` package.

## Dependency bumps (from `pnpm dlx taze latest -r -w`)

| Package | Before | After | Type |
|---|---|---|---|
| `@geoql/v-maplibre` | `^1.8.0` | `^1.8.1` | patch |
| `wrangler` | `^4.91.0` | `^4.92.0` | minor |
| `pnpm` (packageManager) | `^11.1.1` | `^11.1.2` | patch |

`cargo upgrade --compatible` reports zero compatible bumps. `mlt-core` is the only outstanding incompatible candidate (pinned to `0.9.x` per constraint memory).

## Lucide migration

`lucide-vue-next@1.0.0` is **deprecated upstream** — pnpm now flags it with `deprecated: Package deprecated. Please use @lucide/vue instead.` Migrated:

- `pnpm-workspace.yaml` catalog: `lucide-vue-next ^1.0.0` → `@lucide/vue ^1.16.0`
- All 3 app `package.json` files (`apps/client`, `apps/marketing`, `apps/docs`)
- **52 source files** across the 3 apps — find/replace `from 'lucide-vue-next'` → `from '@lucide/vue'`

## Brand-icon shim (`Github`)

Lucide v1.x removed all brand icons (project policy change — no longer ships third-party brand marks). The `Github` icon (used in 7 spots across marketing + docs) was replaced with **`@nuxt/icon` + the `simple-icons` collection**:

- Added `@nuxt/icon` to marketing + docs `nuxt.config.ts` `modules`
- Added `@nuxt/icon` runtime + `@iconify-json/simple-icons` devDep to both apps via catalog
- 6 components changed from `<Github class="size-N" />` → `<Icon name="simple-icons:github" class="size-N" />`
- `MobileNav.vue` refactored from `icon: Github` (component reference) → `iconName: 'simple-icons:github'` (string) with template `<Icon v-if="link.iconName" :name="link.iconName">`

This keeps Lucide for utility icons (Globe, Menu, Sun, etc.) while routing brand icons through `simple-icons`, which the Iconify ecosystem maintains specifically for company logos.

## Verification

| Gate | Result |
|---|---|
| Build CLIENT | ✅ EXIT 0 |
| Build MARKETING | ✅ EXIT 0 |
| Build DOCS | ✅ EXIT 0 |
| Lint CLIENT | ✅ 0 warnings, 0 errors |
| Lint MARKETING | ✅ 32 pre-existing warnings (Tailwind class names), 0 errors |
| Lint DOCS | ✅ 0 warnings, 0 errors (3 fixable were `lint:fix`'d in this PR) |
| `cargo fmt --all --check` | ✅ EXIT 0 |
| `cargo clippy --all-targets --all-features -- -D warnings` | ✅ EXIT 0 |
| `cargo test --all --all-features` | ✅ 929 tests passed, 0 failed |

## Files changed

60 files, +236/-137. No source-logic changes — purely import paths + 2 nuxt.config additions + 3 package.json adds + catalog rename.