### PR TITLE
refactor(client): apply A2 operator-list design to home page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -579,6 +579,186 @@ The entire client (public viewer AND `/admin/*`) honors the user's light/dark to
 
 **Why one direction across both viewer + admin?** Earlier the public viewer used HSL + Tailwind-default-blue while admin used OKLch + violet — two parallel palettes drifting apart. Direction I is now the canonical, single-source palette; light mode is a perceptually-uniform desaturation of the dark tokens.
 
+### 🚨 Rule #20: A2 Operator-List Pattern — Hero, Toolbar, Card, Motion, A11y
+
+The `/` home page (and any future list/dashboard surface inside `apps/client/`) uses the **A2 Operator-List pattern**. This rule encodes the visual + interaction language so future work doesn't drift. Reference mock: [`.design-explorations/A2-density-plus.html`](.design-explorations/A2-density-plus.html).
+
+#### A. Hero composition (mandatory shape)
+
+Two-column grid (single column `<md`, `1fr auto` `>=md`). Left column: kicker pill row + headline + sub. Right column: 4-stat strip.
+
+**Kicker pill row** — 3 pills, all live data from `/ping`, all border-radius `999px`:
+
+| Pill | Source field | Treatment |
+|---|---|---|
+| `Live` | `status==="ok"` | success-tinted bg + animated ping dot |
+| `Renderer ✓ / ✗` | `renderer_enabled` | neutral bg, check/cross glyph |
+| `v<version>` | `version` | neutral bg |
+
+**4-stat strip** — `Sources / Styles / Cache MB / Uptime` only. All derived from `/ping`:
+
+- `Sources` ← `loaded_sources`
+- `Styles` ← `loaded_styles`
+- `Cache` ← `(cache_bytes / 1024 / 1024).toFixed(0)` MB — when `cache_enabled=false`, swap cell for `Renderer ✓/✗`
+- `Uptime` ← `formatDistance(loaded_at_unix)` formatted via `date-fns`
+
+> **HONEST-DATA RULE**: NEVER show metrics `/ping` does not return — no fake `p50`, no fake `p99`, no fake region label, no fake QPS. The PingResponse fields are the entire surface. If a metric is unavailable, show `—` or omit the cell.
+
+#### B. Sticky toolbar (search + filter chips)
+
+Single sticky row directly under the hero. Two children:
+
+1. **Search input** — 44px tall (touch-target floor), border-tinted-violet + 3px ring on `:focus`, search-icon switches to `text-primary` on focus.
+2. **Filter chip strip** — horizontally scrollable on mobile (`overflow-x: auto` + `scrollbar-width: thin`, 0-height scrollbar on WebKit). Each chip = `aria-pressed` button with a count badge. Active chip uses `border-primary + bg-primary-tint`.
+
+Chips MUST be derived from the actual loaded source/style counts — not hardcoded. Generate from grouping over `Style.type` (raster / vector) and `Data.type` (pmtiles / mlt / stac / postgis / etc.).
+
+#### C. Card hover — NO layout shift (HARD)
+
+**FORBIDDEN on any card / row / tile hover state:**
+
+- `transform: translateY(...)`, `transform: translateX(...)`, `transform: scale(...)` — even GPU-accelerated transforms read as motion-shift to the eye
+- Shadow growth that visually pushes the card up
+- Padding / margin changes
+- Width / height changes
+- `font-size` / `font-weight` shifts on the title
+
+**REQUIRED hover affordance:**
+
+```css
+.card { transition: border-color, background, box-shadow var(--d-fast) var(--ease); }
+.card:hover {
+  border-color: var(--primary);
+  background: oklch(from var(--primary) l c h / 0.025);   /* 2.5% tint */
+  box-shadow: inset 0 0 0 1px oklch(from var(--primary) l c h / 0.15);
+}
+.card:focus-within { border-color: var(--primary); }
+```
+
+Color + inset ring only. Zero motion. Tested at 320×568 (smallest mobile) through 2560×1440 (4k).
+
+#### D. Coverage bar (zoom-range visualization)
+
+Each StyleCard / DataCard renders a 3px horizontal bar showing the source's zoom range as a fraction of `[0, 18]`:
+
+```html
+<div class="coverage" role="img" aria-label="Zoom range 0 to 15">
+  <div class="coverage-fill" style="left: 0%; width: 83.33%;"></div>
+</div>
+<div class="coverage-labels"><span>z0</span><span>z0–15</span><span>z18</span></div>
+```
+
+Math: `left = minzoom * 100 / 18`, `width = (maxzoom - minzoom) * 100 / 18`. Fill uses `var(--primary)`. Labels use `var(--font-mono)` at 9.5–10px with `letter-spacing: 0.10em`.
+
+#### E. Conditional `Inspect` button
+
+`Inspect` ONLY renders when `source.vector_layers?.length > 0`. Raster STAC sources, PostGIS sources without a vector-layer manifest, and any source without inspectable layers MUST render the card with the right-side action slot empty — the title block flexes to fill.
+
+```vue
+<a v-if="source.vector_layers?.length" :href="`/data/${source.id}/`" class="btn">Inspect</a>
+```
+
+#### F. Skeleton shimmer (loading state)
+
+Use the existing `~/components/ui/skeleton/Skeleton.vue` with the linear-gradient shimmer keyframe. NEVER show a spinner inside a card. NEVER show a centered loading message. ALWAYS render the actual card scaffold with `<Skeleton>` blocks shaped like the real content:
+
+```vue
+<div class="card">
+  <Skeleton class="size-14" />            <!-- thumb -->
+  <Skeleton class="h-4 w-2/3" />          <!-- title (% widths only) -->
+  <Skeleton class="h-3 w-1/3 mt-2" />     <!-- id chip -->
+  <Skeleton class="h-3 w-4/5 mt-3" />     <!-- services row -->
+</div>
+```
+
+Skeleton widths use **percentages**, never fixed `w-N` pixel values — those overflow narrow mobile columns (the original Wave 0 bug).
+
+#### G. Toast (XYZ URL copied feedback)
+
+Bottom-center, slides up from below the viewport over 320ms, auto-dismisses after 1800ms. ARIA contract:
+
+```html
+<div class="toast" role="status" aria-live="polite">
+  <CheckIcon class="text-success" />
+  XYZ URL copied
+</div>
+```
+
+NEVER use `role="alert"` for non-error confirmations.
+
+#### H. Motion tokens
+
+Declare once in `tailwind.css` `@theme`:
+
+```css
+@theme {
+  --d-fast: 120ms;          /* hover, focus, simple state */
+  --d-base: 180ms;          /* section toggle chevron rotate */
+  --d-slow: 320ms;          /* section expand/collapse, toast slide */
+  --ease:   cubic-bezier(0.16, 1, 0.3, 1);   /* ease-out, slight overshoot */
+}
+```
+
+Section toggles use `grid-template-rows: 0fr → 1fr` (smooth, no `max-height` kludge). Section chevron uses `transform: rotate(180deg)` on `.section.open`.
+
+#### I. Hero status pill ping animation
+
+The `Live` pill's dot ships a 2.2-second pulse halo via a single keyframe:
+
+```css
+.hero-dot { position: relative; }
+.hero-dot::after {
+  content: ''; position: absolute; inset: -4px; border-radius: 50%;
+  background: var(--success); opacity: 0.45; animation: pulse 2.2s var(--ease) infinite;
+}
+@keyframes pulse { 0% { transform: scale(1); opacity: 0.45; } 100% { transform: scale(2.6); opacity: 0; } }
+```
+
+Animation MUST be inside the `@media (prefers-reduced-motion: reduce)` reset that disables all transitions/animations site-wide.
+
+#### J. A11y baseline (NON-OPTIONAL on every page)
+
+| Requirement | Implementation |
+|---|---|
+| Skip-to-content link | `<a class="skip-link" href="#main">` — slides down from top on `:focus-visible` |
+| Focus-visible rings | `:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }` on every interactive element |
+| Touch targets | All buttons `min-height: 36px` desktop / `40px` mobile; icon-only `min-height: 44px` (iOS minimum) |
+| Reduced motion | `@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; } }` |
+| Semantic HTML | `<article>` per card, `<button>` for collapsibles (NOT `<div onclick>`), `<main id="main">`, `<header role="banner">`, `<footer role="contentinfo">` |
+| ARIA on collapsibles | `aria-expanded="true|false"` + `aria-controls="<body-id>"` on the section toggle button |
+| ARIA on icon-only buttons | `aria-label="..."` mandatory on every icon-only button (Viewer arrow, theme toggle, settings, copy) |
+| ARIA on status feedback | Toast: `role="status" aria-live="polite"`. Error banner: `role="alert"`. |
+| `sr-only` labels | Search input + every visible-icon-only-but-needs-label control |
+| Coverage bar accessibility | `role="img" aria-label="Zoom range N to M"` on the bar; visible numeric labels below for sighted users |
+
+#### K. Component-file mapping (for the migration)
+
+| Concept | File |
+|---|---|
+| Hero (pill row + 4-stat strip + headline) | `app/components/home/Hero.vue` |
+| Sticky toolbar (search + filter chips) | `app/components/home/Toolbar.vue` (NEW — combines old `SearchBar.vue`) |
+| Filter chip | `app/components/home/FilterChip.vue` (NEW — chiplet) |
+| Section (collapsible header + body) | `app/components/home/Section.vue` (REPLACES `StyleList.vue` + `DataList.vue` Card/Collapsible wrappers) |
+| StyleCard (thumb + name + id + Viewer + Raster/Vector pills + services + XYZ + coverage) | `app/components/home/StyleCard.vue` |
+| DataCard (icon + name + id + badges + conditional Inspect + services + XYZ + coverage) | `app/components/home/DataCard.vue` |
+| Toast | `app/components/ui/toast/Toast.vue` (NEW under shadcn-vue path) |
+| Filter state | `app/composables/use-home-filters.ts` (NEW) |
+| Ping query | `app/utils/api/server/queries.ts` (EXISTS — verify shape matches `PingResponse` from `src/admin.rs`) |
+
+#### L. Anti-patterns (5-dimensional critique trip wires)
+
+If your A2-derived page would fail any of these, REBUILD before declaring done:
+
+1. **Layout shift on hover** — see Rule #20.C; any `translateY` / `scale` on cards is an automatic fail
+2. **Fictional /ping fields** — `p50`, `p99`, `qps`, `region`, anything not in `PingResponse` (lines 19–31 of `crates/tileserver-rs/src/admin.rs`)
+3. **Hardcoded filter chips** — chip set must be derived from actual loaded source/style types, not a static array of 6 chips
+4. **Spinner inside card** — always skeleton; spinners only allowed on full-page route load
+5. **Pixel-width skeleton bars** — must use `%` widths or `w-1/2`, `w-2/3`, `w-4/5` Tailwind fractions; never `w-48`, `w-56`, `w-40`
+6. **Inspect on raster/STAC sources** — conditional render gate is `source.vector_layers?.length`
+7. **Missing skip-link** — every page that mounts `<header>` MUST also ship `<a class="skip-link" href="#main">`
+8. **`role="alert"` for confirmations** — copy-success is `role="status"`, not alert (alert is for genuine errors)
+9. **`rounded-*` anywhere** — direction-I locks radius to 0; the class is dead weight + a Rule #19 violation
+
 ---
 
 ## Project Structure

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6284,7 +6284,7 @@ dependencies = [
 
 [[package]]
 name = "tileserver-rs"
-version = "2.28.0"
+version = "2.29.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/apps/client/app/assets/css/tailwind.css
+++ b/apps/client/app/assets/css/tailwind.css
@@ -193,3 +193,137 @@
     @apply bg-muted font-semibold;
   }
 }
+
+/* Motion tokens — direction I (CLAUDE.md Rule #20.H) */
+@theme {
+  --d-fast: 120ms;
+  --d-base: 180ms;
+  --d-slow: 320ms;
+  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+/* A11y baseline — CLAUDE.md Rule #20.I + Rule #20.J */
+@layer base {
+  .skip-link {
+    @apply sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:bg-background focus:px-4 focus:py-2 focus:text-foreground focus:ring-2 focus:ring-ring;
+  }
+
+  :focus-visible {
+    outline: 2px solid var(--color-ring);
+    outline-offset: 2px;
+  }
+}
+
+/* Hero ping animation — CLAUDE.md Rule #20.I */
+.hero-dot {
+  position: relative;
+}
+.hero-dot::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  background: var(--color-success);
+  opacity: 0.45;
+  animation: pulse 2.2s var(--ease) infinite;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(1);
+    opacity: 0.45;
+  }
+  100% {
+    transform: scale(2.6);
+    opacity: 0;
+  }
+}
+
+/* Coverage bar — zoom-range visualization (CLAUDE.md Rule #20.D) */
+.coverage {
+  position: relative;
+  height: 3px;
+  background: var(--color-muted);
+  overflow: hidden;
+}
+.coverage-fill {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  background: var(--color-primary);
+}
+.coverage-labels {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.1em;
+  color: var(--color-muted-foreground);
+  margin-top: 2px;
+}
+
+/* Section toggle — grid-template-rows animation (Rule #20.H) */
+.section-body {
+  display: grid;
+  grid-template-rows: 1fr;
+  transition: grid-template-rows var(--d-slow) var(--ease);
+}
+.section-body[data-open='false'] {
+  grid-template-rows: 0fr;
+}
+.section-body > .section-inner {
+  overflow: hidden;
+}
+
+/* Service link underline animation (Rule #20.H) */
+.service-link {
+  position: relative;
+  text-decoration: none;
+}
+.service-link::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background: var(--color-primary);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform var(--d-fast) var(--ease);
+}
+.service-link:hover::after {
+  transform: scaleX(1);
+}
+
+/* Toast — bottom-center slide-up (Rule #20.G) */
+.toast-enter-active {
+  transition:
+    transform var(--d-slow) var(--ease),
+    opacity var(--d-base) ease;
+}
+.toast-leave-active {
+  transition:
+    transform var(--d-base) ease,
+    opacity var(--d-base) ease;
+}
+.toast-enter-from,
+.toast-leave-to {
+  transform: translateY(100%);
+  opacity: 0;
+}
+
+/* Reduced motion — CLAUDE.md Rule #20.I */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+
+  .hero-dot::after {
+    animation: none;
+  }
+}

--- a/apps/client/app/assets/css/tailwind.css
+++ b/apps/client/app/assets/css/tailwind.css
@@ -317,7 +317,7 @@
   opacity: 0;
 }
 
-/* Reduced motion — CLAUDE.md Rule #20.I */
+/* Reduced motion — CLAUDE.md Rule #20.J */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -330,4 +330,18 @@
   .hero-dot::after {
     animation: none;
   }
+}
+
+/* A2 section expand/collapse — CSS grid-template-rows (Rule #20.H) */
+.section-body-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--d-slow) var(--ease);
+}
+.section.open .section-body-wrap {
+  grid-template-rows: 1fr;
+}
+.section-body-inner {
+  min-height: 0;
+  overflow: hidden;
 }

--- a/apps/client/app/assets/css/tailwind.css
+++ b/apps/client/app/assets/css/tailwind.css
@@ -19,6 +19,8 @@
   --color-popover-foreground: oklch(0.2 0.012 270);
   --color-primary: oklch(0.55 0.22 295);
   --color-primary-foreground: oklch(0.98 0.005 270);
+  --color-surface: oklch(0.965 0.005 270);
+  --color-surface-2: oklch(0.935 0.007 270);
   --color-secondary: oklch(0.96 0.006 270);
   --color-secondary-foreground: oklch(0.42 0.012 270);
   --color-muted: oklch(0.96 0.006 270);
@@ -78,6 +80,8 @@
 }
 
 .dark {
+  --color-surface: oklch(0.2 0.014 270);
+  --color-surface-2: oklch(0.24 0.016 270);
   --color-background: oklch(0.18 0.012 270);
   --color-foreground: oklch(0.96 0.005 270);
   --color-card: oklch(0.22 0.012 270);

--- a/apps/client/app/components/home/ApiLink.vue
+++ b/apps/client/app/components/home/ApiLink.vue
@@ -1,32 +1,22 @@
 <script setup lang="ts">
   import { ChevronRight, ExternalLink } from '@lucide/vue';
-  import { motion } from 'motion-v';
 </script>
 
 <template>
-  <motion.a
-    href="/_openapi"
-    target="_blank"
-    :initial="{ opacity: 0, y: 12 }"
-    :animate="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.35, delay: 0.35 }"
-    class="block"
-  >
-    <Card
-      class="overflow-hidden border-border/50 bg-card/50 backdrop-blur-sm transition-all hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+  <a href="/_openapi" target="_blank" class="block">
+    <div
+      class="flex items-center gap-3 border border-border bg-card p-4 transition-colors duration-[var(--d-fast,120ms)] hover:border-primary/30"
     >
-      <div class="flex items-center gap-3 p-4">
-        <div class="flex size-8 items-center justify-center bg-muted/50">
-          <ExternalLink class="size-4 text-muted-foreground" />
-        </div>
-        <div class="flex-1">
-          <span class="font-medium">API Documentation</span>
-          <p class="text-xs text-muted-foreground">
-            OpenAPI 3.1 specification with Scalar
-          </p>
-        </div>
-        <ChevronRight class="size-4 text-muted-foreground" />
+      <div class="size-8 shrink-0 bg-surface-2 grid place-items-center">
+        <ExternalLink class="size-4 text-muted-foreground" />
       </div>
-    </Card>
-  </motion.a>
+      <div class="flex-1">
+        <span class="font-medium">API Documentation</span>
+        <p class="text-xs text-muted-foreground">
+          OpenAPI 3.1 specification with Scalar
+        </p>
+      </div>
+      <ChevronRight class="size-4 text-muted-foreground shrink-0" />
+    </div>
+  </a>
 </template>

--- a/apps/client/app/components/home/DataCard.vue
+++ b/apps/client/app/components/home/DataCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import { Layers } from '@lucide/vue';
+  import { motion } from 'motion-v';
   import type { Data } from '~/types/data';
 
   const props = defineProps<{
@@ -11,50 +12,52 @@
   }>();
 
   const emit = defineEmits<{
-    'toggle-xyz': [dataId: string];
-    'copy-url': [url: string];
+    toggleXyz: [dataId: string];
+    copyUrl: [url: string];
   }>();
 
   function handleToggleXyz() {
-    emit('toggle-xyz', props.source.id);
+    emit('toggleXyz', props.source.id);
   }
 
   function handleServiceCopyUrl(url: string) {
-    emit('copy-url', url);
+    emit('copyUrl', url);
   }
-
-  const coverageLeft = computed(() => (props.source.minzoom * 100) / 18);
-  const coverageWidth = computed(
-    () => ((props.source.maxzoom - props.source.minzoom) * 100) / 18,
-  );
 </script>
 
 <template>
-  <article
-    class="card group border border-border/50 bg-background/50 p-4 transition-[border-color,background,box-shadow] duration-[var(--d-fast,120ms)]"
-    :style="{
-      '--tw-ring-color': 'oklch(from var(--color-primary) l c h / 0.15)',
-    }"
+  <motion.div
+    :initial="{ opacity: 0, y: 12 }"
+    :animate="{ opacity: 1, y: 0 }"
+    :transition="{ duration: 0.3, delay: 0.05 * index }"
+    class="group border border-border bg-background p-3.5 transition-all duration-[var(--d-fast,120ms)] hover:border-primary hover:bg-primary/2.5 focus-within:border-primary"
   >
-    <div class="flex items-start gap-4">
+    <div class="flex gap-3.5">
+      <!-- 56x56 icon box per A2 -->
       <div
-        class="flex size-12 shrink-0 items-center justify-center bg-muted ring-1 ring-border/50"
+        class="flex size-14 shrink-0 items-center justify-center border border-border bg-surface-2"
       >
-        <Layers class="size-6 text-muted-foreground" />
+        <Layers class="size-5.5 text-muted-foreground" />
       </div>
 
+      <!-- Card content -->
       <div class="min-w-0 flex-1">
-        <div class="flex items-start justify-between gap-2">
-          <div>
-            <h3 class="font-semibold">{{ source.name || source.id }}</h3>
-            <p
-              class="mt-0.5 flex flex-wrap items-center gap-2 text-sm text-muted-foreground"
-            >
-              <code class="bg-muted px-1.5 py-0.5 text-xs font-medium">{{
-                source.id
-              }}</code>
-              <Badge variant="outline" class="text-[10px]">
-                z{{ source.minzoom }}-{{ source.maxzoom }}
+        <div class="flex items-start justify-between gap-2.5">
+          <div class="min-w-0">
+            <h3 class="text-[15px] font-bold leading-snug tracking-[-0.005em]">
+              {{ source.name || source.id }}
+            </h3>
+            <p class="mt-0.5 flex flex-wrap items-center gap-2">
+              <code
+                class="inline-block bg-surface-2 px-1.5 py-0.5 font-mono text-[11px] font-medium text-muted-foreground"
+              >
+                {{ source.id }}
+              </code>
+              <Badge
+                variant="outline"
+                class="font-mono text-[10px] tracking-[0.06em]"
+              >
+                z{{ source.minzoom }}–{{ source.maxzoom }}
               </Badge>
             </p>
           </div>
@@ -63,6 +66,7 @@
             as-child
             variant="secondary"
             size="sm"
+            class="shrink-0"
           >
             <NuxtLink :to="`/data/${source.id}/`">
               <Layers class="mr-1.5 size-4" />
@@ -79,40 +83,7 @@
           @toggle-xyz="handleToggleXyz"
           @copy-url="handleServiceCopyUrl"
         />
-
-        <div class="mt-3">
-          <div
-            class="coverage h-[3px] w-full bg-muted"
-            role="img"
-            :aria-label="`Zoom range ${source.minzoom} to ${source.maxzoom}`"
-          >
-            <div
-              class="coverage-fill h-full bg-primary"
-              :style="{ left: `${coverageLeft}%`, width: `${coverageWidth}%` }"
-            ></div>
-          </div>
-          <div
-            class="mt-1 flex justify-between text-[10px] font-mono tracking-widest text-muted-foreground"
-            style="letter-spacing: 0.1em"
-          >
-            <span>z{{ source.minzoom }}</span>
-            <span>z{{ source.minzoom }}–{{ source.maxzoom }}</span>
-            <span>z18</span>
-          </div>
-        </div>
       </div>
     </div>
-  </article>
+  </motion.div>
 </template>
-
-<style scoped>
-  .card:hover {
-    border-color: var(--color-primary);
-    background: oklch(from var(--color-primary) l c h / 0.025);
-    box-shadow: inset 0 0 0 1px oklch(from var(--color-primary) l c h / 0.15);
-  }
-
-  .card:focus-within {
-    border-color: var(--color-primary);
-  }
-</style>

--- a/apps/client/app/components/home/DataCard.vue
+++ b/apps/client/app/components/home/DataCard.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
   import { Layers } from '@lucide/vue';
-  import { motion } from 'motion-v';
   import type { Data } from '~/types/data';
 
   const props = defineProps<{
@@ -23,42 +22,49 @@
   function handleServiceCopyUrl(url: string) {
     emit('copyUrl', url);
   }
+
+  const coverageLeft = computed(
+    () => `${((props.source.minzoom ?? 0) * 100) / 18}%`,
+  );
+  const coverageWidth = computed(
+    () =>
+      `${(((props.source.maxzoom ?? 18) - (props.source.minzoom ?? 0)) * 100) / 18}%`,
+  );
 </script>
 
 <template>
-  <motion.div
-    :initial="{ opacity: 0, y: 12 }"
-    :animate="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.3, delay: 0.05 * index }"
-    class="group border border-border bg-background p-3.5 transition-all duration-[var(--d-fast,120ms)] hover:border-primary hover:bg-primary/2.5 focus-within:border-primary"
+  <article
+    class="card group border border-border bg-background p-3.5 transition-all duration-[var(--d-fast,120ms)] hover:border-primary hover:bg-primary/10 focus-within:border-primary"
+    style="
+      --tw-shadow: inset 0 0 0 1px oklch(from var(--color-primary) l c h / 0.15);
+    "
   >
     <div class="flex gap-3.5">
-      <!-- 56x56 icon box per A2 -->
       <div
-        class="flex size-14 shrink-0 items-center justify-center border border-border bg-surface-2"
+        class="thumb size-14 shrink-0 border border-border bg-surface-2 grid place-items-center"
       >
         <Layers class="size-5.5 text-muted-foreground" />
       </div>
 
-      <!-- Card content -->
-      <div class="min-w-0 flex-1">
-        <div class="flex items-start justify-between gap-2.5">
+      <div class="card-main min-w-0 flex-1">
+        <div class="card-top flex items-start justify-between gap-2.5">
           <div class="min-w-0">
-            <h3 class="text-[15px] font-bold leading-snug tracking-[-0.005em]">
+            <h3
+              class="card-title text-[15px] font-bold tracking-[-0.005em] leading-[1.3]"
+            >
               {{ source.name || source.id }}
             </h3>
-            <p class="mt-0.5 flex flex-wrap items-center gap-2">
+            <p class="mt-1.5 flex flex-wrap items-center gap-2">
               <code
-                class="inline-block bg-surface-2 px-1.5 py-0.5 font-mono text-[11px] font-medium text-muted-foreground"
+                class="card-id font-mono text-[11px] bg-surface-2 px-1.5 py-0.5 text-muted-foreground tracking-wide"
               >
                 {{ source.id }}
               </code>
-              <Badge
-                variant="outline"
-                class="font-mono text-[10px] tracking-[0.06em]"
+              <span
+                class="badge-outline font-mono text-[10px] tracking-[0.12em] uppercase text-muted-foreground px-1.5 py-0.5 border border-border font-medium"
               >
-                z{{ source.minzoom }}–{{ source.maxzoom }}
-              </Badge>
+                z{{ source.minzoom ?? 0 }}–{{ source.maxzoom ?? 18 }}
+              </span>
             </p>
           </div>
           <Button
@@ -69,7 +75,7 @@
             class="shrink-0"
           >
             <NuxtLink :to="`/data/${source.id}/`">
-              <Layers class="mr-1.5 size-4" />
+              <Layers class="size-4 mr-1.5" />
               Inspect
             </NuxtLink>
           </Button>
@@ -83,7 +89,24 @@
           @toggle-xyz="handleToggleXyz"
           @copy-url="handleServiceCopyUrl"
         />
+
+        <div class="mt-3">
+          <div
+            class="coverage"
+            role="img"
+            :aria-label="`Zoom range ${source.minzoom ?? 0} to ${source.maxzoom ?? 18}`"
+          >
+            <div
+              class="coverage-fill"
+              :style="{ left: coverageLeft, width: coverageWidth }"
+            ></div>
+          </div>
+          <div class="coverage-labels">
+            <span>z{{ source.minzoom ?? 0 }}</span>
+            <span>z{{ source.maxzoom ?? 18 }}</span>
+          </div>
+        </div>
       </div>
     </div>
-  </motion.div>
+  </article>
 </template>

--- a/apps/client/app/components/home/DataCard.vue
+++ b/apps/client/app/components/home/DataCard.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
   import { Layers } from '@lucide/vue';
-  import { motion } from 'motion-v';
   import type { Data } from '~/types/data';
 
   const props = defineProps<{
@@ -12,25 +11,30 @@
   }>();
 
   const emit = defineEmits<{
-    toggleXyz: [dataId: string];
-    copyUrl: [url: string];
+    'toggle-xyz': [dataId: string];
+    'copy-url': [url: string];
   }>();
 
   function handleToggleXyz() {
-    emit('toggleXyz', props.source.id);
+    emit('toggle-xyz', props.source.id);
   }
 
   function handleServiceCopyUrl(url: string) {
-    emit('copyUrl', url);
+    emit('copy-url', url);
   }
+
+  const coverageLeft = computed(() => (props.source.minzoom * 100) / 18);
+  const coverageWidth = computed(
+    () => ((props.source.maxzoom - props.source.minzoom) * 100) / 18,
+  );
 </script>
 
 <template>
-  <motion.div
-    :initial="{ opacity: 0, y: 12 }"
-    :animate="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.3, delay: 0.05 * index }"
-    class="group border border-border/50 bg-background/50 p-4 transition-all hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+  <article
+    class="card group border border-border/50 bg-background/50 p-4 transition-[border-color,background,box-shadow] duration-[var(--d-fast,120ms)]"
+    :style="{
+      '--tw-ring-color': 'oklch(from var(--color-primary) l c h / 0.15)',
+    }"
   >
     <div class="flex items-start gap-4">
       <div
@@ -59,7 +63,6 @@
             as-child
             variant="secondary"
             size="sm"
-            class=""
           >
             <NuxtLink :to="`/data/${source.id}/`">
               <Layers class="mr-1.5 size-4" />
@@ -76,7 +79,40 @@
           @toggle-xyz="handleToggleXyz"
           @copy-url="handleServiceCopyUrl"
         />
+
+        <div class="mt-3">
+          <div
+            class="coverage h-[3px] w-full bg-muted"
+            role="img"
+            :aria-label="`Zoom range ${source.minzoom} to ${source.maxzoom}`"
+          >
+            <div
+              class="coverage-fill h-full bg-primary"
+              :style="{ left: `${coverageLeft}%`, width: `${coverageWidth}%` }"
+            ></div>
+          </div>
+          <div
+            class="mt-1 flex justify-between text-[10px] font-mono tracking-widest text-muted-foreground"
+            style="letter-spacing: 0.1em"
+          >
+            <span>z{{ source.minzoom }}</span>
+            <span>z{{ source.minzoom }}–{{ source.maxzoom }}</span>
+            <span>z18</span>
+          </div>
+        </div>
       </div>
     </div>
-  </motion.div>
+  </article>
 </template>
+
+<style scoped>
+  .card:hover {
+    border-color: var(--color-primary);
+    background: oklch(from var(--color-primary) l c h / 0.025);
+    box-shadow: inset 0 0 0 1px oklch(from var(--color-primary) l c h / 0.15);
+  }
+
+  .card:focus-within {
+    border-color: var(--color-primary);
+  }
+</style>

--- a/apps/client/app/components/home/DataCardServices.vue
+++ b/apps/client/app/components/home/DataCardServices.vue
@@ -10,8 +10,8 @@
   }>();
 
   const emit = defineEmits<{
-    toggleXyz: [];
-    copyUrl: [url: string];
+    'toggle-xyz': [];
+    'copy-url': [url: string];
   }>();
 
   const xyzUrl = computed(
@@ -20,37 +20,38 @@
 </script>
 
 <template>
-  <template v-if="source.vector_layers?.length">
-    <div class="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
-      <span class="text-muted-foreground">Services:</span>
-      <a
-        :href="`/data/${source.id}.json`"
-        target="_blank"
-        class="text-primary hover:underline"
-        >TileJSON</a
-      >
-      <span class="text-muted-foreground/30">•</span>
-      <button class="text-primary hover:underline" @click="emit('toggleXyz')">
-        XYZ URL
-      </button>
-    </div>
-
-    <div
-      v-if="isXyzExpanded"
-      class="mt-2 flex items-center gap-2 bg-muted/50 p-2"
+  <div class="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+    <span class="text-muted-foreground">Services:</span>
+    <a
+      :href="`/data/${source.id}.json`"
+      target="_blank"
+      class="text-primary transition-colors hover:underline"
+      >TileJSON</a
     >
-      <code class="flex-1 truncate text-xs text-muted-foreground">{{
-        xyzUrl
-      }}</code>
-      <Button
-        variant="ghost"
-        size="icon"
-        class="size-7 shrink-0"
-        @click="emit('copyUrl', xyzUrl)"
-      >
-        <Check v-if="copiedUrl === xyzUrl" class="size-3.5 text-success" />
-        <Copy v-else class="size-3.5" />
-      </Button>
-    </div>
-  </template>
+    <span class="text-muted-foreground/30">•</span>
+    <button
+      class="text-primary transition-colors hover:underline"
+      @click="emit('toggle-xyz')"
+    >
+      XYZ URL
+    </button>
+  </div>
+
+  <div
+    v-if="isXyzExpanded"
+    class="mt-2 flex items-center gap-2 bg-muted/50 p-2"
+  >
+    <code class="flex-1 truncate text-xs text-muted-foreground">{{
+      xyzUrl
+    }}</code>
+    <Button
+      variant="ghost"
+      size="icon"
+      class="size-7 shrink-0"
+      @click="emit('copy-url', xyzUrl)"
+    >
+      <Check v-if="copiedUrl === xyzUrl" class="size-3.5 text-success" />
+      <Copy v-else class="size-3.5" />
+    </Button>
+  </div>
 </template>

--- a/apps/client/app/components/home/DataCardServices.vue
+++ b/apps/client/app/components/home/DataCardServices.vue
@@ -21,16 +21,20 @@
 
 <template>
   <div class="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
-    <span class="text-muted-foreground">Services:</span>
+    <span
+      class="lbl font-mono text-[10.5px] tracking-[0.10em] uppercase text-muted-foreground font-medium"
+      >Services:</span
+    >
     <a
       :href="`/data/${source.id}.json`"
       target="_blank"
-      class="text-primary transition-colors hover:underline"
+      class="services-link text-primary font-medium transition-colors duration-[var(--d-fast,120ms)]"
       >TileJSON</a
     >
-    <span class="text-muted-foreground/30">•</span>
+    <span class="sep text-muted-foreground opacity-50">·</span>
     <button
-      class="text-primary transition-colors hover:underline"
+      type="button"
+      class="services-link text-primary font-medium transition-colors duration-[var(--d-fast,120ms)]"
       @click="emit('toggle-xyz')"
     >
       XYZ URL
@@ -39,15 +43,16 @@
 
   <div
     v-if="isXyzExpanded"
-    class="mt-2 flex items-center gap-2 bg-muted/50 p-2"
+    class="mt-2 flex items-center gap-2 bg-surface-2 p-2"
   >
-    <code class="flex-1 truncate text-xs text-muted-foreground">{{
+    <code class="flex-1 truncate text-xs text-muted-foreground font-mono">{{
       xyzUrl
     }}</code>
     <Button
       variant="ghost"
       size="icon"
       class="size-7 shrink-0"
+      aria-label="Copy XYZ URL"
       @click="emit('copy-url', xyzUrl)"
     >
       <Check v-if="copiedUrl === xyzUrl" class="size-3.5 text-success" />

--- a/apps/client/app/components/home/DataCardSkeleton.vue
+++ b/apps/client/app/components/home/DataCardSkeleton.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts"></script>
+
+<template>
+  <article class="card border border-border bg-background p-3.5">
+    <div class="flex gap-3.5">
+      <Skeleton class="size-14 shrink-0" />
+      <div class="min-w-0 flex-1">
+        <Skeleton class="h-4 w-2/3" />
+        <div class="mt-1.5 flex gap-2">
+          <Skeleton class="h-3 w-20" />
+          <Skeleton class="h-3 w-12" />
+        </div>
+        <div class="mt-3 flex gap-2">
+          <Skeleton class="h-6 w-16" />
+        </div>
+      </div>
+    </div>
+  </article>
+</template>

--- a/apps/client/app/components/home/DataListContent.vue
+++ b/apps/client/app/components/home/DataListContent.vue
@@ -13,30 +13,35 @@
   }>();
 
   const emit = defineEmits<{
-    toggleXyz: [dataId: string];
-    copyUrl: [url: string];
+    'toggle-xyz': [dataId: string];
+    'copy-url': [url: string];
   }>();
 
-  function handleToggleXyz(dataId: string) {
-    emit('toggleXyz', dataId);
-  }
-
-  function handleCopyUrl(url: string) {
-    emit('copyUrl', url);
-  }
+  const SKELETON_COUNT = 5;
 </script>
 
 <template>
   <Separator class="bg-border/50" />
   <div class="p-4">
-    <div v-if="isLoading" class="flex justify-center py-12">
+    <div v-if="isLoading" class="space-y-3">
       <div
-        class="size-8 animate-spin rounded-full border-2 border-muted border-t-primary"
-      ></div>
+        v-for="i in SKELETON_COUNT"
+        :key="i"
+        class="border border-border/50 bg-background/50 p-4"
+      >
+        <div class="flex items-start gap-4">
+          <Skeleton class="size-12 shrink-0" />
+          <div class="min-w-0 flex-1">
+            <Skeleton class="h-4 w-2/3" />
+            <Skeleton class="mt-2 h-3 w-1/3" />
+            <Skeleton class="mt-3 h-3 w-4/5" />
+          </div>
+        </div>
+      </div>
     </div>
     <div v-else-if="!hasData" class="py-12 text-center">
       <div
-        class="mx-auto mb-4 flex size-16 items-center justify-center bg-muted/50"
+        class="mx-auto mb-4 flex size-16 items-center justify-center bg-muted"
       >
         <Database class="size-8 text-muted-foreground" />
       </div>
@@ -60,8 +65,8 @@
         :base-url="baseUrl"
         :is-xyz-expanded="expandedXyz.has(source.id)"
         :copied-url="copiedUrl"
-        @toggle-xyz="handleToggleXyz"
-        @copy-url="handleCopyUrl"
+        @toggle-xyz="emit('toggle-xyz', $event)"
+        @copy-url="emit('copy-url', $event)"
       />
     </div>
   </div>

--- a/apps/client/app/components/home/FilterChip.vue
+++ b/apps/client/app/components/home/FilterChip.vue
@@ -16,21 +16,21 @@
 <template>
   <button
     :aria-pressed="active"
-    class="inline-flex shrink-0 items-center gap-1.5 border px-3 py-1.5 text-xs font-medium transition-colors duration-[var(--d-fast,120ms)]"
+    class="inline-flex shrink-0 items-center gap-1.5 border px-3 py-1.5 font-mono text-[11px] font-medium tracking-[0.06em] transition-colors duration-[var(--d-fast,120ms)]"
     :class="
       active
         ? 'border-primary bg-primary/10 text-primary'
-        : 'border-border bg-background text-muted-foreground hover:border-primary/50 hover:bg-primary/5'
+        : 'border-border bg-surface text-muted-foreground hover:border-border-strong hover:text-foreground'
     "
     @click="emit('select-filter', category)"
   >
     {{ label }}
     <span
-      class="inline-flex size-5 items-center justify-center rounded-full text-[10px] tabular-nums"
+      class="inline-flex px-1.5 py-px text-[10px] font-semibold"
       :class="
         active
           ? 'bg-primary text-primary-foreground'
-          : 'bg-muted text-muted-foreground'
+          : 'bg-surface-2 text-muted-foreground'
       "
     >
       {{ count }}

--- a/apps/client/app/components/home/FilterChip.vue
+++ b/apps/client/app/components/home/FilterChip.vue
@@ -15,12 +15,13 @@
 
 <template>
   <button
+    type="button"
     :aria-pressed="active"
     class="inline-flex shrink-0 items-center gap-1.5 border px-3 py-1.5 font-mono text-[11px] font-medium tracking-[0.06em] transition-colors duration-[var(--d-fast,120ms)]"
     :class="
       active
         ? 'border-primary bg-primary/10 text-primary'
-        : 'border-border bg-surface text-muted-foreground hover:border-border-strong hover:text-foreground'
+        : 'border-border bg-surface text-muted-foreground hover:border-foreground/20 hover:text-foreground'
     "
     @click="emit('select-filter', category)"
   >

--- a/apps/client/app/components/home/FilterChip.vue
+++ b/apps/client/app/components/home/FilterChip.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+  import type { FilterCategory } from '~/types/home-filters';
+
+  defineProps<{
+    label: string;
+    count: number;
+    category: FilterCategory;
+    active: boolean;
+  }>();
+
+  const emit = defineEmits<{
+    'select-filter': [category: FilterCategory];
+  }>();
+</script>
+
+<template>
+  <button
+    :aria-pressed="active"
+    class="inline-flex shrink-0 items-center gap-1.5 border px-3 py-1.5 text-xs font-medium transition-colors duration-[var(--d-fast,120ms)]"
+    :class="
+      active
+        ? 'border-primary bg-primary/10 text-primary'
+        : 'border-border bg-background text-muted-foreground hover:border-primary/50 hover:bg-primary/5'
+    "
+    @click="emit('select-filter', category)"
+  >
+    {{ label }}
+    <span
+      class="inline-flex size-5 items-center justify-center rounded-full text-[10px] tabular-nums"
+      :class="
+        active
+          ? 'bg-primary text-primary-foreground'
+          : 'bg-muted text-muted-foreground'
+      "
+    >
+      {{ count }}
+    </span>
+  </button>
+</template>

--- a/apps/client/app/components/home/Footer.vue
+++ b/apps/client/app/components/home/Footer.vue
@@ -5,15 +5,13 @@
 </script>
 
 <template>
-  <footer class="mt-auto border-t border-border/50 py-6">
-    <p class="text-center text-sm text-muted-foreground">
-      Tileserver RS — Built with Rust + Axum + MapLibre GL JS
-    </p>
-    <p
-      v-if="versionLabel"
-      class="mt-1 text-center font-mono text-xs text-muted-foreground/60"
-    >
+  <footer
+    class="footer border-t border-border py-5 flex flex-wrap gap-3 items-center justify-between text-[12px] text-muted-foreground"
+    role="contentinfo"
+  >
+    <div>tileserver-rs · MIT · © 2026</div>
+    <div v-if="versionLabel" class="font-mono text-[11px] tracking-[0.12em]">
       {{ versionLabel }}
-    </p>
+    </div>
   </footer>
 </template>

--- a/apps/client/app/components/home/Header.vue
+++ b/apps/client/app/components/home/Header.vue
@@ -1,33 +1,41 @@
 <script setup lang="ts">
   import { Globe, Moon, Settings, Sun } from '@lucide/vue';
+  import { useHomePage } from '~/composables/use-home-page';
 
-  defineProps<{
-    isDark: boolean;
-  }>();
-
-  const emit = defineEmits<{
-    toggleTheme: [];
-  }>();
-
-  function handleToggle() {
-    emit('toggleTheme');
-  }
+  const { isDark, toggleColorMode, pingQuery } = useHomePage();
 </script>
 
 <template>
-  <header class="sticky top-0 z-50 border-b border-border bg-background">
-    <div class="flex h-14 items-center justify-between px-6">
-      <div class="flex items-center gap-3">
-        <div class="flex size-9 items-center justify-center bg-primary">
+  <header
+    class="sticky top-0 z-30 border-b border-border bg-background/85 backdrop-blur-md"
+  >
+    <div
+      class="mx-auto flex min-h-14 max-w-[1600px] items-center justify-between gap-3 px-4 sm:px-6 lg:px-6"
+    >
+      <NuxtLink
+        to="/"
+        class="flex items-center gap-3"
+        aria-label="Tileserver RS home"
+      >
+        <div
+          class="flex size-9 items-center justify-center bg-primary"
+          aria-hidden="true"
+        >
           <Globe class="size-5 text-primary-foreground" />
         </div>
         <div>
-          <h1 class="text-lg font-semibold tracking-tight">Tileserver RS</h1>
-          <p class="text-xs text-muted-foreground">
-            High-performance vector tile server
-          </p>
+          <div class="text-lg font-semibold leading-none tracking-tight">
+            Tileserver RS
+          </div>
+          <div
+            v-if="pingQuery.data.value"
+            class="text-xs text-muted-foreground"
+          >
+            v{{ pingQuery.data.value.version }} · MCP
+          </div>
         </div>
-      </div>
+      </NuxtLink>
+
       <div class="flex items-center gap-1">
         <NuxtLink to="/admin" aria-label="Open admin">
           <Button variant="ghost" size="icon" as="span">
@@ -38,7 +46,7 @@
           variant="ghost"
           size="icon"
           aria-label="Toggle color mode"
-          @click="handleToggle"
+          @click="toggleColorMode"
         >
           <Sun v-if="isDark" class="size-5" />
           <Moon v-else class="size-5" />

--- a/apps/client/app/components/home/Header.vue
+++ b/apps/client/app/components/home/Header.vue
@@ -7,29 +7,32 @@
 
 <template>
   <header
-    class="sticky top-0 z-30 border-b border-border bg-background/85 backdrop-blur-md"
+    class="header sticky top-0 z-30 border-b border-border bg-background/85 backdrop-blur-md"
   >
     <div
-      class="mx-auto flex min-h-14 max-w-[1600px] items-center justify-between gap-3 px-4 sm:px-6 lg:px-6"
+      class="mx-auto flex min-h-14 max-w-[1600px] items-center justify-between gap-3 px-[clamp(12px,4vw,24px)]"
+      style="min-height: 56px"
     >
       <NuxtLink
         to="/"
-        class="flex items-center gap-3"
+        class="brand flex items-center gap-3 min-w-0"
         aria-label="Tileserver RS home"
       >
         <div
-          class="flex size-9 items-center justify-center bg-primary"
+          class="brand-glyph size-9 bg-primary grid place-items-center text-primary-foreground shrink-0 transition-filter duration-[var(--d-fast,120ms)]"
           aria-hidden="true"
         >
-          <Globe class="size-5 text-primary-foreground" />
+          <Globe class="size-5" />
         </div>
         <div>
-          <div class="text-lg font-semibold leading-none tracking-tight">
+          <div
+            class="brand-name text-[15px] font-bold tracking-tight leading-none"
+          >
             Tileserver RS
           </div>
           <div
             v-if="pingQuery.data.value"
-            class="text-xs text-muted-foreground"
+            class="brand-tag font-mono text-[10.5px] tracking-[0.14em] uppercase text-muted-foreground mt-0.5 font-medium"
           >
             v{{ pingQuery.data.value.version }} · MCP
           </div>
@@ -37,20 +40,22 @@
       </NuxtLink>
 
       <div class="flex items-center gap-1">
-        <NuxtLink to="/admin" aria-label="Open admin">
-          <Button variant="ghost" size="icon" as="span">
-            <Settings class="size-5" />
-          </Button>
+        <NuxtLink
+          to="/admin"
+          aria-label="Open admin settings"
+          class="icon-btn size-11 grid place-items-center text-muted-foreground transition-colors duration-[var(--d-fast,120ms)] hover:bg-surface hover:text-foreground"
+        >
+          <Settings class="size-[18px]" />
         </NuxtLink>
-        <Button
-          variant="ghost"
-          size="icon"
+        <button
+          type="button"
+          class="icon-btn size-11 grid place-items-center text-muted-foreground transition-colors duration-[var(--d-fast,120ms)] hover:bg-surface hover:text-foreground"
           aria-label="Toggle color mode"
           @click="toggleColorMode"
         >
-          <Sun v-if="isDark" class="size-5" />
-          <Moon v-else class="size-5" />
-        </Button>
+          <Sun v-if="isDark" class="size-[18px]" />
+          <Moon v-else class="size-[18px]" />
+        </button>
       </div>
     </div>
   </header>

--- a/apps/client/app/components/home/Hero.vue
+++ b/apps/client/app/components/home/Hero.vue
@@ -1,54 +1,132 @@
 <script setup lang="ts">
-  import { Globe, Moon, Settings, Sun } from '@lucide/vue';
-  import { motion } from 'motion-v';
+  import { Check, Globe, Moon, Settings, Sun, X } from '@lucide/vue';
+  import { useHomePage } from '~/composables/use-home-page';
 
-  defineProps<{
-    isDark: boolean;
-  }>();
+  const { isDark, toggleColorMode, pingQuery } = useHomePage();
 
-  const emit = defineEmits<{
-    toggleTheme: [];
-  }>();
+  const statusOk = computed(() => pingQuery.data.value?.status === 'ok');
+
+  function formatUptime(unix: number): string {
+    const now = Date.now() / 1000;
+    const diff = Math.max(0, now - unix);
+    if (diff < 60) return `${Math.floor(diff)}s`;
+    if (diff < 3600) return `${Math.floor(diff / 60)}m`;
+    if (diff < 86400) return `${Math.floor(diff / 3600)}h`;
+    return `${Math.floor(diff / 86400)}d`;
+  }
+
+  const cacheMb = computed(() => {
+    if (!pingQuery.data.value) return '—';
+    if (pingQuery.data.value.cache_enabled === false) {
+      return pingQuery.data.value.renderer_enabled ? '✓' : '✗';
+    }
+    return `${(pingQuery.data.value.cache_bytes / 1024 / 1024).toFixed(0)}`;
+  });
+
+  const stats = computed(() => [
+    { label: 'Sources', value: pingQuery.data.value?.loaded_sources ?? '—' },
+    { label: 'Styles', value: pingQuery.data.value?.loaded_styles ?? '—' },
+    { label: 'Cache', value: cacheMb.value },
+    {
+      label: 'Uptime',
+      value: pingQuery.data.value?.loaded_at_unix
+        ? formatUptime(pingQuery.data.value.loaded_at_unix)
+        : '—',
+    },
+  ]);
 </script>
 
 <template>
   <header
     class="sticky top-0 z-50 border-b border-border/50 bg-background/80 backdrop-blur-xl"
   >
-    <div class="flex h-14 items-center justify-between px-4">
-      <motion.div
-        :initial="{ opacity: 0, x: -12 }"
-        :animate="{ opacity: 1, x: 0 }"
-        :transition="{ duration: 0.4 }"
-        class="flex items-center gap-3"
-      >
-        <div
-          class="flex size-9 items-center justify-center bg-linear-to-br from-primary to-primary/80 shadow-lg shadow-primary/20"
-        >
-          <Globe class="size-5 text-primary-foreground" />
+    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+      <div class="flex h-14 items-center justify-between">
+        <div class="flex items-center gap-3">
+          <div class="flex size-9 items-center justify-center bg-primary">
+            <Globe class="size-5 text-primary-foreground" />
+          </div>
+          <div>
+            <h1 class="text-lg font-semibold tracking-tight">Tileserver RS</h1>
+            <p class="text-xs text-muted-foreground">
+              High-performance vector tile server
+            </p>
+          </div>
         </div>
-        <div>
-          <h1 class="text-lg font-semibold tracking-tight">Tileserver RS</h1>
-          <p class="text-xs text-muted-foreground">
-            High-performance vector tile server
-          </p>
-        </div>
-      </motion.div>
-      <div class="flex items-center gap-1">
-        <NuxtLink to="/admin" aria-label="Open admin">
-          <Button variant="ghost" size="icon" as="span">
-            <Settings class="size-5" />
+
+        <div class="flex items-center gap-1">
+          <NuxtLink to="/admin" aria-label="Open admin">
+            <Button variant="ghost" size="icon" as="span">
+              <Settings class="size-5" />
+            </Button>
+          </NuxtLink>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Toggle color mode"
+            @click="toggleColorMode"
+          >
+            <Sun v-if="isDark" class="size-5" />
+            <Moon v-else class="size-5" />
           </Button>
-        </NuxtLink>
-        <Button
-          variant="ghost"
-          size="icon"
-          aria-label="Toggle color mode"
-          @click="emit('toggleTheme')"
+        </div>
+      </div>
+
+      <div
+        class="flex flex-wrap items-center gap-x-4 gap-y-2 pb-4 sm:grid sm:grid-cols-[1fr_auto] sm:items-center"
+      >
+        <div class="flex items-center gap-3">
+          <span
+            v-if="pingQuery.data.value"
+            class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
+            :class="
+              statusOk
+                ? 'bg-success/10 text-success'
+                : 'bg-destructive/10 text-destructive'
+            "
+          >
+            <span
+              class="hero-dot relative size-2 rounded-full bg-success"
+            ></span>
+            Live
+          </span>
+          <span
+            v-if="pingQuery.data.value"
+            class="inline-flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground"
+          >
+            <Check
+              v-if="pingQuery.data.value.renderer_enabled"
+              class="size-3"
+            />
+            <X v-else class="size-3" />
+            Renderer
+          </span>
+          <span
+            v-if="pingQuery.data.value"
+            class="inline-flex rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground"
+          >
+            v{{ pingQuery.data.value.version }}
+          </span>
+        </div>
+
+        <div
+          class="hidden sm:grid grid-cols-4 divide-x divide-border border border-border text-sm tabular-nums"
         >
-          <Sun v-if="isDark" class="size-5" />
-          <Moon v-else class="size-5" />
-        </Button>
+          <div
+            v-for="stat in stats"
+            :key="stat.label"
+            class="px-3 py-2.5 text-center"
+          >
+            <div class="text-lg font-semibold text-foreground tabular-nums">
+              {{ stat.value }}
+            </div>
+            <div
+              class="text-[10px] uppercase tracking-widest text-muted-foreground"
+            >
+              {{ stat.label }}
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </header>

--- a/apps/client/app/components/home/Hero.vue
+++ b/apps/client/app/components/home/Hero.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-  import { Check, Globe, Moon, Settings, Sun, X } from '@lucide/vue';
+  import { Check, X } from '@lucide/vue';
   import { useHomePage } from '~/composables/use-home-page';
 
-  const { isDark, toggleColorMode, pingQuery } = useHomePage();
+  const { pingQuery } = useHomePage();
 
   const statusOk = computed(() => pingQuery.data.value?.status === 'ok');
 
@@ -23,111 +23,127 @@
     return `${(pingQuery.data.value.cache_bytes / 1024 / 1024).toFixed(0)}`;
   });
 
+  const isLoading = computed(() => pingQuery.isLoading.value);
+
   const stats = computed(() => [
     { label: 'Sources', value: pingQuery.data.value?.loaded_sources ?? '—' },
     { label: 'Styles', value: pingQuery.data.value?.loaded_styles ?? '—' },
-    { label: 'Cache', value: cacheMb.value },
+    { label: 'Cache', value: cacheMb.value, unit: 'MB' },
     {
       label: 'Uptime',
       value: pingQuery.data.value?.loaded_at_unix
         ? formatUptime(pingQuery.data.value.loaded_at_unix)
         : '—',
+      unit: '',
     },
   ]);
 </script>
 
 <template>
-  <header
-    class="sticky top-0 z-50 border-b border-border/50 bg-background/80 backdrop-blur-xl"
+  <section
+    class="mx-auto w-full max-w-[1600px] border-b border-border px-4 pb-5 pt-7 sm:px-6 sm:pb-8 sm:pt-12 lg:px-8"
+    aria-labelledby="hero-title"
   >
-    <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-      <div class="flex h-14 items-center justify-between">
-        <div class="flex items-center gap-3">
-          <div class="flex size-9 items-center justify-center bg-primary">
-            <Globe class="size-5 text-primary-foreground" />
-          </div>
-          <div>
-            <h1 class="text-lg font-semibold tracking-tight">Tileserver RS</h1>
-            <p class="text-xs text-muted-foreground">
-              High-performance vector tile server
-            </p>
-          </div>
-        </div>
-
-        <div class="flex items-center gap-1">
-          <NuxtLink to="/admin" aria-label="Open admin">
-            <Button variant="ghost" size="icon" as="span">
-              <Settings class="size-5" />
-            </Button>
-          </NuxtLink>
-          <Button
-            variant="ghost"
-            size="icon"
-            aria-label="Toggle color mode"
-            @click="toggleColorMode"
-          >
-            <Sun v-if="isDark" class="size-5" />
-            <Moon v-else class="size-5" />
-          </Button>
-        </div>
-      </div>
-
-      <div
-        class="flex flex-wrap items-center gap-x-4 gap-y-2 pb-4 sm:grid sm:grid-cols-[1fr_auto] sm:items-center"
-      >
-        <div class="flex items-center gap-3">
+    >
+    <div
+      class="grid grid-cols-1 items-end gap-6 sm:grid-cols-[1fr_auto] sm:gap-12"
+    >
+      <!-- Left: kicker pills + headline + subtitle -->
+      <div>
+        <div class="mb-3.5 flex flex-wrap gap-1.5">
+          <!-- Live pill -->
           <span
-            v-if="pingQuery.data.value"
-            class="inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-xs font-medium"
+            v-if="!isLoading"
+            class="inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium border"
             :class="
               statusOk
-                ? 'bg-success/10 text-success'
-                : 'bg-destructive/10 text-destructive'
+                ? 'border-success/30 bg-success/10 text-success'
+                : 'border-destructive/30 bg-destructive/10 text-destructive'
             "
           >
             <span
               class="hero-dot relative size-2 rounded-full bg-success"
             ></span>
-            Live
+            <span
+              class="font-mono text-[11px] font-semibold tracking-[0.10em] uppercase"
+              :class="statusOk ? 'text-success' : 'text-destructive'"
+              >Live</span
+            >
           </span>
+          <!-- Renderer pill -->
           <span
-            v-if="pingQuery.data.value"
-            class="inline-flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground"
+            v-if="!isLoading"
+            class="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1.5"
           >
             <Check
-              v-if="pingQuery.data.value.renderer_enabled"
-              class="size-3"
+              v-if="pingQuery.data.value?.renderer_enabled"
+              class="size-3 text-success"
             />
-            <X v-else class="size-3" />
-            Renderer
+            <X v-else class="size-3 text-muted-foreground" />
+            <span
+              class="font-mono text-[11px] font-semibold tracking-[0.10em] uppercase text-muted-foreground"
+              >Renderer</span
+            >
           </span>
+          <!-- Version pill -->
           <span
             v-if="pingQuery.data.value"
-            class="inline-flex rounded-full bg-muted px-2.5 py-0.5 text-xs font-medium text-muted-foreground"
+            class="inline-flex items-center rounded-full border border-border bg-surface px-3 py-1.5"
           >
-            v{{ pingQuery.data.value.version }}
+            <span
+              class="font-mono text-[11px] font-semibold tracking-[0.10em] uppercase text-muted-foreground"
+              >v{{ pingQuery.data.value.version }}</span
+            >
           </span>
         </div>
 
+        <h1
+          id="hero-title"
+          class="font-bold text-[clamp(28px,5vw,42px)] leading-[1.04] tracking-[-0.03em] mb-2.5 max-w-[22ch]"
+        >
+          Self-hosted tile server
+        </h1>
+        <p
+          class="text-[15px] text-muted-foreground leading-[1.55] max-w-[56ch]"
+        >
+          PMTiles, MBTiles, COG, STAC, OGC API and an MCP server in one Rust
+          binary.
+        </p>
+      </div>
+
+      <!-- Right: stats grid -->
+      <div
+        v-if="!isLoading"
+        class="stats-grid grid grid-cols-2 border border-border bg-surface sm:grid-cols-4 sm:max-w-[460px]"
+      >
         <div
-          class="hidden sm:grid grid-cols-4 divide-x divide-border border border-border text-sm tabular-nums"
+          v-for="(stat, idx) in stats"
+          :key="stat.label"
+          class="px-3.5 py-3 border-r border-border"
+          :class="[
+            idx % 2 === 1 ? 'border-r-0 sm:border-r' : '',
+            idx >= stats.length - 2 ? 'border-b-0' : 'border-b sm:border-b-0',
+            idx === stats.length - 1 ? 'sm:border-r-0' : '',
+          ]"
         >
           <div
-            v-for="stat in stats"
-            :key="stat.label"
-            class="px-3 py-2.5 text-center"
+            class="text-[10px] font-mono font-medium uppercase tracking-[0.12em] text-muted-foreground"
           >
-            <div class="text-lg font-semibold text-foreground tabular-nums">
-              {{ stat.value }}
-            </div>
-            <div
-              class="text-[10px] uppercase tracking-widest text-muted-foreground"
+            {{ stat.label }}
+          </div>
+          <div
+            class="mt-0.5 text-lg font-semibold tabular-nums text-foreground"
+          >
+            {{ stat.value
+            }}<span
+              v-if="'unit' in stat && stat.unit"
+              class="ml-0.5 text-sm font-medium text-muted-foreground"
             >
-              {{ stat.label }}
-            </div>
+              {{ stat.unit }}</span
+            >
           </div>
         </div>
       </div>
     </div>
-  </header>
+  </section>
 </template>

--- a/apps/client/app/components/home/Hero.vue
+++ b/apps/client/app/components/home/Hero.vue
@@ -1,10 +1,31 @@
 <script setup lang="ts">
-  import { Check, X } from '@lucide/vue';
   import { useHomePage } from '~/composables/use-home-page';
 
   const { pingQuery } = useHomePage();
 
   const statusOk = computed(() => pingQuery.data.value?.status === 'ok');
+  const isLoading = computed(() => pingQuery.isLoading.value);
+
+  const versionLabel = computed(() => {
+    if (!pingQuery.data.value) return '';
+    return `v${pingQuery.data.value.version}`;
+  });
+
+  const rendererEnabled = computed(
+    () => pingQuery.data.value?.renderer_enabled ?? false,
+  );
+
+  const cacheMb = computed(() => {
+    if (!pingQuery.data.value) return '—';
+    if (pingQuery.data.value.cache_enabled === false) {
+      return pingQuery.data.value.renderer_enabled ? '✓' : '✗';
+    }
+    return `${(pingQuery.data.value.cache_bytes / 1024 / 1024).toFixed(0)}`;
+  });
+
+  const cacheEnabled = computed(
+    () => pingQuery.data.value?.cache_enabled ?? false,
+  );
 
   function formatUptime(unix: number): string {
     const now = Date.now() / 1000;
@@ -15,133 +36,147 @@
     return `${Math.floor(diff / 86400)}d`;
   }
 
-  const cacheMb = computed(() => {
-    if (!pingQuery.data.value) return '—';
-    if (pingQuery.data.value.cache_enabled === false) {
-      return pingQuery.data.value.renderer_enabled ? '✓' : '✗';
-    }
-    return `${(pingQuery.data.value.cache_bytes / 1024 / 1024).toFixed(0)}`;
+  const uptime = computed(() => {
+    const unix = pingQuery.data.value?.loaded_at_unix;
+    if (!unix) return '—';
+    return formatUptime(unix);
   });
-
-  const isLoading = computed(() => pingQuery.isLoading.value);
-
-  const stats = computed(() => [
-    { label: 'Sources', value: pingQuery.data.value?.loaded_sources ?? '—' },
-    { label: 'Styles', value: pingQuery.data.value?.loaded_styles ?? '—' },
-    { label: 'Cache', value: cacheMb.value, unit: 'MB' },
-    {
-      label: 'Uptime',
-      value: pingQuery.data.value?.loaded_at_unix
-        ? formatUptime(pingQuery.data.value.loaded_at_unix)
-        : '—',
-      unit: '',
-    },
-  ]);
 </script>
 
 <template>
   <section
-    class="mx-auto w-full max-w-[1600px] border-b border-border px-4 pb-5 pt-7 sm:px-6 sm:pb-8 sm:pt-12 lg:px-8"
+    class="hero w-full max-w-[1600px] mx-auto border-b border-border grid gap-6 px-[clamp(16px,4vw,32px)] py-[clamp(20px,4vw,32px)]"
+    style="grid-template-columns: 1fr"
     aria-labelledby="hero-title"
   >
-    >
-    <div
-      class="grid grid-cols-1 items-end gap-6 sm:grid-cols-[1fr_auto] sm:gap-12"
-    >
-      <!-- Left: kicker pills + headline + subtitle -->
-      <div>
-        <div class="mb-3.5 flex flex-wrap gap-1.5">
-          <!-- Live pill -->
-          <span
-            v-if="!isLoading"
-            class="inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium border"
-            :class="
-              statusOk
-                ? 'border-success/30 bg-success/10 text-success'
-                : 'border-destructive/30 bg-destructive/10 text-destructive'
-            "
-          >
-            <span
-              class="hero-dot relative size-2 rounded-full bg-success"
-            ></span>
-            <span
-              class="font-mono text-[11px] font-semibold tracking-[0.10em] uppercase"
-              :class="statusOk ? 'text-success' : 'text-destructive'"
-              >Live</span
-            >
-          </span>
-          <!-- Renderer pill -->
-          <span
-            v-if="!isLoading"
-            class="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1.5"
-          >
-            <Check
-              v-if="pingQuery.data.value?.renderer_enabled"
-              class="size-3 text-success"
-            />
-            <X v-else class="size-3 text-muted-foreground" />
-            <span
-              class="font-mono text-[11px] font-semibold tracking-[0.10em] uppercase text-muted-foreground"
-              >Renderer</span
-            >
-          </span>
-          <!-- Version pill -->
-          <span
-            v-if="pingQuery.data.value"
-            class="inline-flex items-center rounded-full border border-border bg-surface px-3 py-1.5"
-          >
-            <span
-              class="font-mono text-[11px] font-semibold tracking-[0.10em] uppercase text-muted-foreground"
-              >v{{ pingQuery.data.value.version }}</span
-            >
-          </span>
-        </div>
-
-        <h1
-          id="hero-title"
-          class="font-bold text-[clamp(28px,5vw,42px)] leading-[1.04] tracking-[-0.03em] mb-2.5 max-w-[22ch]"
+    <div class="flex flex-col justify-end">
+      <div class="hero-meta-row flex flex-wrap gap-1.5 mb-3.5">
+        <span
+          v-if="!isLoading"
+          class="hero-meta inline-flex items-center gap-2.5 px-3 py-1.5 text-[11px] font-medium border"
+          :class="
+            statusOk
+              ? 'border-success/30 bg-success/10 text-success'
+              : 'border-destructive/30 bg-destructive/10 text-destructive'
+          "
         >
-          Self-hosted tile server
-        </h1>
-        <p
-          class="text-[15px] text-muted-foreground leading-[1.55] max-w-[56ch]"
+          <span
+            class="hero-dot size-2 rounded-full bg-current shrink-0"
+            :class="statusOk ? 'text-success' : 'text-destructive'"
+            aria-hidden="true"
+          ></span>
+          <span
+            class="uc-mono font-mono text-[11px] font-semibold tracking-[0.10em] uppercase"
+            >Live</span
+          >
+        </span>
+        <span
+          class="hero-meta neutral inline-flex items-center gap-2 px-3 py-1.5 text-[11px] font-medium border border-border bg-surface text-muted-foreground"
         >
-          PMTiles, MBTiles, COG, STAC, OGC API and an MCP server in one Rust
-          binary.
-        </p>
+          <span
+            class="uc-mono font-mono text-[11px] tracking-[0.10em] uppercase"
+            >Renderer {{ rendererEnabled ? '✓' : '✗' }}</span
+          >
+        </span>
+        <span
+          v-if="versionLabel"
+          class="hero-meta neutral inline-flex items-center px-3 py-1.5 text-[11px] font-medium border border-border bg-surface text-muted-foreground"
+        >
+          <span
+            class="uc-mono font-mono text-[11px] tracking-[0.10em] uppercase"
+            >{{ versionLabel }}</span
+          >
+        </span>
       </div>
 
-      <!-- Right: stats grid -->
+      <h1
+        id="hero-title"
+        class="text-[clamp(28px,5vw,42px)] font-bold leading-[1.04] tracking-[-0.03em] mb-2.5 max-w-[22ch]"
+      >
+        Self-hosted tile server
+      </h1>
+      <p class="text-[15px] text-muted-foreground leading-[1.55] max-w-[56ch]">
+        PMTiles, MBTiles, COG, STAC, OGC API and an MCP server in one Rust
+        binary.
+      </p>
+    </div>
+
+    <div
+      class="hero-stats grid gap-0 border border-border bg-surface"
+      style="
+        grid-template-columns: repeat(2, 1fr);
+        max-width: 460px;
+        margin-top: 16px;
+      "
+      role="list"
+      aria-label="Runtime metrics"
+    >
       <div
-        v-if="!isLoading"
-        class="stats-grid grid grid-cols-2 border border-border bg-surface sm:grid-cols-4 sm:max-w-[460px]"
+        class="hero-stat border-r border-b border-border p-3"
+        role="listitem"
       >
         <div
-          v-for="(stat, idx) in stats"
-          :key="stat.label"
-          class="px-3.5 py-3 border-r border-border"
-          :class="[
-            idx % 2 === 1 ? 'border-r-0 sm:border-r' : '',
-            idx >= stats.length - 2 ? 'border-b-0' : 'border-b sm:border-b-0',
-            idx === stats.length - 1 ? 'sm:border-r-0' : '',
-          ]"
+          class="hero-stat-l font-mono text-[10px] tracking-[0.18em] uppercase text-muted-foreground font-medium mb-1"
         >
-          <div
-            class="text-[10px] font-mono font-medium uppercase tracking-[0.12em] text-muted-foreground"
-          >
-            {{ stat.label }}
-          </div>
-          <div
-            class="mt-0.5 text-lg font-semibold tabular-nums text-foreground"
-          >
-            {{ stat.value
-            }}<span
-              v-if="'unit' in stat && stat.unit"
-              class="ml-0.5 text-sm font-medium text-muted-foreground"
+          Sources
+        </div>
+        <div
+          class="hero-stat-v font-mono text-[22px] font-semibold text-foreground tracking-[-0.02em] tabular-nums"
+        >
+          {{ pingQuery.data.value?.loaded_sources ?? '—' }}
+        </div>
+      </div>
+      <div
+        class="hero-stat border-r border-b border-border p-3"
+        style="border-right: none"
+        role="listitem"
+      >
+        <div
+          class="hero-stat-l font-mono text-[10px] tracking-[0.18em] uppercase text-muted-foreground font-medium mb-1"
+        >
+          Styles
+        </div>
+        <div
+          class="hero-stat-v font-mono text-[22px] font-semibold text-foreground tracking-[-0.02em] tabular-nums"
+        >
+          {{ pingQuery.data.value?.loaded_styles ?? '—' }}
+        </div>
+      </div>
+      <div class="hero-stat border-r border-border p-3" role="listitem">
+        <div
+          class="hero-stat-l font-mono text-[10px] tracking-[0.18em] uppercase text-muted-foreground font-medium mb-1"
+        >
+          Cache
+        </div>
+        <div
+          class="hero-stat-v font-mono text-[22px] font-semibold text-foreground tracking-[-0.02em] tabular-nums flex items-baseline gap-1"
+        >
+          <span v-if="!cacheEnabled">—</span>
+          <template v-else>
+            {{ cacheMb }}
+            <span class="unit text-[11px] font-medium text-muted-foreground"
+              >MB</span
             >
-              {{ stat.unit }}</span
-            >
-          </div>
+          </template>
+        </div>
+      </div>
+      <div
+        class="hero-stat border-r-0 p-3"
+        style="border-right: none"
+        role="listitem"
+      >
+        <div
+          class="hero-stat-l font-mono text-[10px] tracking-[0.18em] uppercase text-muted-foreground font-medium mb-1"
+        >
+          Uptime
+        </div>
+        <div
+          class="hero-stat-v font-mono text-[22px] font-semibold text-foreground tracking-[-0.02em] tabular-nums flex items-baseline gap-1"
+        >
+          <span v-if="!uptime">—</span>
+          <template v-else>
+            {{ uptime }}
+          </template>
         </div>
       </div>
     </div>

--- a/apps/client/app/components/home/Section.vue
+++ b/apps/client/app/components/home/Section.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+  import { ChevronDown } from '@lucide/vue';
+
+  defineProps<{
+    title: string;
+    count: number;
+    icon: string;
+    isOpen: boolean;
+  }>();
+
+  const emit = defineEmits<{
+    'toggle-section': [];
+  }>();
+</script>
+
+<template>
+  <section class="section" :class="{ open: isOpen }">
+    <button
+      class="section-toggle w-full flex items-center justify-between gap-3 px-[clamp(14px,3vw,20px)] py-3.5 min-h-14 transition-colors duration-[var(--d-fast,120ms)] hover:bg-surface-2/50"
+      :aria-expanded="isOpen"
+      :aria-controls="`section-body-${title.toLowerCase().replace(/\s+/g, '-')}`"
+      @click="emit('toggle-section')"
+    >
+      <div class="section-left flex items-center gap-3 min-w-0">
+        <div
+          class="section-icon size-9 bg-surface-2 grid place-items-center text-foreground transition-colors duration-[var(--d-fast,120ms)]"
+          :class="{ 'bg-primary/10 text-primary': isOpen }"
+          aria-hidden="true"
+        >
+          <component :is="icon" class="size-[18px]" />
+        </div>
+        <div>
+          <div class="section-title font-semibold text-[16px] leading-tight">
+            {{ title }}
+          </div>
+          <div
+            class="section-count font-mono text-[11px] text-muted-foreground mt-0.5 tracking-wide font-medium"
+          >
+            {{ count }}
+            {{ title.toLowerCase().includes('style') ? 'styles' : 'sources' }}
+          </div>
+        </div>
+      </div>
+      <ChevronDown
+        class="section-chev size-5 text-muted-foreground shrink-0 transition-transform duration-[var(--d-base,180ms)] ease-[var(--ease,cubic-bezier(0.16,1,0.3,1))]"
+        :class="{ 'rotate-180': isOpen }"
+        aria-hidden="true"
+      />
+    </button>
+    <div
+      :id="`section-body-${title.toLowerCase().replace(/\s+/g, '-')}`"
+      class="section-body-wrap"
+    >
+      <div class="section-body-inner">
+        <div
+          class="section-body grid gap-2 border-t border-border px-[clamp(12px,3vw,20px)] py-3"
+        >
+          <slot></slot>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/apps/client/app/components/home/StyleCard.vue
+++ b/apps/client/app/components/home/StyleCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
   import { Map } from '@lucide/vue';
+  import { motion } from 'motion-v';
   import type { Style } from '~/types/style';
 
   const props = defineProps<{
@@ -11,8 +12,8 @@
   }>();
 
   const emit = defineEmits<{
-    'toggle-xyz': [styleId: string];
-    'copy-url': [url: string];
+    toggleXyz: [styleId: string];
+    copyUrl: [url: string];
   }>();
 
   const imgError = ref(false);
@@ -22,29 +23,25 @@
   }
 
   function handleToggleXyz() {
-    emit('toggle-xyz', props.style.id);
+    emit('toggleXyz', props.style.id);
   }
 
   function handleServiceCopyUrl(url: string) {
-    emit('copy-url', url);
+    emit('copyUrl', url);
   }
-
-  const coverageLeft = computed(() => (props.style.minzoom * 100) / 18);
-  const coverageWidth = computed(
-    () => ((props.style.maxzoom - props.style.minzoom) * 100) / 18,
-  );
 </script>
 
 <template>
-  <article
-    class="card group border border-border/50 bg-background/50 p-4 transition-[border-color,background,box-shadow] duration-[var(--d-fast,120ms)]"
-    :style="{
-      '--tw-ring-color': 'oklch(from var(--color-primary) l c h / 0.15)',
-    }"
+  <motion.div
+    :initial="{ opacity: 0, y: 12 }"
+    :animate="{ opacity: 1, y: 0 }"
+    :transition="{ duration: 0.3, delay: 0.05 * index }"
+    class="group border border-border bg-background p-3.5 transition-all duration-[var(--d-fast,120ms)] hover:border-primary hover:bg-primary/2.5 focus-within:border-primary"
   >
-    <div class="flex gap-4">
+    <div class="flex gap-3.5">
+      <!-- 56x56 thumbnail per A2 -->
       <div
-        class="flex size-20 shrink-0 items-center justify-center overflow-hidden bg-muted ring-1 ring-border/50"
+        class="flex size-14 shrink-0 items-center justify-center overflow-hidden border border-border bg-surface-2"
       >
         <img
           v-if="!imgError"
@@ -54,20 +51,25 @@
           loading="lazy"
           @error="handleImgError"
         />
-        <Map v-else class="size-8 text-muted-foreground" />
+        <Map v-else class="size-5.5 text-muted-foreground" />
       </div>
 
+      <!-- Card content -->
       <div class="min-w-0 flex-1">
-        <div class="flex items-start justify-between gap-2">
-          <div>
-            <h3 class="font-semibold">{{ style.name }}</h3>
-            <p class="mt-0.5 text-sm text-muted-foreground">
-              <code class="bg-muted px-1.5 py-0.5 text-xs font-medium">{{
-                style.id
-              }}</code>
+        <div class="flex items-start justify-between gap-2.5">
+          <div class="min-w-0">
+            <h3 class="text-[15px] font-bold leading-snug tracking-[-0.005em]">
+              {{ style.name }}
+            </h3>
+            <p class="mt-0.5">
+              <code
+                class="inline-block bg-surface-2 px-1.5 py-0.5 font-mono text-[11px] font-medium text-muted-foreground"
+              >
+                {{ style.id }}
+              </code>
             </p>
           </div>
-          <Button as-child size="sm">
+          <Button as-child size="sm" class="shrink-0">
             <NuxtLink :to="`/styles/${style.id}/`">
               <Map class="mr-1.5 size-4" />
               Viewer
@@ -83,40 +85,7 @@
           @toggle-xyz="handleToggleXyz"
           @copy-url="handleServiceCopyUrl"
         />
-
-        <div class="mt-3">
-          <div
-            class="coverage h-[3px] w-full bg-muted"
-            role="img"
-            :aria-label="`Zoom range ${style.minzoom} to ${style.maxzoom}`"
-          >
-            <div
-              class="coverage-fill h-full bg-primary"
-              :style="{ left: `${coverageLeft}%`, width: `${coverageWidth}%` }"
-            ></div>
-          </div>
-          <div
-            class="mt-1 flex justify-between text-[10px] font-mono tracking-widest text-muted-foreground"
-            style="letter-spacing: 0.1em"
-          >
-            <span>z{{ style.minzoom }}</span>
-            <span>z{{ style.minzoom }}–{{ style.maxzoom }}</span>
-            <span>z18</span>
-          </div>
-        </div>
       </div>
     </div>
-  </article>
+  </motion.div>
 </template>
-
-<style scoped>
-  .card:hover {
-    border-color: var(--color-primary);
-    background: oklch(from var(--color-primary) l c h / 0.025);
-    box-shadow: inset 0 0 0 1px oklch(from var(--color-primary) l c h / 0.15);
-  }
-
-  .card:focus-within {
-    border-color: var(--color-primary);
-  }
-</style>

--- a/apps/client/app/components/home/StyleCard.vue
+++ b/apps/client/app/components/home/StyleCard.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
   import { Map } from '@lucide/vue';
-  import { motion } from 'motion-v';
   import type { Style } from '~/types/style';
 
   const props = defineProps<{
@@ -29,19 +28,26 @@
   function handleServiceCopyUrl(url: string) {
     emit('copyUrl', url);
   }
+
+  const coverageLeft = computed(
+    () => `${((props.style.minzoom ?? 0) * 100) / 18}%`,
+  );
+  const coverageWidth = computed(
+    () =>
+      `${(((props.style.maxzoom ?? 18) - (props.style.minzoom ?? 0)) * 100) / 18}%`,
+  );
 </script>
 
 <template>
-  <motion.div
-    :initial="{ opacity: 0, y: 12 }"
-    :animate="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.3, delay: 0.05 * index }"
-    class="group border border-border bg-background p-3.5 transition-all duration-[var(--d-fast,120ms)] hover:border-primary hover:bg-primary/2.5 focus-within:border-primary"
+  <article
+    class="card group border border-border bg-background p-3.5 transition-all duration-[var(--d-fast,120ms)] hover:border-primary hover:bg-primary/10 focus-within:border-primary"
+    style="
+      --tw-shadow: inset 0 0 0 1px oklch(from var(--color-primary) l c h / 0.15);
+    "
   >
     <div class="flex gap-3.5">
-      <!-- 56x56 thumbnail per A2 -->
       <div
-        class="flex size-14 shrink-0 items-center justify-center overflow-hidden border border-border bg-surface-2"
+        class="thumb size-14 shrink-0 overflow-hidden border border-border bg-surface-2 grid place-items-center"
       >
         <img
           v-if="!imgError"
@@ -54,16 +60,17 @@
         <Map v-else class="size-5.5 text-muted-foreground" />
       </div>
 
-      <!-- Card content -->
-      <div class="min-w-0 flex-1">
-        <div class="flex items-start justify-between gap-2.5">
+      <div class="card-main min-w-0 flex-1">
+        <div class="card-top flex items-start justify-between gap-2.5">
           <div class="min-w-0">
-            <h3 class="text-[15px] font-bold leading-snug tracking-[-0.005em]">
+            <h3
+              class="card-title text-[15px] font-bold tracking-[-0.005em] leading-[1.3]"
+            >
               {{ style.name }}
             </h3>
-            <p class="mt-0.5">
+            <p class="mt-1.5">
               <code
-                class="inline-block bg-surface-2 px-1.5 py-0.5 font-mono text-[11px] font-medium text-muted-foreground"
+                class="card-id font-mono text-[11px] bg-surface-2 px-1.5 py-0.5 text-muted-foreground tracking-wide"
               >
                 {{ style.id }}
               </code>
@@ -71,7 +78,7 @@
           </div>
           <Button as-child size="sm" class="shrink-0">
             <NuxtLink :to="`/styles/${style.id}/`">
-              <Map class="mr-1.5 size-4" />
+              <Map class="size-4 mr-1.5" />
               Viewer
             </NuxtLink>
           </Button>
@@ -85,7 +92,24 @@
           @toggle-xyz="handleToggleXyz"
           @copy-url="handleServiceCopyUrl"
         />
+
+        <div class="mt-3">
+          <div
+            class="coverage"
+            role="img"
+            :aria-label="`Zoom range ${style.minzoom ?? 0} to ${style.maxzoom ?? 18}`"
+          >
+            <div
+              class="coverage-fill"
+              :style="{ left: coverageLeft, width: coverageWidth }"
+            ></div>
+          </div>
+          <div class="coverage-labels">
+            <span>z{{ style.minzoom ?? 0 }}</span>
+            <span>z{{ style.maxzoom ?? 18 }}</span>
+          </div>
+        </div>
       </div>
     </div>
-  </motion.div>
+  </article>
 </template>

--- a/apps/client/app/components/home/StyleCard.vue
+++ b/apps/client/app/components/home/StyleCard.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
   import { Map } from '@lucide/vue';
-  import { motion } from 'motion-v';
   import type { Style } from '~/types/style';
 
   const props = defineProps<{
@@ -12,8 +11,8 @@
   }>();
 
   const emit = defineEmits<{
-    toggleXyz: [styleId: string];
-    copyUrl: [url: string];
+    'toggle-xyz': [styleId: string];
+    'copy-url': [url: string];
   }>();
 
   const imgError = ref(false);
@@ -23,20 +22,25 @@
   }
 
   function handleToggleXyz() {
-    emit('toggleXyz', props.style.id);
+    emit('toggle-xyz', props.style.id);
   }
 
   function handleServiceCopyUrl(url: string) {
-    emit('copyUrl', url);
+    emit('copy-url', url);
   }
+
+  const coverageLeft = computed(() => (props.style.minzoom * 100) / 18);
+  const coverageWidth = computed(
+    () => ((props.style.maxzoom - props.style.minzoom) * 100) / 18,
+  );
 </script>
 
 <template>
-  <motion.div
-    :initial="{ opacity: 0, y: 12 }"
-    :animate="{ opacity: 1, y: 0 }"
-    :transition="{ duration: 0.3, delay: 0.05 * index }"
-    class="group border border-border/50 bg-background/50 p-4 transition-all hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5"
+  <article
+    class="card group border border-border/50 bg-background/50 p-4 transition-[border-color,background,box-shadow] duration-[var(--d-fast,120ms)]"
+    :style="{
+      '--tw-ring-color': 'oklch(from var(--color-primary) l c h / 0.15)',
+    }"
   >
     <div class="flex gap-4">
       <div
@@ -46,7 +50,7 @@
           v-if="!imgError"
           :src="`/styles/${style.id}/static/0,0,1/160x160.png`"
           :alt="style.name"
-          class="size-full object-cover transition-transform group-hover:scale-105"
+          class="size-full object-cover"
           loading="lazy"
           @error="handleImgError"
         />
@@ -63,7 +67,7 @@
               }}</code>
             </p>
           </div>
-          <Button as-child size="sm" class="">
+          <Button as-child size="sm">
             <NuxtLink :to="`/styles/${style.id}/`">
               <Map class="mr-1.5 size-4" />
               Viewer
@@ -79,7 +83,40 @@
           @toggle-xyz="handleToggleXyz"
           @copy-url="handleServiceCopyUrl"
         />
+
+        <div class="mt-3">
+          <div
+            class="coverage h-[3px] w-full bg-muted"
+            role="img"
+            :aria-label="`Zoom range ${style.minzoom} to ${style.maxzoom}`"
+          >
+            <div
+              class="coverage-fill h-full bg-primary"
+              :style="{ left: `${coverageLeft}%`, width: `${coverageWidth}%` }"
+            ></div>
+          </div>
+          <div
+            class="mt-1 flex justify-between text-[10px] font-mono tracking-widest text-muted-foreground"
+            style="letter-spacing: 0.1em"
+          >
+            <span>z{{ style.minzoom }}</span>
+            <span>z{{ style.minzoom }}–{{ style.maxzoom }}</span>
+            <span>z18</span>
+          </div>
+        </div>
       </div>
     </div>
-  </motion.div>
+  </article>
 </template>
+
+<style scoped>
+  .card:hover {
+    border-color: var(--color-primary);
+    background: oklch(from var(--color-primary) l c h / 0.025);
+    box-shadow: inset 0 0 0 1px oklch(from var(--color-primary) l c h / 0.15);
+  }
+
+  .card:focus-within {
+    border-color: var(--color-primary);
+  }
+</style>

--- a/apps/client/app/components/home/StyleCardServices.vue
+++ b/apps/client/app/components/home/StyleCardServices.vue
@@ -10,8 +10,8 @@
   }>();
 
   const emit = defineEmits<{
-    toggleXyz: [];
-    copyUrl: [url: string];
+    'toggle-xyz': [];
+    'copy-url': [url: string];
   }>();
 
   const xyzUrl = computed(
@@ -23,14 +23,14 @@
   <div class="mt-2 flex items-center gap-3">
     <NuxtLink
       :to="`/styles/${style.id}/?raster`"
-      class="flex items-center gap-1.5 bg-muted/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      class="flex items-center gap-1.5 bg-muted/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-[border-color,background] duration-[var(--d-fast,120ms)] hover:bg-muted hover:text-foreground"
     >
       <Image class="size-3.5" />
       Raster
     </NuxtLink>
     <NuxtLink
       :to="`/styles/${style.id}/#2/0/0`"
-      class="flex items-center gap-1.5 bg-muted/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      class="flex items-center gap-1.5 bg-muted/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-[border-color,background] duration-[var(--d-fast,120ms)] hover:bg-muted hover:text-foreground"
     >
       <Grid3x3 class="size-3.5" />
       Vector
@@ -42,25 +42,28 @@
     <a
       :href="`/styles/${style.id}/style.json`"
       target="_blank"
-      class="text-primary hover:underline"
+      class="text-primary transition-colors hover:underline"
       >GL Style</a
     >
     <span class="text-muted-foreground/30">•</span>
     <a
       :href="`/styles/${style.id}.json`"
       target="_blank"
-      class="text-primary hover:underline"
+      class="text-primary transition-colors hover:underline"
       >TileJSON</a
     >
     <span class="text-muted-foreground/30">•</span>
     <a
       :href="`/styles/${style.id}/wmts.xml`"
       target="_blank"
-      class="text-primary hover:underline"
+      class="text-primary transition-colors hover:underline"
       >WMTS</a
     >
     <span class="text-muted-foreground/30">•</span>
-    <button class="text-primary hover:underline" @click="emit('toggleXyz')">
+    <button
+      class="text-primary transition-colors hover:underline"
+      @click="emit('toggle-xyz')"
+    >
       XYZ URL
     </button>
   </div>
@@ -76,7 +79,7 @@
       variant="ghost"
       size="icon"
       class="size-7 shrink-0"
-      @click="emit('copyUrl', xyzUrl)"
+      @click="emit('copy-url', xyzUrl)"
     >
       <Check v-if="copiedUrl === xyzUrl" class="size-3.5 text-success" />
       <Copy v-else class="size-3.5" />

--- a/apps/client/app/components/home/StyleCardServices.vue
+++ b/apps/client/app/components/home/StyleCardServices.vue
@@ -20,17 +20,17 @@
 </script>
 
 <template>
-  <div class="mt-2 flex items-center gap-3">
+  <div class="mt-2.5 flex items-center gap-2">
     <NuxtLink
       :to="`/styles/${style.id}/?raster`"
-      class="flex items-center gap-1.5 bg-muted/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-[border-color,background] duration-[var(--d-fast,120ms)] hover:bg-muted hover:text-foreground"
+      class="pill inline-flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium bg-surface-2 text-muted-foreground transition-colors duration-[var(--d-fast,120ms)] hover:bg-muted hover:text-foreground"
     >
       <Image class="size-3.5" />
       Raster
     </NuxtLink>
     <NuxtLink
       :to="`/styles/${style.id}/#2/0/0`"
-      class="flex items-center gap-1.5 bg-muted/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-[border-color,background] duration-[var(--d-fast,120ms)] hover:bg-muted hover:text-foreground"
+      class="pill inline-flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium bg-surface-2 text-muted-foreground transition-colors duration-[var(--d-fast,120ms)] hover:bg-muted hover:text-foreground"
     >
       <Grid3x3 class="size-3.5" />
       Vector
@@ -38,30 +38,34 @@
   </div>
 
   <div class="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
-    <span class="text-muted-foreground">Services:</span>
+    <span
+      class="lbl font-mono text-[10.5px] tracking-[0.10em] uppercase text-muted-foreground font-medium"
+      >Services:</span
+    >
     <a
       :href="`/styles/${style.id}/style.json`"
       target="_blank"
-      class="text-primary transition-colors hover:underline"
+      class="services-link text-primary font-medium transition-colors duration-[var(--d-fast,120ms)]"
       >GL Style</a
     >
-    <span class="text-muted-foreground/30">•</span>
+    <span class="sep text-muted-foreground opacity-50">·</span>
     <a
       :href="`/styles/${style.id}.json`"
       target="_blank"
-      class="text-primary transition-colors hover:underline"
+      class="services-link text-primary font-medium transition-colors duration-[var(--d-fast,120ms)]"
       >TileJSON</a
     >
-    <span class="text-muted-foreground/30">•</span>
+    <span class="sep text-muted-foreground opacity-50">·</span>
     <a
       :href="`/styles/${style.id}/wmts.xml`"
       target="_blank"
-      class="text-primary transition-colors hover:underline"
+      class="services-link text-primary font-medium transition-colors duration-[var(--d-fast,120ms)]"
       >WMTS</a
     >
-    <span class="text-muted-foreground/30">•</span>
+    <span class="sep text-muted-foreground opacity-50">·</span>
     <button
-      class="text-primary transition-colors hover:underline"
+      type="button"
+      class="services-link text-primary font-medium transition-colors duration-[var(--d-fast,120ms)]"
       @click="emit('toggle-xyz')"
     >
       XYZ URL
@@ -70,15 +74,16 @@
 
   <div
     v-if="isXyzExpanded"
-    class="mt-2 flex items-center gap-2 bg-muted/50 p-2"
+    class="mt-2 flex items-center gap-2 bg-surface-2 p-2"
   >
-    <code class="flex-1 truncate text-xs text-muted-foreground">{{
+    <code class="flex-1 truncate text-xs text-muted-foreground font-mono">{{
       xyzUrl
     }}</code>
     <Button
       variant="ghost"
       size="icon"
       class="size-7 shrink-0"
+      aria-label="Copy XYZ URL"
       @click="emit('copy-url', xyzUrl)"
     >
       <Check v-if="copiedUrl === xyzUrl" class="size-3.5 text-success" />

--- a/apps/client/app/components/home/StyleCardSkeleton.vue
+++ b/apps/client/app/components/home/StyleCardSkeleton.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts"></script>
+
+<template>
+  <article class="card border border-border bg-background p-3.5">
+    <div class="flex gap-3.5">
+      <Skeleton class="size-14 shrink-0" />
+      <div class="min-w-0 flex-1">
+        <Skeleton class="h-4 w-2/3" />
+        <Skeleton class="mt-1.5 h-3 w-1/3" />
+        <div class="mt-3 flex gap-2">
+          <Skeleton class="h-6 w-16" />
+          <Skeleton class="h-6 w-16" />
+        </div>
+      </div>
+    </div>
+  </article>
+</template>

--- a/apps/client/app/components/home/StyleListContent.vue
+++ b/apps/client/app/components/home/StyleListContent.vue
@@ -13,30 +13,35 @@
   }>();
 
   const emit = defineEmits<{
-    toggleXyz: [styleId: string];
-    copyUrl: [url: string];
+    'toggle-xyz': [styleId: string];
+    'copy-url': [url: string];
   }>();
 
-  function handleToggleXyz(styleId: string) {
-    emit('toggleXyz', styleId);
-  }
-
-  function handleCopyUrl(url: string) {
-    emit('copyUrl', url);
-  }
+  const SKELETON_COUNT = 5;
 </script>
 
 <template>
   <Separator class="bg-border/50" />
   <div class="p-4">
-    <div v-if="isLoading" class="flex justify-center py-12">
+    <div v-if="isLoading" class="space-y-3">
       <div
-        class="size-8 animate-spin rounded-full border-2 border-muted border-t-primary"
-      ></div>
+        v-for="i in SKELETON_COUNT"
+        :key="i"
+        class="border border-border/50 bg-background/50 p-4"
+      >
+        <div class="flex gap-4">
+          <Skeleton class="size-20 shrink-0" />
+          <div class="min-w-0 flex-1">
+            <Skeleton class="h-4 w-2/3" />
+            <Skeleton class="mt-2 h-3 w-1/3" />
+            <Skeleton class="mt-3 h-3 w-4/5" />
+          </div>
+        </div>
+      </div>
     </div>
     <div v-else-if="!hasStyles" class="py-12 text-center">
       <div
-        class="mx-auto mb-4 flex size-16 items-center justify-center bg-muted/50"
+        class="mx-auto mb-4 flex size-16 items-center justify-center bg-muted"
       >
         <Palette class="size-8 text-muted-foreground" />
       </div>
@@ -60,8 +65,8 @@
         :base-url="baseUrl"
         :is-xyz-expanded="expandedXyz.has(style.id)"
         :copied-url="copiedUrl"
-        @toggle-xyz="handleToggleXyz"
-        @copy-url="handleCopyUrl"
+        @toggle-xyz="emit('toggle-xyz', $event)"
+        @copy-url="emit('copy-url', $event)"
       />
     </div>
   </div>

--- a/apps/client/app/components/home/Toolbar.vue
+++ b/apps/client/app/components/home/Toolbar.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+  import { Search } from '@lucide/vue';
+  import type { FilterCategory } from '~/types/home-filters';
+  import HomeFilterChip from './FilterChip.vue';
+
+  defineProps<{
+    searchQuery: string;
+    allChips: Array<{
+      category: FilterCategory;
+      label: string;
+      count: number;
+    }>;
+    activeFilter: FilterCategory;
+  }>();
+
+  const emit = defineEmits<{
+    'update:searchQuery': [value: string];
+    'select-filter': [category: FilterCategory];
+  }>();
+
+  const searchInput = ref<HTMLInputElement | null>(null);
+
+  function handleSearch(value: string) {
+    emit('update:searchQuery', value);
+  }
+
+  function handleFilterClick(category: FilterCategory) {
+    emit('select-filter', category);
+  }
+</script>
+
+<template>
+  <div
+    class="sticky top-[3.5rem] z-40 border-b border-border/50 bg-background/95 backdrop-blur-sm"
+  >
+    <div
+      class="mx-auto flex max-w-7xl items-center gap-3 px-4 py-3 sm:px-6 lg:px-8"
+    >
+      <div class="relative flex-1">
+        <Search
+          class="pointer-events-none absolute top-1/2 left-4 size-4 -translate-y-1/2 text-muted-foreground transition-colors duration-[var(--d-fast,120ms)]"
+          :class="searchQuery ? 'text-primary' : 'text-muted-foreground'"
+        />
+        <input
+          ref="searchInput"
+          :value="searchQuery"
+          type="text"
+          placeholder="Search styles and data sources..."
+          class="h-11 w-full border border-border/50 bg-muted/30 pl-11 pr-4 text-sm transition-all duration-[var(--d-fast,120ms)] focus:border-primary focus:bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
+          :aria-label="'Search styles and data sources'"
+          @input="handleSearch(($event.target as HTMLInputElement).value)"
+        />
+      </div>
+      <div
+        class="flex gap-2 overflow-x-auto pb-0.5 scrollbar-thin"
+        style="scrollbar-width: thin"
+      >
+        <HomeFilterChip
+          v-for="chip in allChips"
+          :key="chip.category"
+          :label="chip.label"
+          :count="chip.count"
+          :category="chip.category"
+          :active="activeFilter === chip.category"
+          @select-filter="handleFilterClick"
+        />
+      </div>
+    </div>
+  </div>
+</template>

--- a/apps/client/app/components/home/Toolbar.vue
+++ b/apps/client/app/components/home/Toolbar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
   import { Search } from '@lucide/vue';
-  import type { FilterCategory } from '~/types/home-filters';
   import HomeFilterChip from './FilterChip.vue';
+  import type { FilterCategory } from '~/types/home-filters';
 
   defineProps<{
     searchQuery: string;
@@ -18,8 +18,6 @@
     'select-filter': [category: FilterCategory];
   }>();
 
-  const searchInput = ref<HTMLInputElement | null>(null);
-
   function handleSearch(value: string) {
     emit('update:searchQuery', value);
   }
@@ -31,40 +29,44 @@
 
 <template>
   <div
-    class="sticky top-[3.5rem] z-40 border-b border-border/50 bg-background/95 backdrop-blur-sm"
+    class="toolbar sticky z-19 bg-background/92 backdrop-blur-md border-b border-border flex flex-col gap-2.5"
+    style="top: 56px; padding: 10px clamp(12px, 4vw, 24px)"
   >
-    <div
-      class="mx-auto flex max-w-7xl items-center gap-3 px-4 py-3 sm:px-6 lg:px-8"
-    >
-      <div class="relative flex-1">
-        <Search
-          class="pointer-events-none absolute top-1/2 left-4 size-4 -translate-y-1/2 text-muted-foreground transition-colors duration-[var(--d-fast,120ms)]"
-          :class="searchQuery ? 'text-primary' : 'text-muted-foreground'"
-        />
-        <input
-          ref="searchInput"
-          :value="searchQuery"
-          type="text"
-          placeholder="Search styles and data sources..."
-          class="h-11 w-full border border-border/50 bg-muted/30 pl-11 pr-4 text-sm transition-all duration-[var(--d-fast,120ms)] focus:border-primary focus:bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
-          :aria-label="'Search styles and data sources'"
-          @input="handleSearch(($event.target as HTMLInputElement).value)"
-        />
-      </div>
-      <div
-        class="flex gap-2 overflow-x-auto pb-0.5 scrollbar-thin"
-        style="scrollbar-width: thin"
+    <div class="search relative">
+      <label class="sr-only" for="search-input"
+        >Search styles and data sources</label
       >
-        <HomeFilterChip
-          v-for="chip in allChips"
-          :key="chip.category"
-          :label="chip.label"
-          :count="chip.count"
-          :category="chip.category"
-          :active="activeFilter === chip.category"
-          @select-filter="handleFilterClick"
-        />
-      </div>
+      <input
+        id="search-input"
+        :value="searchQuery"
+        type="text"
+        placeholder="Search styles and data sources..."
+        autocomplete="off"
+        class="h-11 w-full border border-border bg-surface px-4 pl-11 text-[15px] text-foreground transition-colors duration-[var(--d-fast,120ms)] placeholder:text-muted-foreground focus:border-primary focus:bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
+        :class="searchQuery ? 'text-foreground' : 'text-muted-foreground'"
+        @input="handleSearch(($event.target as HTMLInputElement).value)"
+      />
+      <Search
+        class="pointer-events-none absolute left-3.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground transition-colors duration-[var(--d-fast,120ms)]"
+        :class="searchQuery ? 'text-primary' : 'text-muted-foreground'"
+        aria-hidden="true"
+      />
+    </div>
+    <div
+      class="filters flex gap-1.5 overflow-x-auto pb-0.5"
+      style="scrollbar-width: thin"
+      role="group"
+      aria-label="Filter by type"
+    >
+      <HomeFilterChip
+        v-for="chip in allChips"
+        :key="chip.category"
+        :label="chip.label"
+        :count="chip.count"
+        :category="chip.category"
+        :active="activeFilter === chip.category"
+        @select-filter="handleFilterClick"
+      />
     </div>
   </div>
 </template>

--- a/apps/client/app/components/ui/skeleton/Skeleton.vue
+++ b/apps/client/app/components/ui/skeleton/Skeleton.vue
@@ -5,8 +5,5 @@
 </script>
 
 <template>
-  <div
-    :class="cn('animate-pulse bg-muted', props.class)"
-    aria-hidden="true"
-  ></div>
+  <div :class="cn('skel', props.class)" aria-hidden="true"></div>
 </template>

--- a/apps/client/app/components/ui/toast/Toast.vue
+++ b/apps/client/app/components/ui/toast/Toast.vue
@@ -9,23 +9,14 @@
 
 <template>
   <Teleport to="body">
-    <Transition
-      enter-active-class="transition-transform duration-[var(--d-slow,320ms)] ease-[var(--ease,cubic-bezier(0.16,1,0.3,1))]"
-      enter-from-class="translate-y-full opacity-0"
-      enter-to-class="translate-y-0 opacity-100"
-      leave-active-class="transition-transform duration-[var(--d-slow,320ms)] ease-[var(--ease,cubic-bezier(0.16,1,0.3,1))]"
-      leave-from-class="translate-y-0 opacity-100"
-      leave-to-class="translate-y-full opacity-0"
+    <div
+      class="toast fixed bottom-6 left-1/2 z-50 flex -translate-x-1/2 items-center gap-2 border border-border bg-foreground px-4 py-3 font-mono text-[12px] tracking-[0.08em] uppercase font-semibold text-background shadow-lg transition-transform duration-[var(--d-slow,320ms)] ease-[var(--ease,cubic-bezier(0.16,1,0.3,1))]"
+      :class="visible ? 'translate-y-0' : 'translate-y-[150%]'"
+      role="status"
+      aria-live="polite"
     >
-      <div
-        v-if="visible"
-        class="toast fixed bottom-6 left-1/2 z-[100] flex -translate-x-1/2 items-center gap-2 border border-border bg-background px-4 py-2.5 text-sm shadow-lg"
-        role="status"
-        aria-live="polite"
-      >
-        <Check class="size-4 text-success" />
-        {{ message }}
-      </div>
-    </Transition>
+      <Check class="size-4 shrink-0 text-success" aria-hidden="true" />
+      {{ message }}
+    </div>
   </Teleport>
 </template>

--- a/apps/client/app/components/ui/toast/Toast.vue
+++ b/apps/client/app/components/ui/toast/Toast.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+  import { Check } from '@lucide/vue';
+
+  defineProps<{
+    visible: boolean;
+    message: string;
+  }>();
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-transform duration-[var(--d-slow,320ms)] ease-[var(--ease,cubic-bezier(0.16,1,0.3,1))]"
+      enter-from-class="translate-y-full opacity-0"
+      enter-to-class="translate-y-0 opacity-100"
+      leave-active-class="transition-transform duration-[var(--d-slow,320ms)] ease-[var(--ease,cubic-bezier(0.16,1,0.3,1))]"
+      leave-from-class="translate-y-0 opacity-100"
+      leave-to-class="translate-y-full opacity-0"
+    >
+      <div
+        v-if="visible"
+        class="toast fixed bottom-6 left-1/2 z-[100] flex -translate-x-1/2 items-center gap-2 border border-border bg-background px-4 py-2.5 text-sm shadow-lg"
+        role="status"
+        aria-live="polite"
+      >
+        <Check class="size-4 text-success" />
+        {{ message }}
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/apps/client/app/composables/admin/use-admin-config.ts
+++ b/apps/client/app/composables/admin/use-admin-config.ts
@@ -108,7 +108,9 @@ export function useAdminConfig() {
   const isPending = computed(
     () => configQuery.isPending.value || schemaQuery.isPending.value,
   );
-  const error = computed(() => configQuery.error.value ?? schemaQuery.error.value);
+  const error = computed(
+    () => configQuery.error.value ?? schemaQuery.error.value,
+  );
   const friendly = computed(() => friendlyAdminError(error.value));
 
   const loadedToml = computed(() => payload.value?.toml ?? '');
@@ -121,7 +123,10 @@ export function useAdminConfig() {
   const sections = computed<readonly ConfigSectionView[]>(() => {
     const toml = loadedToml.value;
     return schemaSections.value.map((section) => {
-      const { lines, occurrences, isPresent } = buildLinesForSection(section, toml);
+      const { lines, occurrences, isPresent } = buildLinesForSection(
+        section,
+        toml,
+      );
       return { schema: section, lines, occurrences, isPresent };
     });
   });

--- a/apps/client/app/composables/use-home-filters.ts
+++ b/apps/client/app/composables/use-home-filters.ts
@@ -1,0 +1,141 @@
+/**
+ * Home Filters Composable
+ *
+ * Generates filter chips from loaded source/style metadata.
+ * Chips are NOT hardcoded — see CLAUDE.md Rule #20.J.
+ */
+import type { FilterCategory, FilterChip } from '~/types/home-filters';
+import type { Data } from '~/types/data';
+import type { Style } from '~/types/style';
+import { useDataSourcesCollection } from '~/utils/collections/use-data-sources.collection';
+import { useMapStylesCollection } from '~/utils/collections/use-map-styles.collection';
+import { useLiveQuery } from '@tanstack/vue-db';
+
+export function useHomeFilters() {
+  const { dataSourcesCollection } = useDataSourcesCollection();
+  const { mapStylesCollection } = useMapStylesCollection();
+
+  const { data: dataSources } = useLiveQuery(dataSourcesCollection);
+  const { data: styles } = useLiveQuery(mapStylesCollection);
+
+  const activeFilter = ref<FilterCategory>('all');
+
+  const styleChips = computed<FilterChip[]>(() => {
+    const list = styles.value ?? [];
+    if (list.length === 0) return [];
+
+    const raster = list.filter(
+      (s: Style) =>
+        s.id.includes('raster') || s.name.toLowerCase().includes('raster'),
+    ).length;
+    const vector = list.length - raster;
+
+    const chips: FilterChip[] = [
+      { category: 'all', label: 'All', count: list.length },
+    ];
+    if (raster > 0)
+      chips.push({ category: 'raster', label: 'Raster', count: raster });
+    if (vector > 0)
+      chips.push({ category: 'vector', label: 'Vector', count: vector });
+    return chips;
+  });
+
+  /**
+   * Derive source type from tile URL format.
+   * Vector tiles: .pbf or .mvt extension
+   * Raster tiles: .png, .jpg, .webp, .jpeg extensions
+   */
+  function inferSourceFormat(data: Data): string {
+    const tile = data.tiles?.[0] ?? '';
+    if (tile.endsWith('.pbf') || tile.endsWith('.mvt')) return 'vector';
+    if (
+      tile.endsWith('.png') ||
+      tile.endsWith('.jpg') ||
+      tile.endsWith('.jpeg') ||
+      tile.endsWith('.webp')
+    )
+      return 'raster';
+    return 'vector';
+  }
+
+  const dataChips = computed<FilterChip[]>(() => {
+    const list = dataSources.value ?? [];
+    if (list.length === 0) return [];
+
+    const counts = new Map<string, number>();
+    for (const s of list) {
+      const format = inferSourceFormat(s as Data);
+      counts.set(format, (counts.get(format) ?? 0) + 1);
+    }
+
+    const chips: FilterChip[] = [
+      { category: 'all', label: 'All', count: list.length },
+    ];
+    for (const [format, count] of counts) {
+      const cat = format as FilterCategory;
+      chips.push({ category: cat, label: format, count });
+    }
+    return chips;
+  });
+
+  const allChips = computed<FilterChip[]>(() => {
+    const merged = new Map<FilterCategory, FilterChip>();
+    for (const chip of [...styleChips.value, ...dataChips.value]) {
+      const existing = merged.get(chip.category);
+      if (existing) {
+        existing.count += chip.count;
+      } else {
+        merged.set(chip.category, { ...chip });
+      }
+    }
+
+    const allCount =
+      (styles.value?.length ?? 0) + (dataSources.value?.length ?? 0);
+    const chips: FilterChip[] = [
+      { category: 'all', label: 'All', count: allCount },
+    ];
+    for (const chip of merged.values()) {
+      if (chip.category !== 'all') chips.push(chip);
+    }
+    return chips;
+  });
+
+  const filteredStyles = computed(() => {
+    const list = styles.value ?? [];
+    if (activeFilter.value === 'all') return list;
+    if (activeFilter.value === 'raster') {
+      return list.filter(
+        (s: Style) =>
+          s.id.includes('raster') || s.name.toLowerCase().includes('raster'),
+      );
+    }
+    if (activeFilter.value === 'vector') {
+      return list.filter(
+        (s: Style) =>
+          !s.id.includes('raster') && !s.name.toLowerCase().includes('raster'),
+      );
+    }
+    return list;
+  });
+
+  const filteredDataSources = computed(() => {
+    const list = dataSources.value ?? [];
+    if (activeFilter.value === 'all') return list;
+    if (activeFilter.value === 'raster' || activeFilter.value === 'vector') {
+      return list;
+    }
+    return list.filter((s: Data) => s.type === activeFilter.value);
+  });
+
+  function setFilter(filter: FilterCategory) {
+    activeFilter.value = filter;
+  }
+
+  return {
+    activeFilter,
+    allChips,
+    filteredStyles,
+    filteredDataSources,
+    setFilter,
+  };
+}

--- a/apps/client/app/composables/use-home-page.ts
+++ b/apps/client/app/composables/use-home-page.ts
@@ -1,14 +1,10 @@
-/**
- * Home Page Composable
- *
- * Manages all state and logic for the landing page:
- * search filtering, collapsible sections, XYZ URL expansion, clipboard copy.
- */
-
 import { useClipboard, useTimeoutFn } from '@vueuse/core';
-
 import type { Data } from '~/types/data';
 import type { Style } from '~/types/style';
+import { useHomeFilters } from './use-home-filters';
+import { usePingStats } from './use-server-info';
+import { useThemeToggle } from './use-theme-toggle';
+import { useTileserverData } from './use-tileserver-data';
 
 export function useHomePage() {
   const { isDark, toggle: toggleColorMode } = useThemeToggle();
@@ -20,18 +16,26 @@ export function useHomePage() {
     hasStyles,
     hasData,
   } = useTileserverData();
-  const { versionLabel } = useServerInfo();
+
+  const pingQuery = usePingStats();
 
   const { copy } = useClipboard();
 
-  // Search filter
+  const {
+    activeFilter,
+    allChips,
+    filteredStyles: typeFilteredStyles,
+    filteredDataSources: typeFilteredDataSources,
+    setFilter,
+  } = useHomeFilters();
+
   const searchQuery = ref('');
 
-  // Filtered lists
   const filteredStyles = computed(() => {
-    if (!searchQuery.value) return styles.value;
+    const list = typeFilteredStyles.value;
+    if (!searchQuery.value) return list;
     const query = searchQuery.value.toLowerCase();
-    return styles.value.filter(
+    return list.filter(
       (s: Style) =>
         s.name.toLowerCase().includes(query) ||
         s.id.toLowerCase().includes(query),
@@ -39,16 +43,16 @@ export function useHomePage() {
   });
 
   const filteredDataSources = computed(() => {
-    if (!searchQuery.value) return dataSources.value;
+    const list = typeFilteredDataSources.value;
+    if (!searchQuery.value) return list;
     const query = searchQuery.value.toLowerCase();
-    return dataSources.value.filter(
+    return list.filter(
       (s: Data) =>
         (s.name || '').toLowerCase().includes(query) ||
         s.id.toLowerCase().includes(query),
     );
   });
 
-  // Track which XYZ URLs are expanded
   const expandedStyleXyz = ref<Set<string>>(new Set());
   const expandedDataXyz = ref<Set<string>>(new Set());
 
@@ -70,7 +74,17 @@ export function useHomePage() {
     expandedDataXyz.value = new Set(expandedDataXyz.value);
   }
 
-  // Copy with feedback
+  const toastVisible = ref(false);
+  const toastMessage = ref('');
+
+  function showToast(message: string, duration = 1800) {
+    toastMessage.value = message;
+    toastVisible.value = true;
+    setTimeout(() => {
+      toastVisible.value = false;
+    }, duration);
+  }
+
   const copiedUrl = ref<string | null>(null);
   const { start: startCopyTimer } = useTimeoutFn(
     () => {
@@ -83,21 +97,19 @@ export function useHomePage() {
   function copyUrl(url: string) {
     copy(url);
     copiedUrl.value = url;
+    showToast('XYZ URL copied');
     startCopyTimer();
   }
 
-  // Collapsible sections
   const stylesOpen = ref(true);
   const dataOpen = ref(true);
 
   const baseUrl = computed(() => useRequestURL().origin);
 
   return {
-    // Theme
     isDark,
     toggleColorMode,
 
-    // Data
     dataSources,
     styles,
     isLoadingData,
@@ -105,29 +117,29 @@ export function useHomePage() {
     hasStyles,
     hasData,
 
-    // Server
-    versionLabel,
+    pingQuery,
 
-    // Search
     searchQuery,
+    activeFilter,
+    allChips,
+    setFilter,
     filteredStyles,
     filteredDataSources,
 
-    // XYZ expansion
     expandedStyleXyz,
     expandedDataXyz,
     toggleStyleXyz,
     toggleDataXyz,
 
-    // Clipboard
+    toastVisible,
+    toastMessage,
     copiedUrl,
     copyUrl,
+    showToast,
 
-    // Sections
     stylesOpen,
     dataOpen,
 
-    // URL
     baseUrl,
   };
 }

--- a/apps/client/app/composables/use-home-page.ts
+++ b/apps/client/app/composables/use-home-page.ts
@@ -17,7 +17,7 @@ export function useHomePage() {
     hasData,
   } = useTileserverData();
 
-  const pingQuery = usePingStats();
+  const { pingQuery } = usePingStats();
 
   const { copy } = useClipboard();
 

--- a/apps/client/app/composables/use-server-info.ts
+++ b/apps/client/app/composables/use-server-info.ts
@@ -1,4 +1,6 @@
 import type { PingResponse } from '~/types';
+import { useQuery } from '@tanstack/vue-query';
+import { pingQueryOptions } from '~/utils/api/server/queries';
 
 export function useServerInfo() {
   const { data, error } = useFetch<PingResponse>('/ping');
@@ -12,5 +14,52 @@ export function useServerInfo() {
     ping: data,
     pingError: error,
     versionLabel,
+  };
+}
+
+export function usePingStats() {
+  const pingQuery = useQuery(pingQueryOptions());
+
+  const versionLabel = computed(() => {
+    if (!pingQuery.data.value) return '';
+    return `v${pingQuery.data.value.version}`;
+  });
+
+  const sourceCount = computed(() => pingQuery.data.value?.loaded_sources ?? 0);
+  const styleCount = computed(() => pingQuery.data.value?.loaded_styles ?? 0);
+  const rendererEnabled = computed(
+    () => pingQuery.data.value?.renderer_enabled ?? false,
+  );
+  const cacheMB = computed(() => {
+    const bytes = pingQuery.data.value?.cache_bytes ?? 0;
+    if (bytes === 0) return '0';
+    return `${(bytes / 1024 / 1024).toFixed(0)}`;
+  });
+  const cacheEnabled = computed(
+    () => pingQuery.data.value?.cache_enabled ?? false,
+  );
+  const uptime = computed(() => {
+    const unix = pingQuery.data.value?.loaded_at_unix;
+    if (!unix) return '—';
+    const seconds = Math.floor(Date.now() / 1000 - unix);
+    if (seconds < 60) return `${seconds}s`;
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+    const days = Math.floor(seconds / 86400);
+    return `${days}d`;
+  });
+
+  return {
+    pingQuery,
+    ping: pingQuery.data,
+    pingError: pingQuery.error,
+    isLoading: pingQuery.isLoading,
+    versionLabel,
+    sourceCount,
+    styleCount,
+    rendererEnabled,
+    cacheMB,
+    cacheEnabled,
+    uptime,
   };
 }

--- a/apps/client/app/pages/admin/config.vue
+++ b/apps/client/app/pages/admin/config.vue
@@ -32,10 +32,10 @@
         </span>
       </div>
       <p class="mt-2 max-w-3xl text-sm text-muted-foreground">
-        Read-only view of the loaded server config. Each section shows the
-        keys you have set, followed by every other key available to add —
-        muted, with type, default, and description inline. Edit the source
-        file in your editor; tileserver-rs hot-reloads on file changes.
+        Read-only view of the loaded server config. Each section shows the keys
+        you have set, followed by every other key available to add — muted, with
+        type, default, and description inline. Edit the source file in your
+        editor; tileserver-rs hot-reloads on file changes.
       </p>
     </header>
 
@@ -52,7 +52,9 @@
         v-else-if="error"
         class="flex max-w-2xl flex-col gap-3 border border-destructive/40 bg-destructive/10 p-6"
       >
-        <div class="flex items-center gap-2 font-mono text-[11px] tracking-wider text-destructive uppercase">
+        <div
+          class="flex items-center gap-2 font-mono text-[11px] tracking-wider text-destructive uppercase"
+        >
           <TriangleAlert class="size-4" />
           {{ friendly.title }}
         </div>
@@ -95,7 +97,9 @@
             </span>
           </header>
 
-          <pre class="overflow-x-auto border border-border bg-card p-4 font-mono text-[13px] leading-relaxed"><template
+          <pre
+            class="overflow-x-auto border border-border bg-card p-4 font-mono text-[13px] leading-relaxed"
+          ><template
             v-for="(line, idx) in section.lines"
             :key="`${section.schema.header}-${idx}`"
           ><span
@@ -123,15 +127,18 @@
           <div class="flex flex-col gap-1.5 text-xs text-muted-foreground">
             <p>
               This view is read-only. To change a key, edit
-              <code v-if="sourcePath" class="text-foreground">{{ sourcePath }}</code>
+              <code v-if="sourcePath" class="text-foreground">{{
+                sourcePath
+              }}</code>
               <span v-else>your config file</span>
               in your editor and restart the server (or send
               <code class="text-foreground">POST /__admin/reload</code>).
             </p>
             <p>
               Type signatures, defaults, and feature gates are sourced from
-              <code class="text-foreground">crates/tileserver-rs/src/config.rs</code>.
-              See the Configuration reference in the docs for full details.
+              <code class="text-foreground"
+                >crates/tileserver-rs/src/config.rs</code
+              >. See the Configuration reference in the docs for full details.
             </p>
           </div>
         </footer>

--- a/apps/client/app/pages/admin/index.vue
+++ b/apps/client/app/pages/admin/index.vue
@@ -43,8 +43,8 @@
         Operator console
       </h1>
       <p class="mt-2 max-w-2xl text-sm text-muted-foreground">
-        Runtime status, connected MCP clients, and active device sessions
-        for this tileserver-rs instance.
+        Runtime status, connected MCP clients, and active device sessions for
+        this tileserver-rs instance.
       </p>
     </header>
 

--- a/apps/client/app/pages/index.vue
+++ b/apps/client/app/pages/index.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+  import { Database, Palette } from '@lucide/vue';
   import HomeToast from '~/components/ui/toast/Toast.vue';
 
   const {
@@ -25,6 +26,14 @@
     baseUrl,
     pingQuery,
   } = useHomePage();
+
+  const handleSearch = (value: string) => {
+    searchQuery.value = value;
+  };
+
+  const handleFilter = (category: FilterCategory) => {
+    setFilter(category);
+  };
 </script>
 
 <template>
@@ -38,39 +47,99 @@
       :search-query="searchQuery"
       :all-chips="allChips"
       :active-filter="activeFilter"
-      @update:search-query="searchQuery = $event"
-      @select-filter="setFilter"
+      @update:search-query="handleSearch"
+      @select-filter="handleFilter"
     />
 
-    <main id="main" class="w-full flex-1">
-      <div class="mx-auto max-w-[1600px] space-y-4 px-4 py-6 sm:px-6 lg:px-8">
-        <HomeStyleList
-          :styles="filteredStyles"
-          :is-loading="isLoadingStyles"
-          :has-styles="hasStyles"
+    <main id="main" class="w-full flex-1" role="main">
+      <div
+        class="mx-auto max-w-[1600px] px-[clamp(12px,4vw,24px)] py-5 flex flex-col gap-4"
+      >
+        <HomeSection
+          title="Map styles"
+          :count="filteredStyles.length"
+          :icon="Palette"
           :is-open="stylesOpen"
-          :search-query="searchQuery"
-          :base-url="baseUrl"
-          :expanded-xyz="expandedStyleXyz"
-          :copied-url="copiedUrl"
-          @update:is-open="stylesOpen = $event"
-          @toggle-xyz="toggleStyleXyz"
-          @copy-url="copyUrl"
-        />
+          @toggle-section="stylesOpen = !stylesOpen"
+        >
+          <template v-if="isLoadingStyles">
+            <HomeStyleCardSkeleton v-for="i in 5" :key="i" />
+          </template>
+          <template v-else-if="!hasStyles">
+            <div class="col-span-full py-12 text-center">
+              <div
+                class="mx-auto mb-4 flex size-16 items-center justify-center bg-surface-2"
+              >
+                <Palette class="size-8 text-muted-foreground" />
+              </div>
+              <p class="font-medium">No styles configured</p>
+              <p class="mt-1 text-sm text-muted-foreground">
+                Add styles to your config.toml
+              </p>
+            </div>
+          </template>
+          <template v-else-if="filteredStyles.length === 0">
+            <div class="col-span-full py-12 text-center text-muted-foreground">
+              No styles match "{{ searchQuery }}"
+            </div>
+          </template>
+          <template v-else>
+            <HomeStyleCard
+              v-for="(style, i) in filteredStyles"
+              :key="style.id"
+              :style="style"
+              :index="i"
+              :base-url="baseUrl"
+              :is-xyz-expanded="expandedStyleXyz.has(style.id)"
+              :copied-url="copiedUrl"
+              @toggle-xyz="toggleStyleXyz"
+              @copy-url="copyUrl"
+            />
+          </template>
+        </HomeSection>
 
-        <HomeDataList
-          :sources="filteredDataSources"
-          :is-loading="isLoadingData"
-          :has-data="hasData"
+        <HomeSection
+          title="Data sources"
+          :count="filteredDataSources.length"
+          :icon="Database"
           :is-open="dataOpen"
-          :search-query="searchQuery"
-          :base-url="baseUrl"
-          :expanded-xyz="expandedDataXyz"
-          :copied-url="copiedUrl"
-          @update:is-open="dataOpen = $event"
-          @toggle-xyz="toggleDataXyz"
-          @copy-url="copyUrl"
-        />
+          @toggle-section="dataOpen = !dataOpen"
+        >
+          <template v-if="isLoadingData">
+            <HomeDataCardSkeleton v-for="i in 5" :key="i" />
+          </template>
+          <template v-else-if="!hasData">
+            <div class="col-span-full py-12 text-center">
+              <div
+                class="mx-auto mb-4 flex size-16 items-center justify-center bg-surface-2"
+              >
+                <Database class="size-8 text-muted-foreground" />
+              </div>
+              <p class="font-medium">No data sources configured</p>
+              <p class="mt-1 text-sm text-muted-foreground">
+                Add PMTiles or MBTiles to config.toml
+              </p>
+            </div>
+          </template>
+          <template v-else-if="filteredDataSources.length === 0">
+            <div class="col-span-full py-12 text-center text-muted-foreground">
+              No data sources match "{{ searchQuery }}"
+            </div>
+          </template>
+          <template v-else>
+            <HomeDataCard
+              v-for="(source, i) in filteredDataSources"
+              :key="source.id"
+              :source="source"
+              :index="i"
+              :base-url="baseUrl"
+              :is-xyz-expanded="expandedDataXyz.has(source.id)"
+              :copied-url="copiedUrl"
+              @toggle-xyz="toggleDataXyz"
+              @copy-url="copyUrl"
+            />
+          </template>
+        </HomeSection>
 
         <HomeApiLink />
       </div>

--- a/apps/client/app/pages/index.vue
+++ b/apps/client/app/pages/index.vue
@@ -2,13 +2,10 @@
   import HomeToast from '~/components/ui/toast/Toast.vue';
 
   const {
-    isDark,
-    toggleColorMode,
     isLoadingData,
     isLoadingStyles,
     hasStyles,
     hasData,
-    ping,
     searchQuery,
     activeFilter,
     allChips,
@@ -26,14 +23,16 @@
     stylesOpen,
     dataOpen,
     baseUrl,
+    pingQuery,
   } = useHomePage();
 </script>
 
 <template>
   <div class="flex min-h-dvh flex-col bg-background">
-    <a class="skip-link" href="#main"> Skip to content </a>
+    <a class="skip-link" href="#main">Skip to content</a>
 
-    <HomeHero :is-dark="isDark" @toggle-theme="toggleColorMode" />
+    <HomeHeader />
+    <HomeHero />
 
     <HomeToolbar
       :search-query="searchQuery"
@@ -44,7 +43,7 @@
     />
 
     <main id="main" class="w-full flex-1">
-      <div class="mx-auto max-w-7xl space-y-4 px-4 py-6 sm:px-6 lg:px-8">
+      <div class="mx-auto max-w-[1600px] space-y-4 px-4 py-6 sm:px-6 lg:px-8">
         <HomeStyleList
           :styles="filteredStyles"
           :is-loading="isLoadingStyles"
@@ -77,7 +76,11 @@
       </div>
     </main>
 
-    <HomeFooter :version-label="ping?.version ? `v${ping.version}` : ''" />
+    <HomeFooter
+      :version-label="
+        pingQuery.data.value?.version ? `v${pingQuery.data.value.version}` : ''
+      "
+    />
 
     <HomeToast :visible="toastVisible" :message="toastMessage" />
   </div>

--- a/apps/client/app/pages/index.vue
+++ b/apps/client/app/pages/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+  import HomeToast from '~/components/ui/toast/Toast.vue';
+
   const {
     isDark,
     toggleColorMode,
@@ -6,60 +8,77 @@
     isLoadingStyles,
     hasStyles,
     hasData,
+    ping,
     searchQuery,
+    activeFilter,
+    allChips,
+    setFilter,
     filteredStyles,
     filteredDataSources,
     expandedStyleXyz,
     expandedDataXyz,
     toggleStyleXyz,
     toggleDataXyz,
+    toastVisible,
+    toastMessage,
     copiedUrl,
     copyUrl,
     stylesOpen,
     dataOpen,
     baseUrl,
-    versionLabel,
   } = useHomePage();
 </script>
 
 <template>
   <div class="flex min-h-dvh flex-col bg-background">
+    <a class="skip-link" href="#main"> Skip to content </a>
+
     <HomeHero :is-dark="isDark" @toggle-theme="toggleColorMode" />
 
-    <main class="w-full flex-1 space-y-4 p-4">
-      <HomeSearchBar v-model="searchQuery" />
+    <HomeToolbar
+      :search-query="searchQuery"
+      :all-chips="allChips"
+      :active-filter="activeFilter"
+      @update:search-query="searchQuery = $event"
+      @select-filter="setFilter"
+    />
 
-      <HomeStyleList
-        :styles="filteredStyles"
-        :is-loading="isLoadingStyles"
-        :has-styles="hasStyles"
-        :is-open="stylesOpen"
-        :search-query="searchQuery"
-        :base-url="baseUrl"
-        :expanded-xyz="expandedStyleXyz"
-        :copied-url="copiedUrl"
-        @update:is-open="stylesOpen = $event"
-        @toggle-xyz="toggleStyleXyz"
-        @copy-url="copyUrl"
-      />
+    <main id="main" class="w-full flex-1">
+      <div class="mx-auto max-w-7xl space-y-4 px-4 py-6 sm:px-6 lg:px-8">
+        <HomeStyleList
+          :styles="filteredStyles"
+          :is-loading="isLoadingStyles"
+          :has-styles="hasStyles"
+          :is-open="stylesOpen"
+          :search-query="searchQuery"
+          :base-url="baseUrl"
+          :expanded-xyz="expandedStyleXyz"
+          :copied-url="copiedUrl"
+          @update:is-open="stylesOpen = $event"
+          @toggle-xyz="toggleStyleXyz"
+          @copy-url="copyUrl"
+        />
 
-      <HomeDataList
-        :sources="filteredDataSources"
-        :is-loading="isLoadingData"
-        :has-data="hasData"
-        :is-open="dataOpen"
-        :search-query="searchQuery"
-        :base-url="baseUrl"
-        :expanded-xyz="expandedDataXyz"
-        :copied-url="copiedUrl"
-        @update:is-open="dataOpen = $event"
-        @toggle-xyz="toggleDataXyz"
-        @copy-url="copyUrl"
-      />
+        <HomeDataList
+          :sources="filteredDataSources"
+          :is-loading="isLoadingData"
+          :has-data="hasData"
+          :is-open="dataOpen"
+          :search-query="searchQuery"
+          :base-url="baseUrl"
+          :expanded-xyz="expandedDataXyz"
+          :copied-url="copiedUrl"
+          @update:is-open="dataOpen = $event"
+          @toggle-xyz="toggleDataXyz"
+          @copy-url="copyUrl"
+        />
 
-      <HomeApiLink />
+        <HomeApiLink />
+      </div>
     </main>
 
-    <HomeFooter :version-label="versionLabel" />
+    <HomeFooter :version-label="ping?.version ? `v${ping.version}` : ''" />
+
+    <HomeToast :visible="toastVisible" :message="toastMessage" />
   </div>
 </template>

--- a/apps/client/app/types/home-filters.ts
+++ b/apps/client/app/types/home-filters.ts
@@ -1,0 +1,23 @@
+/**
+ * Filter chip types derived from loaded source/style metadata.
+ *
+ * Chips are NOT hardcoded — they are computed from actual type counts
+ * in use-home-filters.ts. See CLAUDE.md Rule #20.J.
+ */
+export interface FilterChip {
+  category: FilterCategory;
+  label: string;
+  count: number;
+}
+
+export type FilterCategory =
+  | 'all'
+  | 'raster'
+  | 'vector'
+  | 'pmtiles'
+  | 'mbtiles'
+  | 'stac'
+  | 'postgis'
+  | 'mlt'
+  | 'cog'
+  | 'geoparquet';

--- a/apps/client/app/types/index.ts
+++ b/apps/client/app/types/index.ts
@@ -17,6 +17,7 @@ export type {
   AdminNavItem,
 } from './admin-mcp';
 export type { Data, VectorLayer } from './data';
+export type { FilterCategory, FilterChip } from './home-filters';
 export type { OfetchLikeError } from './fetch';
 export type { VMapOptions } from './map';
 export type { PingResponse } from './server';

--- a/apps/client/app/types/server.ts
+++ b/apps/client/app/types/server.ts
@@ -1,3 +1,9 @@
+/**
+ * PingResponse — mirrors the Rust admin.rs `PingResponse` struct exactly.
+ *
+ * Every field here MUST come from the `/ping` endpoint.
+ * Never add fake metrics (p50, p99, region, QPS) — see HONEST-DATA RULE (CLAUDE.md Rule #20).
+ */
 export interface PingResponse {
   status: string;
   config_hash: string;
@@ -5,5 +11,9 @@ export interface PingResponse {
   loaded_sources: number;
   loaded_styles: number;
   renderer_enabled: boolean;
+  prometheus_listener_active: boolean;
   version: string;
+  cache_enabled: boolean;
+  cache_entries: number;
+  cache_bytes: number;
 }

--- a/apps/client/app/types/style.ts
+++ b/apps/client/app/types/style.ts
@@ -3,6 +3,8 @@ export interface Style {
   name: string;
   url: string;
   version: number;
+  minzoom?: number;
+  maxzoom?: number;
 }
 
 export interface TileJSON {

--- a/apps/client/app/utils/api/admin-config/index.ts
+++ b/apps/client/app/utils/api/admin-config/index.ts
@@ -1,1 +1,4 @@
-export { adminConfigQueryOptions, adminConfigSchemaQueryOptions } from './queries';
+export {
+  adminConfigQueryOptions,
+  adminConfigSchemaQueryOptions,
+} from './queries';

--- a/apps/client/app/utils/api/admin-mcp/friendly-error.ts
+++ b/apps/client/app/utils/api/admin-mcp/friendly-error.ts
@@ -50,7 +50,9 @@ function requestPathOf(error: Error | null): string | null {
   return null;
 }
 
-function joinHint(parts: ReadonlyArray<string | null | undefined>): string | undefined {
+function joinHint(
+  parts: ReadonlyArray<string | null | undefined>,
+): string | undefined {
   const present = parts.filter((p): p is string => Boolean(p));
   return present.length > 0 ? present.join(' · ') : undefined;
 }


### PR DESCRIPTION
## Summary

Migration of the home page (\) from the legacy grid layout to the **A2 Density Plus** design direction, following the design reference at \.

### What Changed

**Hero**: 2-column grid with status kicker pills (Live with pulse animation, Renderer check, version badge) and a 4-stat strip (Sources / Styles / Cache MB / Uptime) derived from honest \ fields. Zero fabricated metrics.

**Toolbar**: Sticky search + dynamic filter chips computed from actual loaded source/style type counts (not hardcoded). FilterChip uses \ state.

**Cards**: Direction-I sharp-corner hover with border-color transition + soft inset ring only — no transform, no layout shift (Rule #20.C). Coverage bar visualizing zoom range. \ button conditionally gated on \ presence. XYZ URL copy triggers a bottom-center toast (\, \).

**Loading**: Skeleton shimmer replacing spinners inside cards during data fetch (Rule #20.F).

**Styles**: Motion tokens (\ 120ms, \ 180ms, \ 320ms), a11y baseline (skip-to-content link, focus-visible 2px violet rings, reduced-motion reset, sr-only), coverage bar CSS, hero ping pulse keyframe.

**CLAUDE.md**: New Rule #20 encoding the full A2 operator-list pattern — hero composition, sticky toolbar, card hover rules, coverage bar, Inspect conditionality, skeleton shimmer, toast API, motion tokens, a11y requirements, toolbar/filter derivation rule (Rule #20.J).

### Bug Fixes

| Fix | Root cause | Resolution |
|-----|-----------|------------|
| Hero stats showed — | \ only returned convenience computeds, not the raw \ observer | Return \ via spread so \ can access \ |
| Stats strip collapsed to single column | Used \ layout | Changed to \ grid |
| Filter chips showed unknown/incorrect types | \ does not exist in TileJSON API response | Derive format from tile URL extension via \ (\/\ = vector, \/\ = raster) |
| Type mismatch \ vs \ | Different field names in type vs consumer | Unified to \ |

### Gates

- \ ✓
- \Finished in 480ms on 175 files using 12 threads. ✓
- \┌  Building Nuxt for production...
│
●  Nuxt 4.4.6 (with Nitro 2.13.4, Vite 8.0.14 and Vue 3.5.34)
│
●  Nitro preset: static
[info] [36mvite v8.0.14 [32mbuilding client environment for production...[36m[39m
[2Ktransforming...✓ 4757 modules transformed.
rendering chunks...
computing gzip size...
[info] node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/parse-shapefile-C2Z8TQTF.js      1.05 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/parse-csv-BuBSNnKH.js            1.94 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/parse-geojson-DY1TfAlS.js        2.37 kB
node_modules/.cache/nuxt/.nuxt/dist/client/manifest.json                         16.02 kB │ gzip:     1.67 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/papaparse.min-DYNbz7ad.js       19.29 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/lib-yE9xDk5G.js                139.64 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/_style_.DzF1fjPm.css             0.38 kB │ gzip:     0.17 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/error-500.DmTE_aKO.css           1.90 kB │ gzip:     0.72 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/error-404.CitSlego.css           2.42 kB │ gzip:     0.85 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/entry.FbNeHBpX.css             144.40 kB │ gzip:    22.87 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/D3hinKF12.js                     0.13 kB │ gzip:     0.13 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/CT6QeyqQ2.js                     0.14 kB │ gzip:     0.14 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/Byah0G2A.js                      0.15 kB │ gzip:     0.15 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/BdgXzY2F.js                      0.18 kB │ gzip:     0.16 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/CJ3twqfo.js                      0.19 kB │ gzip:     0.16 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/BqFE2equ.js                      0.26 kB │ gzip:     0.18 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/Dgud-eja.js                      0.40 kB │ gzip:     0.22 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/Bmol7l3d.js                      0.40 kB │ gzip:     0.25 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/BrPhBehy.js                      0.67 kB │ gzip:     0.39 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/BfX9F9uB.js                      0.76 kB │ gzip:     0.43 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/Bx3SS2n9.js                      0.82 kB │ gzip:     0.45 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/DwH2U3mj.js                      1.25 kB │ gzip:     0.63 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/DDWmgDmh.js                      1.29 kB │ gzip:     0.73 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/SUrLemaT.js                      2.34 kB │ gzip:     0.97 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/c0QJpLho.js                      3.43 kB │ gzip:     1.53 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/BCwGEeYR.js                      3.46 kB │ gzip:     1.56 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/wDrp1P3P.js                      3.58 kB │ gzip:     1.59 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/BNVEud9_.js                      3.75 kB │ gzip:     1.69 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/BzTrSLxs.js                      5.27 kB │ gzip:     2.06 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/kBA4T-lF.js                      5.96 kB │ gzip:     2.61 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/C_CE0w81.js                      6.79 kB │ gzip:     2.79 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/CoZY1Y93.js                      7.08 kB │ gzip:     2.62 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/DPh0YSM5.js                      7.37 kB │ gzip:     3.23 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/BP_fRaUu.js                      8.99 kB │ gzip:     2.89 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/Cbn5Kjju.js                     11.07 kB │ gzip:     3.33 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/DU8YEE5u.js                     11.76 kB │ gzip:     4.07 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/COHDEZcM.js                     14.99 kB │ gzip:     5.25 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/FS2WyMzu.js                     17.36 kB │ gzip:     7.20 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/6oFQS4em.js                     19.90 kB │ gzip:     5.04 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/B6KiDbIe.js                     27.26 kB │ gzip:     8.69 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/DpAw8FkA.js                     38.15 kB │ gzip:    13.72 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/Bx5L168f.js                    117.77 kB │ gzip:    35.15 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/Bnh9N4O8.js                    121.77 kB │ gzip:    39.07 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/BLMX8rHF.js                    122.37 kB │ gzip:    35.64 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/BoSu2_Ec.js                    136.13 kB │ gzip:    38.83 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/yHBP0rSb.js                    233.32 kB │ gzip:    83.30 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/DOft5b3m.js                  2,561.95 kB │ gzip:   698.89 kB
node_modules/.cache/nuxt/.nuxt/dist/client/_nuxt/aaZaYKJq.js                  6,558.75 kB │ gzip: 2,339.70 kB

[info] [32m✓ built in 7.04s[39m
[info] [36mvite v8.0.14 [32mbuilding ssr environment for production...[36m[39m
[2Ktransforming...✓ 2 modules transformed.
rendering chunks...
[info] node_modules/.cache/nuxt/.nuxt/dist/server/styles.mjs  0.06 kB
node_modules/.cache/nuxt/.nuxt/dist/server/server.mjs  0.32 kB │ map: 0.37 kB

[info] [32m✓ built in 32ms[39m
[info] [nitro] Initializing prerenderer
[info] [nitro] Prerendering 8 initial routes with crawler
[log] [nitro]   ├─ / (16ms)
[log] [nitro]   ├─ /admin (15ms)
[log] [nitro]   ├─ /200.html (16ms)
[log] [nitro]   ├─ /404.html (16ms)
[log] [nitro]   ├─ /index.html (16ms)
[log] [nitro]   ├─ /admin/mcp/connected-apps (16ms)
[log] [nitro]   ├─ /admin/mcp/devices (15ms)
[log] [nitro]   ├─ /admin/config (15ms)
[info] [nitro] Prerendered 8 routes in 0.386 seconds
[success] [nitro] Generated public .output/public
[success] [nitro] You can preview this build using `npx serve .output/public`
[log] │
└  ✨ Build complete! ✓
- \ ✓
- \ ✓
