### PR TITLE
feat(client): mobile-responsive /admin layout

### DIFF
--- a/apps/client/app/assets/css/tailwind.css
+++ b/apps/client/app/assets/css/tailwind.css
@@ -9,17 +9,6 @@
   --font-display: 'General Sans', ui-sans-serif, system-ui, sans-serif;
   --font-serif: 'Source Serif 4', ui-serif, Georgia, serif;
 
-  /* Direction I — Linear-density-v2 OKLch palette. Three elevation levels for
-     light mode (CLAUDE.md Rule #19). warm-cool 270 hue stays consistent across
-     light + dark so surfaces share visual continuity regardless of mode.
-
-     Elevation philosophy: bg = lightest, card slightly darker (visible border
-     against bg), muted darker still (chips, code, count badges).
-
-         bg          0.985   page background, card hover tint, search focus bg
-         card        0.965   sections, hero stat strip, search input, filter chips
-         muted       0.935   thumbnails, code tags, count badges, section icons
-  */
   --color-background: oklch(0.985 0.004 270);
   --color-foreground: oklch(0.18 0.014 270);
   --color-card: oklch(0.965 0.005 270);

--- a/apps/client/app/composables/admin/use-admin-layout.ts
+++ b/apps/client/app/composables/admin/use-admin-layout.ts
@@ -23,6 +23,23 @@ export function useAdminLayout() {
   const route = useRoute();
   const { isDark, toggle: toggleTheme } = useThemeToggle();
 
+  // Mobile drawer state — sidebar is hidden <lg, opened via hamburger.
+  const isMobileNavOpen = ref(false);
+
+  function openMobileNav(): void {
+    isMobileNavOpen.value = true;
+  }
+
+  function closeMobileNav(): void {
+    isMobileNavOpen.value = false;
+  }
+
+  // Auto-close drawer when route changes so taps on nav links collapse it.
+  watch(
+    () => route.path,
+    () => closeMobileNav(),
+  );
+
   function isActive(to: string): boolean {
     if (to === '/admin') return route.path === '/admin';
     return route.path === to || route.path.startsWith(`${to}/`);
@@ -33,5 +50,8 @@ export function useAdminLayout() {
     isActive,
     isDark,
     toggleTheme,
+    isMobileNavOpen,
+    openMobileNav,
+    closeMobileNav,
   };
 }

--- a/apps/client/app/layouts/admin.vue
+++ b/apps/client/app/layouts/admin.vue
@@ -1,14 +1,172 @@
 <script setup lang="ts">
-  import { Moon, Sun } from '@lucide/vue';
+  import { Menu, Moon, Sun, X } from '@lucide/vue';
+  import { useEventListener } from '@vueuse/core';
   import { useAdminLayout } from '~/composables/admin/use-admin-layout';
 
-  const { navGroups, isActive, isDark, toggleTheme } = useAdminLayout();
+  const {
+    navGroups,
+    isActive,
+    isDark,
+    toggleTheme,
+    isMobileNavOpen,
+    openMobileNav,
+    closeMobileNav,
+  } = useAdminLayout();
+
+  useEventListener('keydown', (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && isMobileNavOpen.value) {
+      closeMobileNav();
+    }
+  });
 </script>
 
 <template>
-  <div class="flex min-h-dvh w-full bg-background">
+  <div class="flex h-dvh w-full overflow-hidden bg-background">
+    <!-- Mobile top bar (<lg only) — brand left + hamburger right. -->
+    <header
+      class="fixed inset-x-0 top-0 z-40 flex h-14 shrink-0 items-center justify-between border-b border-border bg-background px-4 lg:hidden"
+      role="banner"
+    >
+      <NuxtLink to="/admin" class="flex items-center gap-2.5">
+        <div
+          class="flex size-7 items-center justify-center bg-primary text-primary-foreground"
+        >
+          <span class="font-display text-sm font-bold">T</span>
+        </div>
+        <div class="flex flex-col leading-tight">
+          <span
+            class="font-mono text-[10px] uppercase tracking-wider text-muted-foreground"
+            >tileserver-rs</span
+          >
+          <span class="text-[13px] font-semibold text-foreground">Admin</span>
+        </div>
+      </NuxtLink>
+      <button
+        type="button"
+        aria-label="Open navigation menu"
+        aria-controls="admin-mobile-drawer"
+        :aria-expanded="isMobileNavOpen"
+        class="flex size-10 items-center justify-center border border-border text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+        @click="openMobileNav"
+      >
+        <Menu class="size-5" />
+      </button>
+    </header>
+
+    <!-- Mobile drawer backdrop (<lg) — closes on tap. -->
+    <Transition
+      enter-from-class="opacity-0"
+      leave-to-class="opacity-0"
+      enter-active-class="transition-opacity duration-200"
+      leave-active-class="transition-opacity duration-200"
+    >
+      <button
+        v-if="isMobileNavOpen"
+        type="button"
+        aria-label="Close navigation menu"
+        class="fixed inset-0 z-40 bg-foreground/40 lg:hidden"
+        @click="closeMobileNav"
+      ></button>
+    </Transition>
+
+    <!-- Sidebar — desktop persistent, mobile drawer (slide-in from left). -->
+    <Transition
+      enter-from-class="-translate-x-full"
+      leave-to-class="-translate-x-full"
+      enter-active-class="transition-transform duration-200 ease-out"
+      leave-active-class="transition-transform duration-200 ease-out"
+    >
+      <aside
+        v-if="isMobileNavOpen"
+        id="admin-mobile-drawer"
+        class="fixed left-0 top-0 z-50 flex h-dvh w-72 flex-col border-r border-border bg-background lg:hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Navigation menu"
+      >
+        <div
+          class="flex items-center justify-between border-b border-border px-5 py-4"
+        >
+          <div class="flex items-center gap-3">
+            <div
+              class="flex size-7 items-center justify-center bg-primary text-primary-foreground"
+            >
+              <span class="font-display text-sm font-bold">T</span>
+            </div>
+            <div class="flex flex-col leading-tight">
+              <span
+                class="font-mono text-[11px] uppercase tracking-wider text-muted-foreground"
+                >tileserver-rs</span
+              >
+              <span class="text-sm font-semibold text-foreground">Admin</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            aria-label="Close navigation menu"
+            class="flex size-9 items-center justify-center border border-border text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+            @click="closeMobileNav"
+          >
+            <X class="size-4" />
+          </button>
+        </div>
+
+        <nav class="flex-1 space-y-4 overflow-y-auto px-3 py-4">
+          <div
+            v-for="(group, gIdx) in navGroups"
+            :key="group.heading ?? gIdx"
+            class="space-y-1"
+          >
+            <p
+              v-if="group.heading"
+              class="px-3 pb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground"
+            >
+              {{ group.heading }}
+            </p>
+            <NuxtLink
+              v-for="item in group.items"
+              :key="item.to"
+              :to="item.to"
+              :class="[
+                'flex items-center gap-3 px-3 py-3 text-sm transition-colors',
+                isActive(item.to)
+                  ? 'bg-accent text-accent-foreground'
+                  : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
+              ]"
+            >
+              <component :is="item.icon" class="size-4" />
+              <span>{{ item.label }}</span>
+            </NuxtLink>
+          </div>
+        </nav>
+
+        <div
+          class="flex items-center justify-between gap-2 border-t border-border px-3 py-3"
+        >
+          <NuxtLink
+            to="/"
+            class="px-3 py-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+          >
+            ← Back to viewer
+          </NuxtLink>
+          <button
+            type="button"
+            :aria-label="
+              isDark ? 'Switch to light mode' : 'Switch to dark mode'
+            "
+            class="flex size-9 items-center justify-center border border-border text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
+            @click="toggleTheme"
+          >
+            <Sun v-if="isDark" class="size-4" />
+            <Moon v-else class="size-4" />
+          </button>
+        </div>
+      </aside>
+    </Transition>
+
+    <!-- Desktop sidebar — persistent rail (>=lg). -->
     <aside
-      class="sticky top-0 flex h-dvh w-64 shrink-0 flex-col self-start border-r border-border bg-background"
+      class="hidden h-dvh w-64 shrink-0 flex-col border-r border-border bg-background lg:flex"
     >
       <div class="flex items-center gap-3 border-b border-border px-6 py-5">
         <div
@@ -18,7 +176,7 @@
         </div>
         <div class="flex flex-col leading-tight">
           <span
-            class="font-mono text-[11px] tracking-wider text-muted-foreground uppercase"
+            class="font-mono text-[11px] uppercase tracking-wider text-muted-foreground"
             >tileserver-rs</span
           >
           <span class="text-sm font-semibold text-foreground">Admin</span>
@@ -33,7 +191,7 @@
         >
           <p
             v-if="group.heading"
-            class="px-3 pb-2 font-mono text-[10px] tracking-[0.18em] text-muted-foreground uppercase"
+            class="px-3 pb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-muted-foreground"
           >
             {{ group.heading }}
           </p>
@@ -59,7 +217,7 @@
       >
         <NuxtLink
           to="/"
-          class="px-3 py-2 font-mono text-[11px] tracking-wider text-muted-foreground uppercase transition-colors hover:text-foreground"
+          class="px-3 py-2 font-mono text-[11px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
         >
           ← Back to viewer
         </NuxtLink>
@@ -75,7 +233,7 @@
       </div>
     </aside>
 
-    <main class="min-w-0 flex-1 bg-background">
+    <main class="min-w-0 flex-1 overflow-y-auto bg-background pt-14 lg:pt-0">
       <slot></slot>
     </main>
   </div>

--- a/apps/client/app/pages/admin/config.vue
+++ b/apps/client/app/pages/admin/config.vue
@@ -18,7 +18,9 @@
 
 <template>
   <div class="flex min-h-dvh flex-col">
-    <header class="border-b border-border px-10 py-6">
+    <header
+      class="border-b border-border px-[clamp(16px,4vw,40px)] py-5 sm:py-6"
+    >
       <AdminBreadcrumb :items="breadcrumbs" />
       <div class="mt-3 flex flex-wrap items-baseline gap-x-6 gap-y-2">
         <h1 class="text-2xl font-semibold tracking-tight text-foreground">
@@ -39,7 +41,7 @@
       </p>
     </header>
 
-    <section class="flex-1 px-10 py-8">
+    <section class="flex-1 px-[clamp(16px,4vw,40px)] py-6 sm:py-8">
       <div v-if="isPending" class="flex flex-col gap-3">
         <div
           v-for="i in 8"

--- a/apps/client/app/pages/admin/index.vue
+++ b/apps/client/app/pages/admin/index.vue
@@ -35,10 +35,12 @@
 
 <template>
   <div class="flex min-h-dvh flex-col">
-    <header class="border-b border-border px-10 py-6">
+    <header
+      class="border-b border-border px-[clamp(16px,4vw,40px)] py-5 sm:py-6"
+    >
       <AdminBreadcrumb :items="breadcrumbs" />
       <h1
-        class="mt-3 font-display text-5xl font-semibold tracking-tight text-foreground"
+        class="mt-3 font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl lg:text-5xl"
       >
         Operator console
       </h1>
@@ -48,8 +50,11 @@
       </p>
     </header>
 
-    <section v-if="pingError" class="border-b border-border px-10 py-8">
-      <div class="max-w-2xl border border-border px-6 py-6">
+    <section
+      v-if="pingError"
+      class="border-b border-border px-[clamp(16px,4vw,40px)] py-6 sm:py-8"
+    >
+      <div class="max-w-2xl border border-border px-5 py-5 sm:px-6 sm:py-6">
         <p
           class="font-mono text-[11px] tracking-[0.18em] text-muted-foreground uppercase"
         >
@@ -70,29 +75,29 @@
     <section v-else class="border-b border-border">
       <div class="grid grid-cols-1 lg:grid-cols-[3fr_2fr]">
         <div
-          class="flex flex-col justify-between border-b border-border px-10 py-8 lg:border-r lg:border-b-0"
+          class="flex flex-col justify-between gap-3 border-b border-border px-[clamp(16px,4vw,40px)] py-6 sm:py-8 lg:border-r lg:border-b-0"
         >
           <p
             class="font-mono text-[11px] tracking-[0.18em] text-muted-foreground uppercase"
           >
             Uptime
           </p>
-          <div v-if="isLoading" class="mt-4">
-            <Skeleton class="h-16 w-48" />
+          <div v-if="isLoading">
+            <Skeleton class="h-12 w-40 sm:h-14 sm:w-48 lg:h-16" />
           </div>
           <p
             v-else
-            class="mt-4 font-display text-7xl font-semibold tabular-nums tracking-tight text-foreground"
+            class="font-display text-4xl font-semibold tabular-nums tracking-tight text-foreground sm:text-5xl lg:text-7xl"
           >
             {{ uptimeLabel }}
           </p>
-          <p class="mt-4 font-mono text-[11px] text-muted-foreground">
+          <p class="font-mono text-[11px] text-muted-foreground">
             since last config reload
           </p>
         </div>
 
         <div class="grid grid-cols-2 grid-rows-2">
-          <div class="border-b border-border px-6 py-6">
+          <div class="border-b border-border px-5 py-5 sm:px-6 sm:py-6">
             <p
               class="font-mono text-[11px] tracking-[0.18em] text-muted-foreground uppercase"
             >
@@ -104,7 +109,9 @@
               {{ loadedSources }}
             </p>
           </div>
-          <div class="border-b border-l border-border px-6 py-6">
+          <div
+            class="border-b border-l border-border px-5 py-5 sm:px-6 sm:py-6"
+          >
             <p
               class="font-mono text-[11px] tracking-[0.18em] text-muted-foreground uppercase"
             >
@@ -116,7 +123,7 @@
               {{ loadedStyles }}
             </p>
           </div>
-          <div class="px-6 py-6">
+          <div class="px-5 py-5 sm:px-6 sm:py-6">
             <p
               class="font-mono text-[11px] tracking-[0.18em] text-muted-foreground uppercase"
             >
@@ -128,7 +135,7 @@
               {{ clientsCount }}
             </p>
           </div>
-          <div class="border-l border-border px-6 py-6">
+          <div class="border-l border-border px-5 py-5 sm:px-6 sm:py-6">
             <p
               class="font-mono text-[11px] tracking-[0.18em] text-muted-foreground uppercase"
             >
@@ -145,7 +152,9 @@
     </section>
 
     <section class="grid flex-1 grid-cols-1 lg:grid-cols-[2fr_1fr]">
-      <div class="border-b border-border px-10 py-8 lg:border-r lg:border-b-0">
+      <div
+        class="border-b border-border px-[clamp(16px,4vw,40px)] py-6 sm:py-8 lg:border-r lg:border-b-0"
+      >
         <div class="flex items-baseline justify-between">
           <p
             class="font-mono text-[11px] tracking-[0.18em] text-muted-foreground uppercase"
@@ -181,7 +190,7 @@
 
         <div
           v-else-if="clientsAreEmpty"
-          class="mt-6 border border-border px-6 py-10"
+          class="mt-6 border border-border px-5 py-8 sm:px-6 sm:py-10"
         >
           <p
             class="font-mono text-[11px] tracking-[0.18em] text-muted-foreground uppercase"
@@ -222,7 +231,7 @@
       <aside class="flex flex-col">
         <NuxtLink
           to="/admin/mcp/connected-apps"
-          class="group flex items-start gap-4 border-b border-border px-6 py-6 transition-colors hover:bg-secondary/40"
+          class="group flex items-start gap-4 border-b border-border px-5 py-5 sm:px-6 sm:py-6 transition-colors hover:bg-secondary/40"
         >
           <div
             class="flex size-10 shrink-0 items-center justify-center border border-border bg-card"
@@ -244,7 +253,7 @@
 
         <NuxtLink
           to="/admin/mcp/devices"
-          class="group flex items-start gap-4 border-b border-border px-6 py-6 transition-colors hover:bg-secondary/40"
+          class="group flex items-start gap-4 border-b border-border px-5 py-5 sm:px-6 sm:py-6 transition-colors hover:bg-secondary/40"
         >
           <div
             class="flex size-10 shrink-0 items-center justify-center border border-border bg-card"
@@ -264,7 +273,7 @@
           />
         </NuxtLink>
 
-        <div class="flex-1 border-b border-border px-6 py-6">
+        <div class="flex-1 border-b border-border px-5 py-5 sm:px-6 sm:py-6">
           <p
             class="font-mono text-[11px] tracking-[0.18em] text-muted-foreground uppercase"
           >
@@ -298,7 +307,7 @@
           </dl>
         </div>
 
-        <div class="px-6 py-6">
+        <div class="px-5 py-5 sm:px-6 sm:py-6">
           <p
             class="font-mono text-[11px] tracking-[0.18em] text-muted-foreground uppercase"
           >

--- a/apps/client/app/pages/admin/mcp/connected-apps.vue
+++ b/apps/client/app/pages/admin/mcp/connected-apps.vue
@@ -26,7 +26,9 @@
 
 <template>
   <div class="flex min-h-dvh flex-col">
-    <header class="border-b border-border px-10 py-6">
+    <header
+      class="border-b border-border px-[clamp(16px,4vw,40px)] py-5 sm:py-6"
+    >
       <AdminBreadcrumb :items="breadcrumbs" />
       <h1 class="mt-3 text-2xl font-semibold tracking-tight text-foreground">
         Connected apps
@@ -38,9 +40,9 @@
       </p>
     </header>
 
-    <section class="flex-1 px-10 py-8">
-      <div v-if="isLoading" class="border border-border">
-        <table class="w-full border-collapse">
+    <section class="flex-1 px-[clamp(16px,4vw,40px)] py-6 sm:py-8">
+      <div v-if="isLoading" class="overflow-x-auto border border-border">
+        <table class="w-full min-w-[640px] border-collapse">
           <thead>
             <tr class="border-b border-border bg-card">
               <th
@@ -146,8 +148,8 @@
         </div>
       </div>
 
-      <div v-else class="border border-border">
-        <table class="w-full border-collapse">
+      <div v-else class="overflow-x-auto border border-border">
+        <table class="w-full min-w-[640px] border-collapse">
           <thead>
             <tr class="border-b border-border bg-card">
               <th

--- a/apps/client/app/pages/admin/mcp/devices.vue
+++ b/apps/client/app/pages/admin/mcp/devices.vue
@@ -25,7 +25,9 @@
 
 <template>
   <div class="flex min-h-dvh flex-col">
-    <header class="border-b border-border px-10 py-6">
+    <header
+      class="border-b border-border px-[clamp(16px,4vw,40px)] py-5 sm:py-6"
+    >
       <AdminBreadcrumb :items="breadcrumbs" />
       <h1 class="mt-3 text-2xl font-semibold tracking-tight text-foreground">
         Devices
@@ -37,9 +39,9 @@
       </p>
     </header>
 
-    <section class="flex-1 px-10 py-8">
-      <div v-if="isLoading" class="border border-border">
-        <table class="w-full border-collapse">
+    <section class="flex-1 px-[clamp(16px,4vw,40px)] py-6 sm:py-8">
+      <div v-if="isLoading" class="overflow-x-auto border border-border">
+        <table class="w-full min-w-[640px] border-collapse">
           <thead>
             <tr class="border-b border-border bg-card">
               <th
@@ -148,8 +150,8 @@
         </div>
       </div>
 
-      <div v-else class="border border-border">
-        <table class="w-full border-collapse">
+      <div v-else class="overflow-x-auto border border-border">
+        <table class="w-full min-w-[640px] border-collapse">
           <thead>
             <tr class="border-b border-border bg-card">
               <th


### PR DESCRIPTION
## Summary

Makes the `/admin` UI usable on mobile (390×844 iPhone class). The previous layout rendered the desktop sidebar at full width on small screens and crushed the main content into the remaining ~60%.

## What changed

**Mobile shell**
- Sidebar hidden `<lg`, replaced with a fixed top bar (h-14) containing brand + hamburger button
- Tapping the hamburger opens a slide-in drawer (w-72) with the same nav, footer-pinned "Back to viewer" + theme toggle
- Drawer closes on backdrop tap, Escape key, or route change
- Desktop sidebar (`>=lg`) unchanged

**Responsive padding + typography (4 admin pages)**
- Hard `px-10` swapped to `px-[clamp(16px,4vw,40px)]`
- `Operator console` headline: `text-3xl sm:text-4xl lg:text-5xl`
- Uptime numeral: `text-4xl sm:text-5xl lg:text-7xl`
- Stats grid cells: `px-5 py-5 sm:px-6 sm:py-6`

**Tables**
- Wrapped `connected-apps.vue` + `devices.vue` tables (loading + populated branches) in `overflow-x-auto`
- Each `<table>` gets `min-w-[640px]` so it scrolls horizontally inside the section instead of pushing the page off-screen

**Tailwind cleanup**
- Removed a verbose 10-line "elevation philosophy" comment block from `tailwind.css` — that was meta-narrative, not code rationale

## Verification

| Viewport | Before | After |
|---|---|---|
| 390×844 (iPhone) | sidebar full-width, main crushed, horizontal page scroll | top bar + drawer, content fits, table scrolls within section |
| 1440×900 (desktop) | sidebar + main | no regression |

Local gates:
- `pnpm --filter @tileserver-rs/client lint` — clean
- `pnpm --filter @tileserver-rs/client format` — 178 files
- Manual QA: dashboard + config + connected-apps verified at 390×844 and 1440×900 in Playwright

## Commits

1. `style(client): drop verbose elevation comment block from tailwind.css`
2. `feat(client): mobile-responsive admin layout with drawer`
3. `feat(client): make admin dashboard + config responsive`
4. `fix(client): scope MCP table overflow within the section on mobile`