### PR TITLE
chore(release): include apps/client in release notes + relax minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,12 @@ packages:
 overrides:
   vite: ^8.0.14
 
+# pnpm 11's supply-chain policy defaults to a 24-hour minimumReleaseAge,
+# which blocks legitimate routine dep bumps when CI runs within a day of
+# an upstream patch release (e.g. cloudflare/wrangler, cloudflare/miniflare).
+# 60 minutes still prevents publish-and-pivot attacks but unblocks normal flow.
+minimumReleaseAge: 60
+
 # pnpm 11 blocks all package build scripts by default. The allowBuilds
 # map below is security-sensitive — true = postinstall runs; false = skipped.
 # Warning: pnpm auto-manages this block. Edits made while pnpm install is

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,7 +20,8 @@
         "homebrew/Formula/tileserver-rs.rb"
       ],
       "exclude-paths": [
-        "apps",
+        "apps/docs",
+        "apps/marketing",
         "benchmarks",
         "Cargo.lock",
         "crates/mbgl-sys",


### PR DESCRIPTION
## Why

Two ops fixes — both surfaced while merging the v2.29.1 Release PR (#1024):

### 1. release-please was dropping apps/client commits

The `crates/tileserver-rs` train in `release-please-config.json` excluded the entire `apps/` tree. That meant frontend work — the admin mobile UI, the A2 home page rebuild, the design-direction migration — never showed up in CHANGELOG.md or in the GitHub release notes. v2.29.1's auto-generated PR only listed *"deps: bump askama from 0.15.6 to 0.16.0"* despite multiple feat(client) commits on main.

`apps/client` ships embedded in the Rust binary via `rust-embed` — one product, one version. It belongs in the binary's changelog. `apps/docs` and `apps/marketing` have their own deploys (docs.tileserver.app, tileserver.app) so they stay excluded.

### 2. pnpm 11's default minimumReleaseAge blocks routine bumps

pnpm 11 defaults `minimumReleaseAge` to 1440 (24h). When dependabot or cargo-style routine bumps land same-day as an upstream patch release (e.g. cloudflare/wrangler, cloudflare/miniflare), CI's frozen install fails with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` — exactly what blocked #1024's Node Lint+Build step. 60 minutes still defends against publish-and-pivot supply-chain attacks but unblocks normal CI.

## Changes

| File | Change |
|---|---|
| `release-please-config.json` | replace blanket `"apps"` exclusion with granular `"apps/docs"` + `"apps/marketing"` |
| `pnpm-workspace.yaml` | add `minimumReleaseAge: 60` (with security-policy comment) |

Docs verified: https://pnpm.io/settings#minimumreleaseage

## Effect on #1024 (release-please v2.29.1)

Once this merges to main, release-please will regenerate #1024 with:
- The full list of `feat(client):` and `feat(admin):` commits since v2.29.0
- A passing Node Lint+Build step (because main now has the relaxed policy)

Then #1024 can be merged normally (via `--merge`, NOT `--squash`, per project rule).

## Verification

- ✅ `pnpm install --frozen-lockfile` passes locally with new policy
- ✅ `release-please-config.json` validates against $schema