### PR TITLE
fix(release): use simple release-type for root pkg to skip workspace sync

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
   "release-search-depth": 50,
   "packages": {
     ".": {
-      "release-type": "rust",
+      "release-type": "simple",
       "component": "tileserver-rs",
       "include-component-in-tag": false,
       "changelog-path": "crates/tileserver-rs/CHANGELOG.md",
@@ -17,8 +17,16 @@
       "prerelease": false,
       "extra-label": "backend,rust,frontend,javascript",
       "extra-files": [
-        "crates/tileserver-rs/Cargo.toml",
-        "apps/client/package.json",
+        {
+          "type": "toml",
+          "path": "crates/tileserver-rs/Cargo.toml",
+          "jsonpath": "$.package.version"
+        },
+        {
+          "type": "json",
+          "path": "apps/client/package.json",
+          "jsonpath": "$.version"
+        },
         "homebrew/Formula/tileserver-rs.rb"
       ],
       "exclude-paths": [


### PR DESCRIPTION
## The bug

Verified the cause directly in release-please source code at [`src/strategies/rust.ts` lines 47-82](https://github.com/googleapis/release-please/blob/main/src/strategies/rust.ts#L47-L82):

```ts
const workspaceManifest = await this.getPackageManifest();
const versionsMap: VersionsMap = new Map();
if (workspaceManifest?.workspace?.members) {
  const members = workspaceManifest.workspace.members;
  // ...
  for (const member of members) {
    const manifestPath = `${member}/Cargo.toml`;
    // ...
    versionsMap.set(manifest.package.name, version);   // ← forces all members to same version
  }
  this.logger.debug('versions map:', versionsMap);     // ← exact log line we observed
}
```

When `release-type: "rust"` is used on a package whose root `Cargo.toml` is a **virtual workspace manifest** (`[workspace]` only, no `[package]`), the Rust strategy walks every `[workspace.members]` entry and **forces all of them to the new bumped version**. This is the documented behavior of the Rust strategy, NOT a plugin auto-activation as I initially speculated.

PR #1027 switched the tileserver-rs package root to `.`, whose `Cargo.toml` IS our virtual workspace manifest. release-please then started bumping mbgl-sys alongside tileserver-rs:

```
versions map: Map(2) {
  'tileserver-rs' => 2.30.0,
  'mbgl-sys'     => 2.30.0,
}
```

mbgl-sys is a separate release train (tags `mbgl-sys-v*`, currently `0.1.6`). It must NOT be dragged along by tileserver-rs commits.

## The fix

Switch the `.` package from `release-type: "rust"` → `release-type: "simple"`. The `simple` strategy [doesn't have the workspace-detection code path](https://github.com/googleapis/release-please/blob/main/src/strategies/simple.ts) — it just bumps the version string in whatever `extra-files`/`version-file` is declared.

To preserve the Cargo.toml + package.json version updates we still need:

```json
"extra-files": [
  { "type": "toml", "path": "crates/tileserver-rs/Cargo.toml", "jsonpath": "$.package.version" },
  { "type": "json", "path": "apps/client/package.json", "jsonpath": "$.version" },
  "homebrew/Formula/tileserver-rs.rb"
]
```

The typed updaters (`toml`+`jsonpath`, `json`+`jsonpath`) explicitly target the version field, so they work without the Rust strategy.

**mbgl-sys section unchanged** — its package root `Cargo.toml` is a regular `[package]` manifest (no `[workspace]`), so the workspace-sync code path never fires. Keeping `release-type: "rust"` there is safe.

## After this merges

release-please will:
- Regenerate the next Release PR for tileserver-rs (currently #1026 → v2.30.0) WITHOUT touching mbgl-sys
- Honor the existing `mbgl-sys-v0.1.6` tag for the mbgl-sys train (next mbgl-sys release stays at v0.1.x semver until real FFI changes land)

## Apology / correction

In the earlier turn I claimed the cargo-workspace **plugin** was auto-activating. That was wrong — I asserted without checking the source. The real cause is in `src/strategies/rust.ts` itself (lines 47-82), not in any plugin. Plugins are only loaded from `manifestOptions.plugins` (see [`src/manifest.ts` line 409](https://github.com/googleapis/release-please/blob/main/src/manifest.ts#L409)) — none auto-activate.

## Verification

- ✅ `python3 -c "import json; json.load(open('release-please-config.json'))"`
- ✅ Diff is minimal: only the `.` package changes; mbgl-sys section untouched

Source links:
- [`src/strategies/rust.ts#L47-L82`](https://github.com/googleapis/release-please/blob/main/src/strategies/rust.ts#L47-L82) — the workspace-sync code
- [`src/manifest.ts#L409`](https://github.com/googleapis/release-please/blob/main/src/manifest.ts#L409) — plugin loading (no auto-activation)

Closes the mbgl-sys side-bump bug introduced by #1027.