### PR TITLE
fix(release): drop version-file to stop overwriting cargo.toml

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,6 @@
       "component": "tileserver-rs",
       "include-component-in-tag": false,
       "changelog-path": "crates/tileserver-rs/CHANGELOG.md",
-      "version-file": "crates/tileserver-rs/Cargo.toml",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,


### PR DESCRIPTION
## The bug

Release PR #1029 (v2.30.0) was generated with **the entire 218-line `crates/tileserver-rs/Cargo.toml` replaced by the literal string `2.30.0`**:

```diff
--- a/crates/tileserver-rs/Cargo.toml
+++ b/crates/tileserver-rs/Cargo.toml
@@ -1,218 +1 @@
-[package]
-name = "tileserver-rs"
-version = "2.29.0"
-... (216 more lines removed)
+2.30.0
```

## Root cause (verified in release-please source)

PR #1027 set BOTH:

```json
"version-file": "crates/tileserver-rs/Cargo.toml",
"extra-files": [
  { "type": "toml", "path": "crates/tileserver-rs/Cargo.toml", "jsonpath": "$.package.version" },
  ...
]
```

For `release-type: "simple"`, `version-file` uses the [`RawContent` updater](https://github.com/googleapis/release-please/blob/main/src/updaters/raw-content.ts):

```ts
updateContent(_content: string | undefined): string {
  return this.rawContent;   // ← ignores prior content, writes only the version string
}
```

So:
1. `version-file` ran → wrote `"2.30.0"` to `crates/tileserver-rs/Cargo.toml`, erasing everything
2. `extra-files: [{type: "toml", jsonpath: "$.package.version"}]` ran → couldn't find `$.package.version` in the now-empty file → logged a warning and did nothing

## The fix

Drop the `version-file` entry entirely. The `extra-files` entry with `type: "toml"` + `jsonpath` is already correct: it uses [`GenericToml` → `replaceTomlValue`](https://github.com/googleapis/release-please/blob/main/src/updaters/generic-toml.ts) to surgically rewrite **only** `$.package.version` while preserving the other 217 lines of the manifest.

The `apps/client/package.json` and `homebrew/Formula/tileserver-rs.rb` entries in `extra-files` already follow the right pattern and are unaffected.

## After this merges

release-please will regenerate Release PR #1029 with:

- `crates/tileserver-rs/Cargo.toml` 1-line diff: `version = "2.29.0"` → `version = "2.30.0"`
- `apps/client/package.json` 1-line diff: `"version": "2.26.2"` → `"version": "2.30.0"` (catching up from 3 releases ago, see #1027)
- `homebrew/Formula/tileserver-rs.rb` 1-line diff: `version "2.29.0"` → `version "2.30.0"`
- `crates/tileserver-rs/CHANGELOG.md` — full 30+ commit changelog (now that paths resolve correctly)

## Apology

This is the third release-please bug surfaced from my PR #1027 (root-package switch). I introduced `version-file` thinking it was needed for the simple strategy to know what to bump — turns out the extra-files entry was already doing that job and the version-file was destructively duplicating it.

## Verification

- ✅ `python3 -c "import json; json.load(open('release-please-config.json'))"`
- ✅ Diff is a single-line removal — minimum-blast-radius fix

Source links:
- [`src/updaters/raw-content.ts`](https://github.com/googleapis/release-please/blob/main/src/updaters/raw-content.ts) — the destructive RawContent updater that `version-file` triggers
- [`src/updaters/generic-toml.ts`](https://github.com/googleapis/release-please/blob/main/src/updaters/generic-toml.ts) — the surgical GenericToml updater used by typed `extra-files`
- [`src/strategies/base.ts#L418`](https://github.com/googleapis/release-please/blob/main/src/strategies/base.ts#L418) — the switch on `extraFile.type` that routes typed entries to GenericToml/GenericJson/etc.

Closes the Cargo.toml wipeout in PR #1029.