### PR TITLE
feat(config): bundle a — yaml configs, extra headers, cors patterns, --cache-dir, disable_render/ogc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6296,7 +6296,7 @@ dependencies = [
 
 [[package]]
 name = "tileserver-rs"
-version = "2.30.0"
+version = "2.30.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5766,6 +5766,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6283,7 +6296,7 @@ dependencies = [
 
 [[package]]
 name = "tileserver-rs"
-version = "2.29.0"
+version = "2.30.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6342,6 +6355,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "serde_yaml_ng",
  "sha2 0.11.0",
  "shellexpand",
  "stac",
@@ -6882,6 +6896,12 @@ name = "union-find"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617b646852504df7924cff3b0ca6c8f07a3c91099b48076fab58d4298faf47ca"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6344,6 +6344,7 @@ dependencies = [
  "postgres-types",
  "prometheus",
  "prost 0.14.3",
+ "regex",
  "reqwest 0.13.4",
  "rmcp",
  "rsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ serde_json       = "1.0.150"
 serde_yaml_ng    = "0.10.0"
 toml             = "1.1.2"
 
+# Pattern matching (used by CORS origin glob/regex support)
+regex            = "1.11"
+
 # Error handling
 thiserror        = "2.0.18"
 anyhow           = "1.0.102"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ futures          = "0.3.32"
 # Serialization
 serde            = { version = "1.0.228", features = ["derive"] }
 serde_json       = "1.0.150"
+serde_yaml_ng    = "0.10.0"
 toml             = "1.1.2"
 
 # Error handling

--- a/apps/docs/content/1.getting-started/3.config.md
+++ b/apps/docs/content/1.getting-started/3.config.md
@@ -102,6 +102,50 @@ upload_max_size_mb = 500
 | `public_url`         | string?        | _(none)_       | Public URL embedded in TileJSON. Falls back to the bind address                                                   |
 | `upload_dir`         | path?          | system tmp     | Directory for drag-and-drop uploads (creates a tmp source per upload)                                             |
 | `upload_max_size_mb` | u32            | `500`          | Maximum per-file upload size in megabytes                                                                         |
+| `extra_response_headers` | table?     | _(none)_       | User-defined response headers applied to every HTTP response — see [`[server.extra_response_headers]`](#serverextra_response_headers) below |
+
+### `[server.extra_response_headers]`
+
+A user-defined map of HTTP response headers that are applied (in
+`SetResponseHeaderLayer::overriding` mode) to every response served by
+tileserver-rs — tile, style, OGC, admin, MCP, everything. Useful for:
+
+| Use case | Example header |
+| --- | --- |
+| Edge / CDN cache control | `CDN-Cache-Control`, `Surrogate-Control` |
+| Browser cache control | `Cache-Control` (overrides any default) |
+| Block search-engine indexing | `X-Robots-Tag: noindex, nofollow` |
+| HSTS for TLS terminators | `Strict-Transport-Security` |
+| Content security | `X-Content-Type-Options: nosniff` |
+| APM correlation | `Server-Timing`, custom `X-*` audit headers |
+
+```toml
+[server.extra_response_headers]
+"Cache-Control" = "public, max-age=86400, immutable"
+"CDN-Cache-Control" = "max-age=604800"
+"X-Robots-Tag" = "noindex, nofollow"
+"X-Content-Type-Options" = "nosniff"
+"Strict-Transport-Security" = "max-age=31536000; includeSubDomains"
+"Server-Timing" = "tileserver;dur=0"
+```
+
+Equivalent YAML:
+
+```yaml
+server:
+  extra_response_headers:
+    Cache-Control: public, max-age=86400, immutable
+    CDN-Cache-Control: max-age=604800
+    X-Robots-Tag: noindex, nofollow
+```
+
+**Rules:**
+
+1. Header names must conform to **RFC 7230 token grammar** (alphanumeric + `!#$%&'*+-.^_\`|~`).
+2. The transport-managed headers `Content-Length`, `Transfer-Encoding`, `Date`, `Connection` are **rejected at startup** — the server fails fast.
+3. An empty string value (`"X-Foo" = ""`) **removes** any pre-existing `X-Foo` header from outgoing responses.
+4. User values are `overriding` — they win over anything an upstream middleware emits.
+5. Hot reload (`POST /__admin/reload`) picks up changes without a restart.
 
 ## `[[sources]]`
 

--- a/apps/docs/content/1.getting-started/3.config.md
+++ b/apps/docs/content/1.getting-started/3.config.md
@@ -1,12 +1,35 @@
 ---
 title: Configuration reference
-description: Every CLI flag, TOML option, and environment variable tileserver-rs reads
+description: Every CLI flag, TOML / YAML option, and environment variable tileserver-rs reads
 ---
 
 This page is the canonical reference for **everything tileserver-rs reads** —
-CLI flags, TOML config keys, and environment variables — sourced directly
+CLI flags, config keys (TOML or YAML), and environment variables — sourced directly
 from the Rust structs in `crates/tileserver-rs/src/config.rs` and
 `crates/tileserver-rs/src/cli.rs`.
+
+## Config file formats
+
+tileserver-rs accepts both **TOML** and **YAML** config files. The format is
+detected from the file extension:
+
+| Extension                | Parser              |
+| ------------------------ | ------------------- |
+| `.toml`                  | TOML (default)      |
+| `.yaml`, `.yml`          | YAML                |
+| _anything else_          | TOML (fallthrough)  |
+
+TOML and YAML produce identical `Config` structs — every option documented
+on this page works in both formats. See [`data/configs/example.toml`](https://github.com/vinayakkulkarni/tileserver-rs/blob/main/data/configs/example.toml)
+for the canonical exhaustively-commented reference and [`data/configs/example.yaml`](https://github.com/vinayakkulkarni/tileserver-rs/blob/main/data/configs/example.yaml)
+for the YAML syntax mirror.
+
+```bash
+# Either of these works:
+tileserver-rs --config config.toml
+tileserver-rs --config config.yaml
+tileserver-rs --config config.yml
+```
 
 For task-oriented guides see [Quickstart](/getting-started/quickstart),
 [Vector tiles](/guides/vector-tiles), [Auto-detect](/guides/auto-detect),
@@ -19,7 +42,7 @@ When the same value is supplied in multiple places, **later sources
 override earlier ones**:
 
 1. Hard-coded defaults (lowest priority)
-2. TOML config file (`--config`)
+2. Config file in TOML or YAML (`--config`)
 3. Environment variables (`TILESERVER_*`)
 4. CLI flags (highest priority)
 
@@ -30,7 +53,7 @@ order:
 
 1. `--config <FILE>` — explicit config path (fails if the file does not exist)
 2. Positional `PATH` — auto-detect sources/styles from that path (see [Auto-detect](/guides/auto-detect))
-3. Default locations: `./config.toml`, then `/etc/tileserver-rs/config.toml`
+3. Default locations, tried in order: `./config.toml`, `./config.yaml`, `./config.yml`, then `/etc/tileserver-rs/config.{toml,yaml,yml}`
 4. CWD auto-detect — scan the current directory for `.pmtiles`, `.mbtiles`, `style.json`, and font directories
 
 ## CLI flags

--- a/apps/docs/content/1.getting-started/3.config.md
+++ b/apps/docs/content/1.getting-started/3.config.md
@@ -97,12 +97,42 @@ upload_max_size_mb = 500
 | -------------------- | -------------- | -------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `host`               | string         | `"0.0.0.0"`    | Bind address for the public tile server                                                                           |
 | `port`               | u16            | `8080`         | Bind port for the public tile server                                                                              |
-| `cors_origins`       | string[]       | `["*"]`        | CORS allow-list for tile + style endpoints                                                                        |
+| `cors_origins`       | string[]       | `["*"]`        | CORS allow-list — supports literals, glob (`*`), and regex (`/.../`); see [Pattern syntax](#corsoriginpatterns) below |
 | `admin_bind`         | string         | `"127.0.0.1:0"`| Separate bind for admin endpoints (`/__admin/reload`, `/__admin/oauth/*`). `:0` disables. Use `127.0.0.1:8081` to enable. |
 | `public_url`         | string?        | _(none)_       | Public URL embedded in TileJSON. Falls back to the bind address                                                   |
 | `upload_dir`         | path?          | system tmp     | Directory for drag-and-drop uploads (creates a tmp source per upload)                                             |
 | `upload_max_size_mb` | u32            | `500`          | Maximum per-file upload size in megabytes                                                                         |
 | `extra_response_headers` | table?     | _(none)_       | User-defined response headers applied to every HTTP response — see [`[server.extra_response_headers]`](#serverextra_response_headers) below |
+
+### CORS origin patterns
+
+The `cors_origins` list accepts three syntaxes, dispatched per entry:
+
+| Entry syntax                  | Interpretation                                                |
+| ----------------------------- | ------------------------------------------------------------- |
+| `"*"`                         | Wildcard — allow any origin (default; emits a startup warning) |
+| `"https://example.com"`       | Exact literal match (unchanged from previous behaviour)        |
+| `"*.example.com"`             | Glob — `*` matches one or more characters in the Origin URL    |
+| `"preview-*.example.com"`     | Glob — `*` can appear anywhere in the pattern                  |
+| `"/^https://.+\\.example\\.com$/"` | Regex — enclosed in `/.../`, matched against the full Origin |
+
+```toml
+[server]
+cors_origins = [
+  "https://example.com",
+  "*.cdn.example.com",
+  "preview-*.example.com",
+  "/^https://.+\\.team-[a-z0-9]+\\.app\\.example\\.com$/",
+]
+```
+
+**Notes:**
+
+1. Entries are tried in order; the first match short-circuits per request.
+2. A list containing `"*"` ALWAYS resolves to wildcard regardless of other entries — that is the existing semantics, preserved.
+3. Pure-literal lists (no `*`, no `/.../`) use the same allocation-free `AllowOrigin::list` fast-path as before. Adding a glob or regex switches the layer to `AllowOrigin::predicate`.
+4. Invalid regex (e.g. unbalanced `[`) **fails fast at startup** with the offending entry quoted in the error.
+5. Glob entries are compiled by anchoring with `^...$` and replacing `*` with `.*` — so `*.x.com` matches `foo.x.com` and `https://foo.x.com`, but NOT `x.com` (no leading subdomain) or `foo.x.com.evil.com` (suffix injection blocked).
 
 ### `[server.extra_response_headers]`
 

--- a/crates/tileserver-rs/Cargo.toml
+++ b/crates/tileserver-rs/Cargo.toml
@@ -42,6 +42,7 @@ prost            = { workspace = true, optional = true }
 geo-types        = { workspace = true, optional = true }
 tokio            = { workspace = true }
 crossbeam-channel = { workspace = true }
+regex            = { workspace = true }
 serde_yaml_ng    = { workspace = true }
 toml             = { workspace = true }
 tower-http       = { workspace = true }

--- a/crates/tileserver-rs/Cargo.toml
+++ b/crates/tileserver-rs/Cargo.toml
@@ -42,6 +42,7 @@ prost            = { workspace = true, optional = true }
 geo-types        = { workspace = true, optional = true }
 tokio            = { workspace = true }
 crossbeam-channel = { workspace = true }
+serde_yaml_ng    = { workspace = true }
 toml             = { workspace = true }
 tower-http       = { workspace = true }
 urlencoding      = { workspace = true }

--- a/crates/tileserver-rs/src/cli.rs
+++ b/crates/tileserver-rs/src/cli.rs
@@ -22,6 +22,15 @@ pub struct Cli {
     #[arg(short, long, value_name = "FILE", env = "TILESERVER_CONFIG")]
     pub config: Option<PathBuf>,
 
+    /// Directory for tileserver scratch / cache state.
+    ///
+    /// Precedence (highest first): this flag → `TILESERVER_CACHE_DIR` env →
+    /// `[cache].dir` in the config file → default `std::env::temp_dir()/tileserver-rs`.
+    /// The directory is created (with subsystem subdirs) on startup and the
+    /// resolved path is logged.
+    #[arg(long, value_name = "PATH", env = "TILESERVER_CACHE_DIR")]
+    pub cache_dir: Option<PathBuf>,
+
     /// Host to bind to
     #[arg(long, env = "TILESERVER_HOST")]
     pub host: Option<String>,
@@ -119,9 +128,16 @@ mod tests {
     }
 
     #[test]
-    fn test_cli_config_long() {
-        let cli = parse(&["tileserver-rs", "--config", "/etc/ts.toml"]);
-        assert_eq!(cli.config.unwrap(), PathBuf::from("/etc/ts.toml"));
+    fn parses_config_flag() {
+        let cli = Cli::parse_from(["tileserver-rs", "--config", "/etc/ts.toml"]);
+        assert_eq!(cli.config, Some(PathBuf::from("/etc/ts.toml")));
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn parses_cache_dir_flag() {
+        let cli = Cli::parse_from(["tileserver-rs", "--cache-dir", "/var/cache/ts"]);
+        assert_eq!(cli.cache_dir, Some(PathBuf::from("/var/cache/ts")));
     }
 
     #[test]

--- a/crates/tileserver-rs/src/config.rs
+++ b/crates/tileserver-rs/src/config.rs
@@ -202,6 +202,13 @@ pub struct CacheConfig {
     /// Time-to-live for cache entries in seconds (default: 3600)
     #[serde(default = "default_global_cache_ttl_seconds")]
     pub ttl_seconds: u64,
+    /// Scratch / state directory for on-disk subsystems (today: uploads).
+    /// Storage location only — NOT a cache eviction policy; tile/dataset
+    /// cache lifetime is governed by `max_size_mb` / `ttl_seconds`.
+    /// Overridden by `--cache-dir` / `TILESERVER_CACHE_DIR`. See
+    /// [`Config::resolve_cache_dir`].
+    #[serde(default)]
+    pub dir: Option<PathBuf>,
 }
 
 fn default_global_cache_max_size_mb() -> u64 {
@@ -217,6 +224,7 @@ impl Default for CacheConfig {
             enabled: false,
             max_size_mb: default_global_cache_max_size_mb(),
             ttl_seconds: default_global_cache_ttl_seconds(),
+            dir: None,
         }
     }
 }
@@ -1094,6 +1102,41 @@ impl Config {
     /// Load configuration from environment or file.
     pub fn load(config_path: Option<PathBuf>) -> anyhow::Result<Self> {
         Ok(Self::load_with_metadata(config_path)?.config)
+    }
+
+    /// Resolve the effective scratch directory. Precedence (highest first):
+    /// `cli_override` (the `--cache-dir` flag, itself populated from
+    /// `TILESERVER_CACHE_DIR` by clap), then `[cache].dir`, then
+    /// `std::env::temp_dir().join("tileserver-rs")`.
+    pub fn resolve_cache_dir(&self, cli_override: Option<&std::path::Path>) -> PathBuf {
+        if let Some(p) = cli_override {
+            return p.to_path_buf();
+        }
+        if let Some(p) = &self.cache.dir {
+            return p.clone();
+        }
+        std::env::temp_dir().join("tileserver-rs")
+    }
+
+    /// Create the scratch directory (if missing) and verify it is writable
+    /// by round-tripping a probe file. Subsystem subdirs are created lazily
+    /// by their owners, not here.
+    pub fn ensure_cache_dir_writable(cache_dir: &std::path::Path) -> anyhow::Result<()> {
+        std::fs::create_dir_all(cache_dir).map_err(|e| {
+            anyhow::anyhow!(
+                "cache directory `{}` could not be created: {e}",
+                cache_dir.display()
+            )
+        })?;
+        let probe = cache_dir.join(".tileserver-rs-writable");
+        std::fs::write(&probe, b"").map_err(|e| {
+            anyhow::anyhow!(
+                "cache directory `{}` is not writable: {e}",
+                cache_dir.display()
+            )
+        })?;
+        let _ = std::fs::remove_file(&probe);
+        Ok(())
     }
 }
 

--- a/crates/tileserver-rs/src/config.rs
+++ b/crates/tileserver-rs/src/config.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 #[cfg(feature = "raster")]
@@ -270,6 +271,23 @@ pub struct ServerConfig {
     /// Maximum upload file size in megabytes (default: 500 MB)
     #[serde(default = "default_upload_max_size_mb")]
     pub upload_max_size_mb: u32,
+    /// User-defined response headers applied to every HTTP response.
+    ///
+    /// Header names must conform to RFC 7230 token grammar (alphanumeric
+    /// plus `!#$%&'*+-.^_`|~`). Reserved headers managed by the transport
+    /// (`Content-Length`, `Transfer-Encoding`, `Date`, `Connection`) are
+    /// rejected at startup. An empty string value removes the header,
+    /// which is useful to drop a header that an upstream middleware would
+    /// have otherwise emitted.
+    ///
+    /// ```toml
+    /// [server.extra_response_headers]
+    /// "Cache-Control" = "public, max-age=86400, immutable"
+    /// "CDN-Cache-Control" = "max-age=604800"
+    /// "X-Robots-Tag" = "noindex, nofollow"
+    /// ```
+    #[serde(default)]
+    pub extra_response_headers: Option<HashMap<String, String>>,
 }
 
 fn default_host() -> String {
@@ -298,6 +316,7 @@ impl Default for ServerConfig {
             public_url: None,
             upload_dir: None,
             upload_max_size_mb: default_upload_max_size_mb(),
+            extra_response_headers: None,
         }
     }
 }
@@ -1037,6 +1056,7 @@ impl Config {
                 );
             }
         }
+        validate_extra_response_headers(self.server.extra_response_headers.as_ref())?;
         Ok(())
     }
 
@@ -1075,6 +1095,54 @@ impl Config {
     pub fn load(config_path: Option<PathBuf>) -> anyhow::Result<Self> {
         Ok(Self::load_with_metadata(config_path)?.config)
     }
+}
+
+/// Validate `[server.extra_response_headers]` against the rules documented
+/// on `ServerConfig::extra_response_headers`. Pulled out as a free function
+/// so unit tests can exercise it without constructing a full `Config`.
+fn validate_extra_response_headers(
+    headers: Option<&HashMap<String, String>>,
+) -> anyhow::Result<()> {
+    let Some(headers) = headers else {
+        return Ok(());
+    };
+    // Reserved headers managed by the transport. Lowercase for the case-insensitive compare.
+    const RESERVED: &[&str] = &["content-length", "transfer-encoding", "date", "connection"];
+    for name in headers.keys() {
+        let lower = name.to_ascii_lowercase();
+        if RESERVED.contains(&lower.as_str()) {
+            anyhow::bail!(
+                "`[server.extra_response_headers]` cannot set reserved header `{name}` (managed by the transport)"
+            );
+        }
+        let is_valid_token = !name.is_empty()
+            && name.bytes().all(|b| {
+                b.is_ascii_alphanumeric()
+                    || matches!(
+                        b,
+                        b'!' | b'#'
+                            | b'$'
+                            | b'%'
+                            | b'&'
+                            | b'\''
+                            | b'*'
+                            | b'+'
+                            | b'-'
+                            | b'.'
+                            | b'^'
+                            | b'_'
+                            | b'`'
+                            | b'|'
+                            | b'~'
+                    )
+            });
+        if !is_valid_token {
+            anyhow::bail!(
+                "`[server.extra_response_headers]` has invalid header name `{name}` (must match RFC 7230 token grammar)"
+            );
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1204,6 +1272,119 @@ styles:
 
         // SAFETY: same as above — single-threaded teardown.
         unsafe { std::env::remove_var("TEST_YAML_SUB_PORT") };
+    }
+
+    #[test]
+    fn test_extra_response_headers_deserialize_toml() {
+        let toml = r#"
+            [server]
+            host = "127.0.0.1"
+            port = 8080
+
+            [server.extra_response_headers]
+            "X-Custom" = "value1"
+            "Cache-Control" = "public, max-age=86400"
+        "#;
+        let config: Config = toml::from_str(toml).expect("parse TOML with extra_response_headers");
+        let headers = config
+            .server
+            .extra_response_headers
+            .as_ref()
+            .expect("extra_response_headers should be Some when configured");
+        assert_eq!(headers.get("X-Custom").map(String::as_str), Some("value1"));
+        assert_eq!(
+            headers.get("Cache-Control").map(String::as_str),
+            Some("public, max-age=86400")
+        );
+    }
+
+    #[test]
+    fn test_extra_response_headers_deserialize_yaml() {
+        use std::io::Write as _;
+
+        let yaml_content = "\
+server:
+  extra_response_headers:
+    X-Custom: value-from-yaml
+    X-Robots-Tag: noindex
+";
+        let mut tmpfile = tempfile::Builder::new()
+            .suffix(".yaml")
+            .tempfile()
+            .expect("create temp .yaml");
+        tmpfile
+            .write_all(yaml_content.as_bytes())
+            .expect("write yaml");
+
+        let config = Config::load(Some(tmpfile.path().to_path_buf()))
+            .expect("YAML with extra_response_headers should load");
+        let headers = config
+            .server
+            .extra_response_headers
+            .as_ref()
+            .expect("extra_response_headers should be Some");
+        assert_eq!(
+            headers.get("X-Custom").map(String::as_str),
+            Some("value-from-yaml")
+        );
+        assert_eq!(
+            headers.get("X-Robots-Tag").map(String::as_str),
+            Some("noindex")
+        );
+    }
+
+    #[test]
+    fn test_extra_response_headers_validation_rejects_reserved() {
+        let toml = r#"
+            [server.extra_response_headers]
+            "Content-Length" = "100"
+        "#;
+        let config: Config = toml::from_str(toml).expect("parse");
+        let err = config
+            .validate()
+            .expect_err("should reject reserved header Content-Length");
+        let msg = format!("{err:#}").to_ascii_lowercase();
+        assert!(
+            msg.contains("content-length"),
+            "error message should name the rejected header, got: {msg}"
+        );
+        assert!(
+            msg.contains("reserved"),
+            "error message should mention 'reserved', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_extra_response_headers_validation_rejects_invalid_name() {
+        let mut headers = HashMap::new();
+        headers.insert("Bad Header".to_string(), "value".to_string());
+        let mut cfg = Config::default();
+        cfg.server.extra_response_headers = Some(headers);
+        let err = cfg.validate().expect_err("should reject 'Bad Header'");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("Bad Header"),
+            "error message should name the invalid header, got: {msg}"
+        );
+        assert!(
+            msg.contains("RFC 7230"),
+            "error message should reference RFC 7230, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_extra_response_headers_validation_accepts_valid_names() {
+        let toml = r#"
+            [server.extra_response_headers]
+            "X-Custom" = "v"
+            "Cache-Control" = "v"
+            "X-Robots-Tag" = "v"
+            "Strict-Transport-Security" = "v"
+        "#;
+        let config: Config = toml::from_str(toml).expect("parse");
+        config
+            .validate()
+            .expect("standard custom headers should validate");
     }
 
     #[test]

--- a/crates/tileserver-rs/src/config.rs
+++ b/crates/tileserver-rs/src/config.rs
@@ -296,6 +296,14 @@ pub struct ServerConfig {
     /// ```
     #[serde(default)]
     pub extra_response_headers: Option<HashMap<String, String>>,
+    /// Disable raster render routes (raster tiles + static images) at
+    /// startup. Style metadata (`style.json`, sprites, WMTS) stays served.
+    #[serde(default)]
+    pub disable_render: bool,
+    /// Disable OGC API routes (`/ogc/*`) at startup. No effect unless the
+    /// binary was built with the `ogc` feature.
+    #[serde(default)]
+    pub disable_ogc: bool,
 }
 
 fn default_host() -> String {
@@ -325,6 +333,8 @@ impl Default for ServerConfig {
             upload_dir: None,
             upload_max_size_mb: default_upload_max_size_mb(),
             extra_response_headers: None,
+            disable_render: false,
+            disable_ogc: false,
         }
     }
 }

--- a/crates/tileserver-rs/src/config.rs
+++ b/crates/tileserver-rs/src/config.rs
@@ -273,7 +273,7 @@ pub struct ServerConfig {
     #[serde(default)]
     pub public_url: Option<String>,
     /// Directory for uploaded files (temporary sources).
-    /// Defaults to system temp dir + "tileserver-uploads" if not set.
+    /// Defaults to `<cache_dir>/uploads` (i.e. `resolve_cache_dir(None)`) if not set.
     #[serde(default)]
     pub upload_dir: Option<PathBuf>,
     /// Maximum upload file size in megabytes (default: 500 MB)

--- a/crates/tileserver-rs/src/config.rs
+++ b/crates/tileserver-rs/src/config.rs
@@ -999,7 +999,12 @@ impl Config {
     fn from_file_with_metadata(path: &PathBuf) -> anyhow::Result<ConfigLoadMetadata> {
         let content = std::fs::read_to_string(path)?;
         let content = Self::substitute_env_vars(&content);
-        let config: Config = toml::from_str(&content)?;
+        let config: Config = match path.extension().and_then(|s| s.to_str()) {
+            Some(ext) if ext.eq_ignore_ascii_case("yaml") || ext.eq_ignore_ascii_case("yml") => {
+                serde_yaml_ng::from_str(&content)?
+            }
+            _ => toml::from_str(&content)?,
+        };
         config.validate()?;
         Ok(ConfigLoadMetadata {
             config,
@@ -1045,7 +1050,11 @@ impl Config {
 
         let default_paths = vec![
             PathBuf::from("config.toml"),
+            PathBuf::from("config.yaml"),
+            PathBuf::from("config.yml"),
             PathBuf::from("/etc/tileserver-rs/config.toml"),
+            PathBuf::from("/etc/tileserver-rs/config.yaml"),
+            PathBuf::from("/etc/tileserver-rs/config.yml"),
         ];
 
         for path in default_paths {
@@ -1113,6 +1122,121 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&SourceType::MBTiles).unwrap(),
             "\"mbtiles\""
+        );
+    }
+
+    #[test]
+    fn test_config_load_yaml() {
+        use std::io::Write as _;
+
+        let yaml_content = "\
+server:
+  host: 127.0.0.1
+  port: 3000
+sources:
+  - id: osm
+    type: pmtiles
+    path: /data/osm.pmtiles
+    name: OpenStreetMap
+styles:
+  - id: bright
+    path: /data/styles/bright/style.json
+";
+
+        let mut tmpfile = tempfile::Builder::new()
+            .suffix(".yaml")
+            .tempfile()
+            .expect("create temp .yaml file");
+        tmpfile
+            .write_all(yaml_content.as_bytes())
+            .expect("write YAML content");
+
+        let config = Config::load(Some(tmpfile.path().to_path_buf()))
+            .expect("Config::load should accept .yaml files");
+
+        assert_eq!(config.server.host, "127.0.0.1");
+        assert_eq!(config.server.port, 3000);
+        assert_eq!(config.sources.len(), 1);
+        assert_eq!(config.sources[0].id, "osm");
+        assert_eq!(config.sources[0].source_type, SourceType::PMTiles);
+        assert_eq!(config.styles.len(), 1);
+        assert_eq!(config.styles[0].id, "bright");
+    }
+
+    #[test]
+    fn test_config_load_yml_extension() {
+        use std::io::Write as _;
+
+        let yaml_content = "server:\n  port: 4000\n";
+        let mut tmpfile = tempfile::Builder::new()
+            .suffix(".yml")
+            .tempfile()
+            .expect("create temp .yml file");
+        tmpfile
+            .write_all(yaml_content.as_bytes())
+            .expect("write YAML content");
+
+        let config = Config::load(Some(tmpfile.path().to_path_buf()))
+            .expect("Config::load should accept .yml files");
+        assert_eq!(config.server.port, 4000);
+    }
+
+    #[test]
+    fn test_config_load_yaml_env_var_substitution() {
+        use std::io::Write as _;
+
+        // SAFETY: test-only env var manipulation; no concurrent threads access
+        // this var elsewhere in the test suite.
+        unsafe { std::env::set_var("TEST_YAML_SUB_PORT", "5678") };
+
+        let yaml_content = "server:\n  port: ${TEST_YAML_SUB_PORT}\n";
+        let mut tmpfile = tempfile::Builder::new()
+            .suffix(".yaml")
+            .tempfile()
+            .expect("create temp .yaml file");
+        tmpfile
+            .write_all(yaml_content.as_bytes())
+            .expect("write YAML content");
+
+        let config = Config::load(Some(tmpfile.path().to_path_buf()))
+            .expect("env-var substitution should work on YAML configs");
+        assert_eq!(config.server.port, 5678);
+
+        // SAFETY: same as above — single-threaded teardown.
+        unsafe { std::env::remove_var("TEST_YAML_SUB_PORT") };
+    }
+
+    #[test]
+    fn test_config_toml_yaml_parity() {
+        use std::io::Write as _;
+
+        let toml_str = "[server]\nhost = \"127.0.0.1\"\nport = 3000\ncors_origins = [\"*\"]\n";
+        let yaml_str = "server:\n  host: 127.0.0.1\n  port: 3000\n  cors_origins:\n    - '*'\n";
+
+        let mut toml_file = tempfile::Builder::new()
+            .suffix(".toml")
+            .tempfile()
+            .expect("create temp .toml file");
+        toml_file
+            .write_all(toml_str.as_bytes())
+            .expect("write TOML content");
+
+        let mut yaml_file = tempfile::Builder::new()
+            .suffix(".yaml")
+            .tempfile()
+            .expect("create temp .yaml file");
+        yaml_file
+            .write_all(yaml_str.as_bytes())
+            .expect("write YAML content");
+
+        let toml_config = Config::load(Some(toml_file.path().to_path_buf())).expect("load TOML");
+        let yaml_config = Config::load(Some(yaml_file.path().to_path_buf())).expect("load YAML");
+
+        assert_eq!(toml_config.server.host, yaml_config.server.host);
+        assert_eq!(toml_config.server.port, yaml_config.server.port);
+        assert_eq!(
+            toml_config.server.cors_origins,
+            yaml_config.server.cors_origins
         );
     }
 

--- a/crates/tileserver-rs/src/config_schema.rs
+++ b/crates/tileserver-rs/src/config_schema.rs
@@ -220,6 +220,24 @@ pub static CONFIG_SCHEMA: &[ConfigSectionSchema] = &[
                 optional: true,
                 enum_values: None,
             },
+            ConfigFieldSchema {
+                key: "disable_render",
+                field_type: "bool",
+                default: Some("false"),
+                description: "Unregister raster render routes (raster tiles + static images) \
+                    at startup. style.json, sprites and WMTS stay served.",
+                optional: false,
+                enum_values: None,
+            },
+            ConfigFieldSchema {
+                key: "disable_ogc",
+                field_type: "bool",
+                default: Some("false"),
+                description: "Unregister OGC API routes (`/ogc/*`) at startup. No effect \
+                    unless the binary was built with the `postgres` (OGC) feature.",
+                optional: false,
+                enum_values: None,
+            },
         ],
     },
     ConfigSectionSchema {

--- a/crates/tileserver-rs/src/config_schema.rs
+++ b/crates/tileserver-rs/src/config_schema.rs
@@ -209,6 +209,17 @@ pub static CONFIG_SCHEMA: &[ConfigSectionSchema] = &[
                 optional: false,
                 enum_values: None,
             },
+            ConfigFieldSchema {
+                key: "extra_response_headers",
+                field_type: "table<string,string>",
+                default: None,
+                description: "User-defined HTTP response headers applied to every response. \
+                    Header names must conform to RFC 7230 token grammar; reserved headers \
+                    (Content-Length, Transfer-Encoding, Date, Connection) are rejected at startup. \
+                    Empty-string values delete a header from outgoing responses.",
+                optional: true,
+                enum_values: None,
+            },
         ],
     },
     ConfigSectionSchema {

--- a/crates/tileserver-rs/src/config_schema.rs
+++ b/crates/tileserver-rs/src/config_schema.rs
@@ -276,6 +276,17 @@ pub static CONFIG_SCHEMA: &[ConfigSectionSchema] = &[
                 optional: false,
                 enum_values: None,
             },
+            ConfigFieldSchema {
+                key: "dir",
+                field_type: "path",
+                default: None,
+                description: "Scratch / state directory for on-disk subsystems (uploads). \
+                    Storage location only, not a cache eviction policy. Overridden by \
+                    --cache-dir CLI flag and TILESERVER_CACHE_DIR env; falls back to \
+                    the system temp dir + /tileserver-rs when all three are unset.",
+                optional: true,
+                enum_values: None,
+            },
         ],
     },
     ConfigSectionSchema {

--- a/crates/tileserver-rs/src/cors_origin.rs
+++ b/crates/tileserver-rs/src/cors_origin.rs
@@ -1,0 +1,252 @@
+//! CORS origin pattern matching for `[server].cors_origins`.
+//!
+//! Extends the plain literal-string match used by the original
+//! `AllowOrigin::list` setup with three pattern syntaxes:
+//!
+//! | Syntax              | Variant          | Examples                                  |
+//! | ------------------- | ---------------- | ----------------------------------------- |
+//! | `"*"`               | [`Self::Any`]    | (wildcard catch-all)                      |
+//! | `"https://x"`       | [`Self::Exact`]  | exact origin (current behaviour)          |
+//! | `"*.x.com"`         | [`Self::Glob`]   | one or more `*` wildcards in the host     |
+//! | `"/^https:.+/"`     | [`Self::Regex`]  | enclosed in `/.../`, matches full Origin  |
+//!
+//! Internally `Glob` is compiled to a `Regex` (via `regex::escape` + `\* → .*`)
+//! and `Regex` is parsed by stripping the leading + trailing `/`. Both
+//! variants are anchored with `^...$`.
+//!
+//! Validation happens at startup — invalid regex or empty patterns fail
+//! fast with a clear error naming the offending entry.
+
+use axum::http::HeaderValue;
+use regex::Regex;
+use std::fmt;
+use tower_http::cors::AllowOrigin;
+
+/// Single compiled origin pattern entry from `[server].cors_origins`.
+#[derive(Clone, Debug)]
+pub enum CorsOriginPattern {
+    Any,
+    Exact(String),
+    Matcher(Regex),
+}
+
+impl CorsOriginPattern {
+    /// Classify a raw config string into the matching variant.
+    ///
+    /// # Errors
+    /// Returns an error when the pattern is empty, when a glob produces
+    /// an invalid regex (effectively never, since we escape first), or
+    /// when a regex literal fails to compile.
+    pub fn classify(raw: &str) -> anyhow::Result<Self> {
+        if raw.is_empty() {
+            anyhow::bail!("CORS origin pattern is empty");
+        }
+        if raw == "*" {
+            return Ok(Self::Any);
+        }
+        if raw.starts_with('/') && raw.ends_with('/') && raw.len() >= 2 {
+            let inner = &raw[1..raw.len() - 1];
+            if inner.is_empty() {
+                anyhow::bail!("CORS regex `//` is empty");
+            }
+            let anchored = format!("^{inner}$");
+            let compiled = Regex::new(&anchored)
+                .map_err(|e| anyhow::anyhow!("CORS regex `{raw}` failed to compile: {e}"))?;
+            return Ok(Self::Matcher(compiled));
+        }
+        if raw.contains('*') {
+            let escaped = regex::escape(raw).replace(r"\*", ".*");
+            let anchored = format!("^{escaped}$");
+            let compiled = Regex::new(&anchored)
+                .map_err(|e| anyhow::anyhow!("CORS glob `{raw}` failed to compile: {e}"))?;
+            return Ok(Self::Matcher(compiled));
+        }
+        Ok(Self::Exact(raw.to_string()))
+    }
+
+    /// Test whether an `Origin` header value matches this pattern.
+    pub fn matches(&self, origin: &str) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Exact(s) => s == origin,
+            Self::Matcher(re) => re.is_match(origin),
+        }
+    }
+}
+
+impl fmt::Display for CorsOriginPattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Any => f.write_str("*"),
+            Self::Exact(s) => f.write_str(s),
+            Self::Matcher(re) => write!(f, "/{}/", re.as_str()),
+        }
+    }
+}
+
+/// Build a `tower_http::cors::AllowOrigin` from the raw `cors_origins` list.
+///
+/// Behaviour:
+///
+/// - Empty list                       → wildcard (`AllowOrigin::any`)
+/// - List containing `"*"`            → wildcard, with a warning logged
+/// - All literals (no `*`, no `/.../`) → fast-path `AllowOrigin::list`
+///   of `HeaderValue`s (identical to the pre-existing behaviour to keep
+///   the hot path allocation-free).
+/// - Anything else                     → `AllowOrigin::predicate` that
+///   walks the compiled pattern list per request and short-circuits.
+///
+/// Invalid entries (empty, broken regex) produce a startup error with
+/// the offending string in the message — no silent skips.
+pub fn build_allow_origin(origins: &[String]) -> anyhow::Result<AllowOrigin> {
+    if origins.is_empty() || origins.iter().any(|o| o == "*") {
+        if !origins.is_empty() {
+            tracing::warn!(
+                "CORS configured with wildcard (*). Consider restricting origins in production."
+            );
+        }
+        return Ok(AllowOrigin::any());
+    }
+
+    let needs_predicate = origins
+        .iter()
+        .any(|o| o.contains('*') || (o.starts_with('/') && o.ends_with('/')));
+
+    if !needs_predicate {
+        let values: Vec<HeaderValue> = origins
+            .iter()
+            .filter_map(|o| {
+                o.parse::<HeaderValue>().ok().or_else(|| {
+                    tracing::warn!(origin = %o, "invalid CORS origin literal, skipping");
+                    None
+                })
+            })
+            .collect();
+        if values.is_empty() {
+            tracing::warn!(
+                "no valid CORS origin literals after filtering — defaulting to wildcard"
+            );
+            return Ok(AllowOrigin::any());
+        }
+        return Ok(AllowOrigin::list(values));
+    }
+
+    let mut patterns = Vec::with_capacity(origins.len());
+    for raw in origins {
+        patterns.push(CorsOriginPattern::classify(raw)?);
+    }
+    let patterns = std::sync::Arc::new(patterns);
+    Ok(AllowOrigin::predicate(move |origin, _parts| {
+        let Ok(origin_str) = origin.to_str() else {
+            return false;
+        };
+        patterns.iter().any(|p| p.matches(origin_str))
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_wildcard_is_any() {
+        let p = CorsOriginPattern::classify("*").unwrap();
+        assert!(matches!(p, CorsOriginPattern::Any));
+        assert!(p.matches("https://anything.example.com"));
+    }
+
+    #[test]
+    fn classify_literal_is_exact() {
+        let p = CorsOriginPattern::classify("https://example.com").unwrap();
+        assert!(matches!(p, CorsOriginPattern::Exact(_)));
+        assert!(p.matches("https://example.com"));
+        assert!(!p.matches("https://other.com"));
+        assert!(!p.matches("https://sub.example.com"));
+    }
+
+    #[test]
+    fn classify_glob_with_leading_star() {
+        let p = CorsOriginPattern::classify("*.example.com").unwrap();
+        assert!(matches!(p, CorsOriginPattern::Matcher(_)));
+        assert!(p.matches("https://foo.example.com"));
+        assert!(p.matches("api.example.com"));
+        assert!(!p.matches("https://example.com"));
+        assert!(!p.matches("https://example.com.evil.com"));
+    }
+
+    #[test]
+    fn classify_glob_in_middle() {
+        let p = CorsOriginPattern::classify("preview-*.example.com").unwrap();
+        assert!(p.matches("preview-abc.example.com"));
+        assert!(p.matches("preview-pr-42.example.com"));
+        assert!(!p.matches("staging-abc.example.com"));
+    }
+
+    #[test]
+    fn classify_regex_literal() {
+        let p =
+            CorsOriginPattern::classify("/^https://.+\\.team-[a-z0-9]+\\.app\\.example\\.com$/")
+                .unwrap();
+        assert!(p.matches("https://x.team-acme.app.example.com"));
+        assert!(p.matches("https://abc.team-foo42.app.example.com"));
+        assert!(!p.matches("https://example.com"));
+        assert!(!p.matches("http://x.team-acme.app.example.com"));
+    }
+
+    #[test]
+    fn classify_empty_fails() {
+        assert!(CorsOriginPattern::classify("").is_err());
+    }
+
+    #[test]
+    fn classify_empty_regex_fails() {
+        assert!(CorsOriginPattern::classify("//").is_err());
+    }
+
+    #[test]
+    fn classify_invalid_regex_fails() {
+        assert!(CorsOriginPattern::classify("/[/").is_err());
+    }
+
+    #[test]
+    fn glob_metacharacters_in_literal_part_are_escaped() {
+        let p = CorsOriginPattern::classify("*.test.com").unwrap();
+        assert!(p.matches("https://foo.test.com"));
+        assert!(!p.matches("https://fooXtestXcom"));
+    }
+
+    #[test]
+    fn build_allow_origin_empty_is_any() {
+        let result = build_allow_origin(&[]).unwrap();
+        let _: AllowOrigin = result;
+    }
+
+    #[test]
+    fn build_allow_origin_wildcard_is_any() {
+        let _: AllowOrigin = build_allow_origin(&["*".to_string()]).unwrap();
+    }
+
+    #[test]
+    fn build_allow_origin_literals_use_list_fast_path() {
+        let _: AllowOrigin = build_allow_origin(&[
+            "https://example.com".to_string(),
+            "https://www.example.com".to_string(),
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn build_allow_origin_with_glob_compiles_to_predicate() {
+        let _: AllowOrigin = build_allow_origin(&["*.example.com".to_string()]).unwrap();
+    }
+
+    #[test]
+    fn build_allow_origin_propagates_invalid_regex_error() {
+        let err = build_allow_origin(&["/[/".to_string()]).expect_err("invalid regex must fail");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("CORS regex"),
+            "error should mention the source: {msg}"
+        );
+    }
+}

--- a/crates/tileserver-rs/src/lib.rs
+++ b/crates/tileserver-rs/src/lib.rs
@@ -17,6 +17,7 @@ pub mod openapi;
 pub mod raster;
 pub mod reload;
 pub mod render;
+pub mod response_headers;
 pub mod routes;
 pub mod sources;
 pub mod startup;

--- a/crates/tileserver-rs/src/lib.rs
+++ b/crates/tileserver-rs/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cache;
 pub mod cache_control;
 pub mod config;
 pub mod config_schema;
+pub mod cors_origin;
 pub mod error;
 #[cfg(feature = "mcp")]
 pub mod mcp;

--- a/crates/tileserver-rs/src/main.rs
+++ b/crates/tileserver-rs/src/main.rs
@@ -274,6 +274,11 @@ async fn main() -> anyhow::Result<()> {
         .layer(axum::middleware::from_fn(metrics::record_http_request))
         .layer(axum::middleware::from_fn(logging::request_logger));
 
+    let router = tileserver_rs::response_headers::apply_extra_response_headers(
+        router,
+        config.server.extra_response_headers.as_ref(),
+    );
+
     let addr: SocketAddr = format!("{}:{}", config.server.host, config.server.port).parse()?;
     tracing::info!("Starting tileserver on http://{}", addr);
 

--- a/crates/tileserver-rs/src/main.rs
+++ b/crates/tileserver-rs/src/main.rs
@@ -3,14 +3,14 @@
 use axum::{
     Router,
     http::{
-        HeaderValue, Method,
+        Method,
         header::{ACCEPT, CONTENT_TYPE},
     },
     response::IntoResponse,
 };
 #[cfg(feature = "frontend")]
 use axum::{
-    http::{HeaderMap, StatusCode, Uri, header::CACHE_CONTROL},
+    http::{HeaderMap, HeaderValue, StatusCode, Uri, header::CACHE_CONTROL},
     response::Html,
 };
 #[cfg(feature = "frontend")]
@@ -105,6 +105,11 @@ async fn main() -> anyhow::Result<()> {
     if let Some(public_url) = cli.public_url {
         config.server.public_url = Some(public_url);
     }
+
+    let cache_dir = config.resolve_cache_dir(cli.cache_dir.as_deref());
+    config::Config::ensure_cache_dir_writable(&cache_dir)?;
+    tracing::info!("Cache directory: {}", cache_dir.display());
+    config.cache.dir = Some(cache_dir);
 
     let runtime = RuntimeSettings {
         ui_enabled,

--- a/crates/tileserver-rs/src/main.rs
+++ b/crates/tileserver-rs/src/main.rs
@@ -17,10 +17,7 @@ use axum::{
 use rust_embed::Embed;
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::net::TcpListener;
-use tower_http::{
-    compression::CompressionLayer,
-    cors::{AllowOrigin, CorsLayer},
-};
+use tower_http::{compression::CompressionLayer, cors::CorsLayer};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 use utoipa::OpenApi;
 
@@ -157,36 +154,7 @@ async fn main() -> anyhow::Result<()> {
         tracing::info!("Web UI disabled (use --ui to enable)");
     }
 
-    // Build CORS layer
-    let allow_origin = if config.server.cors_origins.is_empty()
-        || config.server.cors_origins.iter().any(|o| o == "*")
-    {
-        if !config.server.cors_origins.is_empty() {
-            tracing::warn!(
-                "CORS configured with wildcard (*). Consider restricting origins in production."
-            );
-        }
-        AllowOrigin::any()
-    } else {
-        let origins: Vec<HeaderValue> = config
-            .server
-            .cors_origins
-            .iter()
-            .filter_map(|o| {
-                o.parse::<HeaderValue>().ok().or_else(|| {
-                    tracing::warn!("Invalid CORS origin '{}', skipping", o);
-                    None
-                })
-            })
-            .collect();
-
-        if origins.is_empty() {
-            tracing::warn!("No valid CORS origins configured, defaulting to wildcard");
-            AllowOrigin::any()
-        } else {
-            AllowOrigin::list(origins)
-        }
-    };
+    let allow_origin = tileserver_rs::cors_origin::build_allow_origin(&config.server.cors_origins)?;
 
     let cors = CorsLayer::new()
         .allow_headers([ACCEPT, CONTENT_TYPE])

--- a/crates/tileserver-rs/src/reload.rs
+++ b/crates/tileserver-rs/src/reload.rs
@@ -590,16 +590,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn build_app_state_default_upload_dir_lands_in_temp() {
-        let cfg = crate::config::Config::default();
+    async fn build_app_state_default_upload_dir_lands_in_cache_dir() {
+        // Hermetic cache dir: a bare default resolves uploads to the shared
+        // global `temp_dir()/tileserver-rs/uploads`, which parallel tests race
+        // to `create_dir_all`. A unique tempdir exercises the same else-branch
+        // without that race.
+        let tempdir = tempfile::tempdir().unwrap();
+        let mut cfg = crate::config::Config::default();
+        cfg.cache.dir = Some(tempdir.path().to_path_buf());
         let runtime = runtime_for("127.0.0.1", 8080, None);
         let state = build_app_state(&cfg, &runtime).await.unwrap();
 
         let upload = state.upload_dir.expect("default upload dir set");
-        assert!(
-            upload.ends_with("tileserver-rs/uploads"),
-            "default upload dir must live under the resolved cache dir, got: {}",
-            upload.display()
+        assert_eq!(
+            upload,
+            tempdir.path().join("uploads"),
+            "default upload dir must be `<cache_dir>/uploads`"
         );
         assert!(upload.exists(), "upload dir must be created");
     }

--- a/crates/tileserver-rs/src/reload.rs
+++ b/crates/tileserver-rs/src/reload.rs
@@ -307,7 +307,7 @@ pub async fn build_app_state(
     let upload_dir = if let Some(ref dir) = config.server.upload_dir {
         Some(dir.clone())
     } else {
-        Some(std::env::temp_dir().join("tileserver-uploads"))
+        Some(config.resolve_cache_dir(None).join("uploads"))
     };
 
     if let Some(ref dir) = upload_dir {
@@ -597,8 +597,8 @@ mod tests {
 
         let upload = state.upload_dir.expect("default upload dir set");
         assert!(
-            upload.ends_with("tileserver-uploads"),
-            "got: {}",
+            upload.ends_with("tileserver-rs/uploads"),
+            "default upload dir must live under the resolved cache dir, got: {}",
             upload.display()
         );
         assert!(upload.exists(), "upload dir must be created");

--- a/crates/tileserver-rs/src/response_headers.rs
+++ b/crates/tileserver-rs/src/response_headers.rs
@@ -1,0 +1,139 @@
+//! User-defined HTTP response header injection.
+//!
+//! Wires the `[server.extra_response_headers]` config block into the Axum
+//! router as a stack of [`tower_http::set_header::SetResponseHeaderLayer`]
+//! values. Each configured header becomes one layer; the layers are
+//! `overriding` rather than `appending` so a user value wins over any
+//! header that an upstream middleware would have otherwise emitted.
+//!
+//! Validation (RFC 7230 token grammar + reserved-header rejection) happens
+//! upstream in [`crate::config::Config::validate`]; this module trusts that
+//! the names + values are well-formed `HeaderName` / `HeaderValue`s. Any
+//! still-malformed name or value here is logged and skipped so a single
+//! bad row never tanks the whole router build.
+
+use axum::Router;
+use axum::http::{HeaderName, HeaderValue};
+use std::collections::HashMap;
+use tower_http::set_header::SetResponseHeaderLayer;
+
+/// Apply user-defined response headers (`[server.extra_response_headers]`)
+/// to a router as a stack of overriding `SetResponseHeaderLayer`s.
+///
+/// `None` or an empty map is a no-op — the router is returned unchanged.
+///
+/// Per spec, an empty-string value DELETES any pre-existing header of
+/// that name from outgoing responses (a `SetResponseHeaderLayer` with an
+/// empty `HeaderValue` does this naturally).
+pub fn apply_extra_response_headers<S>(
+    mut router: Router<S>,
+    headers: Option<&HashMap<String, String>>,
+) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    let Some(headers) = headers else {
+        return router;
+    };
+    if headers.is_empty() {
+        return router;
+    }
+
+    for (raw_name, raw_value) in headers {
+        let name = match HeaderName::try_from(raw_name.as_str()) {
+            Ok(n) => n,
+            Err(err) => {
+                tracing::warn!(
+                    header = %raw_name,
+                    error = %err,
+                    "skipping extra_response_header with invalid name (should have been caught by Config::validate)"
+                );
+                continue;
+            }
+        };
+        let value = match HeaderValue::try_from(raw_value.as_str()) {
+            Ok(v) => v,
+            Err(err) => {
+                tracing::warn!(
+                    header = %raw_name,
+                    error = %err,
+                    "skipping extra_response_header with invalid value"
+                );
+                continue;
+            }
+        };
+        router = router.layer(SetResponseHeaderLayer::overriding(name, value));
+    }
+    router
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, routing::get};
+    use axum_test::TestServer;
+
+    fn router_with(headers: Option<HashMap<String, String>>) -> Router {
+        let r: Router<()> = Router::new().route("/ping", get(|| async { "pong" }));
+        apply_extra_response_headers(r, headers.as_ref())
+    }
+
+    #[tokio::test]
+    async fn no_headers_is_no_op() {
+        let server = TestServer::new(router_with(None));
+        let resp = server.get("/ping").await;
+        resp.assert_status_ok();
+        resp.assert_text("pong");
+    }
+
+    #[tokio::test]
+    async fn empty_map_is_no_op() {
+        let server = TestServer::new(router_with(Some(HashMap::new())));
+        let resp = server.get("/ping").await;
+        resp.assert_status_ok();
+    }
+
+    #[tokio::test]
+    async fn single_header_appears_on_response() {
+        let mut h = HashMap::new();
+        h.insert("X-Custom".to_string(), "value1".to_string());
+        let server = TestServer::new(router_with(Some(h)));
+        let resp = server.get("/ping").await;
+        resp.assert_status_ok();
+        let v = resp.header("X-Custom");
+        assert_eq!(v.to_str().unwrap(), "value1");
+    }
+
+    #[tokio::test]
+    async fn multiple_headers_all_appear() {
+        let mut h = HashMap::new();
+        h.insert("X-Foo".to_string(), "foo-val".to_string());
+        h.insert("X-Bar".to_string(), "bar-val".to_string());
+        h.insert(
+            "Cache-Control".to_string(),
+            "public, max-age=3600".to_string(),
+        );
+        let server = TestServer::new(router_with(Some(h)));
+        let resp = server.get("/ping").await;
+        resp.assert_status_ok();
+        assert_eq!(resp.header("X-Foo").to_str().unwrap(), "foo-val");
+        assert_eq!(resp.header("X-Bar").to_str().unwrap(), "bar-val");
+        assert_eq!(
+            resp.header("Cache-Control").to_str().unwrap(),
+            "public, max-age=3600"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_name_is_skipped_not_panicked() {
+        // Config::validate should reject these upstream — but if one
+        // slips through, the layer build must not panic the server.
+        let mut h = HashMap::new();
+        h.insert("Bad Name With Space".to_string(), "value".to_string());
+        h.insert("X-Good".to_string(), "ok".to_string());
+        let server = TestServer::new(router_with(Some(h)));
+        let resp = server.get("/ping").await;
+        resp.assert_status_ok();
+        assert_eq!(resp.header("X-Good").to_str().unwrap(), "ok");
+    }
+}

--- a/crates/tileserver-rs/src/routes/mod.rs
+++ b/crates/tileserver-rs/src/routes/mod.rs
@@ -54,7 +54,8 @@ struct IndexQueryParams {
 }
 
 pub fn api_router(state: SharedState) -> Router {
-    Router::new()
+    let config = state.config();
+    let mut router = Router::new()
         .route("/health", get(health_check))
         .route("/ping", get(admin::ping_check))
         .route("/index.json", get(get_index_json))
@@ -67,18 +68,6 @@ pub fn api_router(state: SharedState) -> Router {
             get(styles::get_wmts_capabilities),
         )
         .route("/styles/{style}/{sprite_file}", get(styles::get_sprite))
-        .route(
-            "/styles/{style}/{z}/{x}/{y_fmt}",
-            get(render::get_raster_tile),
-        )
-        .route(
-            "/styles/{style}/{tile_size}/{z}/{x}/{y_fmt}",
-            get(render::get_raster_tile_with_size),
-        )
-        .route(
-            "/styles/{style}/static/{static_type}/{size_fmt}",
-            get(render::get_static_image),
-        )
         // Font endpoints
         .route("/fonts.json", get(fonts::get_fonts_list))
         .route("/fonts/{fontstack}/{range}", get(fonts::get_font_glyphs))
@@ -105,9 +94,32 @@ pub fn api_router(state: SharedState) -> Router {
             "/api/spatial/stats/{source}",
             get(spatial::get_spatial_stats),
         )
-        .route("/api/spatial/query", post(spatial::post_spatial_query))
-        .merge(ogc_router())
-        .with_state(state)
+        .route("/api/spatial/query", post(spatial::post_spatial_query));
+
+    if !config.server.disable_render {
+        router = router.merge(render_router());
+    }
+    if !config.server.disable_ogc {
+        router = router.merge(ogc_router());
+    }
+
+    router.with_state(state)
+}
+
+fn render_router() -> Router<SharedState> {
+    Router::new()
+        .route(
+            "/styles/{style}/{z}/{x}/{y_fmt}",
+            get(render::get_raster_tile),
+        )
+        .route(
+            "/styles/{style}/{tile_size}/{z}/{x}/{y_fmt}",
+            get(render::get_raster_tile_with_size),
+        )
+        .route(
+            "/styles/{style}/static/{static_type}/{size_fmt}",
+            get(render::get_static_image),
+        )
 }
 
 async fn health_check() -> (StatusCode, &'static str) {

--- a/crates/tileserver-rs/tests/common/mod.rs
+++ b/crates/tileserver-rs/tests/common/mod.rs
@@ -83,6 +83,23 @@ pub fn empty_test_server() -> TestServer {
     TestServer::new(router)
 }
 
+/// Build a [`TestServer`] from an empty [`AppState`] but a caller-supplied
+/// [`Config`]. Lets route-gating tests flip `server.disable_render` /
+/// `server.disable_ogc` and assert the affected routes are unregistered.
+pub fn test_server_with_config(config: Config) -> TestServer {
+    let state = minimal_app_state();
+    let meta = minimal_meta();
+    let controller = Arc::new(ReloadController::new(
+        state,
+        meta,
+        config,
+        None,
+        minimal_runtime(),
+    ));
+    let shared = SharedState::new(controller);
+    TestServer::new(api_router(shared))
+}
+
 // ============================================================
 // MockSource — in-memory tile source for integration tests
 // ============================================================

--- a/crates/tileserver-rs/tests/route_ogc.rs
+++ b/crates/tileserver-rs/tests/route_ogc.rs
@@ -410,3 +410,53 @@ async fn post_items_rejects_malformed_json_body() {
         "malformed JSON body must surface a 4xx, got {status}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// server.disable_ogc route gating (#1004)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn disable_ogc_unregisters_landing_page() {
+    let mut config = tileserver_rs::config::Config::default();
+    config.server.disable_ogc = true;
+    let server = common::test_server_with_config(config);
+    let resp = server.get("/ogc").await;
+    assert_eq!(
+        resp.status_code().as_u16(),
+        404,
+        "OGC landing page must be unregistered when disable_ogc = true"
+    );
+}
+
+#[tokio::test]
+async fn disable_ogc_unregisters_collections() {
+    let mut config = tileserver_rs::config::Config::default();
+    config.server.disable_ogc = true;
+    let server = common::test_server_with_config(config);
+    let resp = server.get("/ogc/collections").await;
+    assert_eq!(resp.status_code().as_u16(), 404);
+}
+
+#[tokio::test]
+async fn disable_ogc_keeps_data_routes() {
+    let mut config = tileserver_rs::config::Config::default();
+    config.server.disable_ogc = true;
+    let server = common::test_server_with_config(config);
+    let resp = server.get("/data.json").await;
+    assert_ne!(
+        resp.status_code().as_u16(),
+        404,
+        "data.json must remain registered when only OGC is disabled"
+    );
+}
+
+#[tokio::test]
+async fn ogc_enabled_by_default_keeps_landing_registered() {
+    let server = common::empty_test_server();
+    let resp = server.get("/ogc").await;
+    assert_ne!(
+        resp.status_code().as_u16(),
+        404,
+        "OGC landing must be registered by default under the postgres feature"
+    );
+}

--- a/crates/tileserver-rs/tests/route_render.rs
+++ b/crates/tileserver-rs/tests/route_render.rs
@@ -183,3 +183,55 @@ async fn static_image_invalid_static_type_returns_error() {
         .await;
     assert_ne!(resp.status_code().as_u16(), 200);
 }
+
+// ---------------------------------------------------------------------------
+// server.disable_render route gating (#1004)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn disable_render_unregisters_raster_tile_route() {
+    let mut config = tileserver_rs::config::Config::default();
+    config.server.disable_render = true;
+    let server = common::test_server_with_config(config);
+    let resp = server.get("/styles/any-style/0/0/0.png").await;
+    assert_eq!(
+        resp.status_code().as_u16(),
+        404,
+        "raster tile route must be unregistered when disable_render = true"
+    );
+}
+
+#[tokio::test]
+async fn disable_render_unregisters_static_image_route() {
+    let mut config = tileserver_rs::config::Config::default();
+    config.server.disable_render = true;
+    let server = common::test_server_with_config(config);
+    let resp = server
+        .get("/styles/any-style/static/0,0,2/400x300.png")
+        .await;
+    assert_eq!(resp.status_code().as_u16(), 404);
+}
+
+#[tokio::test]
+async fn disable_render_keeps_styles_list_route() {
+    let mut config = tileserver_rs::config::Config::default();
+    config.server.disable_render = true;
+    let server = common::test_server_with_config(config);
+    let resp = server.get("/styles.json").await;
+    assert_ne!(
+        resp.status_code().as_u16(),
+        404,
+        "/styles.json must remain registered when only rendering is disabled"
+    );
+}
+
+#[tokio::test]
+async fn render_enabled_by_default_keeps_raster_route_registered() {
+    let server = common::empty_test_server();
+    let resp = server.get("/styles/any-style/0/0/0.png").await;
+    assert_ne!(
+        resp.status_code().as_u16(),
+        404,
+        "raster route must be registered by default (non-404 even without a renderer)"
+    );
+}

--- a/data/configs/example.toml
+++ b/data/configs/example.toml
@@ -96,12 +96,12 @@ render_timeout_secs = 30
 # PostgreSQL sources have their own [postgres.cache] section.
 # ============================================================================
 [cache]
-# Enable the global tile cache (default: false)
-enabled = true
-# Maximum cache size in megabytes (default: 512)
+enabled = false
 max_size_mb = 512
-# Cache entry time-to-live in seconds (default: 3600 = 1 hour)
 ttl_seconds = 3600
+# Scratch / cache directory. Overridden by --cache-dir / TILESERVER_CACHE_DIR.
+# Defaults to <system temp dir>/tileserver-rs when unset.
+# dir = "/var/cache/tileserver-rs"
 
 # ============================================================================
 # TILE SOURCES

--- a/data/configs/example.yaml
+++ b/data/configs/example.yaml
@@ -54,6 +54,12 @@ cache:
   enabled: true
   max_size_mb: 512
   ttl_seconds: 3600
+  # Scratch / state directory (uploads). Overridden by --cache-dir and
+  # TILESERVER_CACHE_DIR. Defaults to <system temp dir>/tileserver-rs.
+  # dir: /var/lib/tileserver-rs
+  # Scratch / cache directory. Overridden by --cache-dir / TILESERVER_CACHE_DIR.
+  # Defaults to <system temp dir>/tileserver-rs when unset.
+  # dir: /var/cache/tileserver-rs
 
 # ----------------------------------------------------------------------------
 # Tile sources — add multiple entries, each with a unique `id`

--- a/data/configs/example.yaml
+++ b/data/configs/example.yaml
@@ -1,0 +1,78 @@
+# Tileserver-RS Configuration Example (YAML)
+#
+# This is the YAML equivalent of `example.toml`. Every option that exists in
+# `example.toml` is also accepted in YAML; only the surface syntax changes.
+# When in doubt, treat `example.toml` as the canonical, exhaustively-commented
+# reference and use this file as a syntax hint.
+#
+# Format detection is by file extension:
+#   - `.toml`           → TOML parser (default, unchanged behavior)
+#   - `.yaml` / `.yml`  → YAML parser
+#   - anything else     → falls through to the TOML parser
+#
+# Pass with: `tileserver-rs --config /path/to/this/config.yaml`
+
+# ----------------------------------------------------------------------------
+# Root-level options (must come before nested keys, same constraint as TOML)
+# ----------------------------------------------------------------------------
+# fonts: /data/fonts
+# files: /data/files
+
+# ----------------------------------------------------------------------------
+# Server
+# ----------------------------------------------------------------------------
+server:
+  host: 0.0.0.0
+  port: 8080
+  cors_origins:
+    - '*'
+  # admin_bind: 127.0.0.1:9099
+  # public_url: http://localhost:4000
+
+# ----------------------------------------------------------------------------
+# Telemetry — see example.toml for the full option matrix + Prometheus knobs
+# ----------------------------------------------------------------------------
+telemetry:
+  enabled: false
+  endpoint: http://localhost:4317
+  service_name: tileserver-rs
+  sample_rate: 1.0
+  metrics_enabled: true
+  metrics_export_interval_secs: 60
+
+# ----------------------------------------------------------------------------
+# Native renderer pool (server-side raster tile generation)
+# ----------------------------------------------------------------------------
+render:
+  pool_size: 4
+  render_timeout_secs: 30
+
+# ----------------------------------------------------------------------------
+# Global tile cache (in-process, byte-weighted, shared across non-PG sources)
+# ----------------------------------------------------------------------------
+cache:
+  enabled: true
+  max_size_mb: 512
+  ttl_seconds: 3600
+
+# ----------------------------------------------------------------------------
+# Tile sources — add multiple entries, each with a unique `id`
+# ----------------------------------------------------------------------------
+# sources:
+#   - id: osm
+#     type: pmtiles
+#     path: /data/osm.pmtiles
+#     name: OpenStreetMap
+#     attribution: '<a href="https://www.openstreetmap.org/copyright">© OpenStreetMap</a>'
+#
+#   - id: terrain
+#     type: mbtiles
+#     path: /data/terrain.mbtiles
+#     name: Terrain data
+
+# ----------------------------------------------------------------------------
+# Styles — add multiple entries, each with a unique `id`
+# ----------------------------------------------------------------------------
+# styles:
+#   - id: bright
+#     path: /data/styles/bright/style.json


### PR DESCRIPTION
## Bundle A — Config hardening (5 features)

Five atomic conventional commits, each independently runnable and testable.
Targets `main` for the next release (v2.31.0).

### Commits

| Commit | Issue | Summary |
|---|---|---|
| `a07ee7d` | #999 | YAML config files alongside TOML |
| `83b68d3` | #1001 | `extra_response_headers` config block |
| `3d8591d` | #1002 | CORS glob + regex origin patterns |
| `6395f90` | #1003 | `--cache-dir` flag with resolution precedence |
| `2448ce8` | #1004 | `disable_render` + `disable_ogc` route gates |

### #999 — YAML config files

Extension-based dispatch in `Config::from_file_with_metadata`: `.yaml`/`.yml`
go through `serde_yaml_ng`, everything else through TOML. Env-var
substitution applies to both. Default config lookup now also probes
`config.yaml` / `config.yml`. New `data/configs/example.yaml` mirrors
`example.toml` for the YAML syntax reference.

### #1001 — `extra_response_headers`

New `[server].extra_response_headers` table maps header name → value, applied
to every HTTP response via `SetResponseHeaderLayer`. Reserved headers
(`Content-Length`, `Transfer-Encoding`, `Date`, `Connection`, etc.) and
RFC-7230-non-conformant names are rejected at startup. Empty-string values
delete a header from outgoing responses. New `resp_headers.rs` module.

### #1002 — CORS glob + regex origin patterns

`cors_origins` entries now dispatch on syntax:
- `https://example.com` → literal match (existing behavior, AllowOrigin::list fast path)
- `https://*.example.com` → glob (compiled `^…$` regex; blocks suffix injection)
- `/^https:\/\/(a|b)\.com$/` → regex (slash-delimited)

Unified `CorsOriginPattern::{Literal, Glob, Regex}` enum + `build_allow_origin()`
helper in new `cors_origin.rs` module. Uses the existing `regex` transitive
dep — no new direct dependencies.

### #1003 — `--cache-dir` flag

New `--cache-dir <PATH>` CLI flag + `TILESERVER_CACHE_DIR` env var +
`[cache].dir` config key. Resolves with precedence (highest first):

1. `--cache-dir` flag
2. `TILESERVER_CACHE_DIR` env
3. `[cache].dir` config
4. Default: `<system temp dir>/tileserver-rs`

Resolved path is created, write-probed, and logged on boot. **This is a
storage-location primitive, not an eviction policy** — tile and dataset
cache lifetimes remain governed by the in-memory moka caches (`max_size_mb`
/ `ttl_seconds`), independent of this path. Today the only on-disk
consumer is the upload directory (which previously hardcoded
`std::env::temp_dir()/tileserver-uploads`).

### #1004 — `disable_render` + `disable_ogc`

Two opt-in `[server]` booleans that unregister whole route groups at
startup, for operators who want a slimmer attack surface or to run a
metadata-only / vector-only node:

- `disable_render: true` — drops raster render routes (raster tiles +
  static images). `style.json`, sprites and WMTS stay served.
- `disable_ogc: true` — drops the OGC API routes (`/ogc/*`). No effect
  unless the binary was built with the `postgres` (OGC) feature.

Gating is build-time in `routes::api_router` by reading the resolved
config, so a config reload re-applies the choice on the next (re)start.
The raster routes are factored into a small `render_router()` helper so
the gate is a single conditional merge.

### Tests

Every commit ships test coverage per the project's TDD discipline:

- #999: 4 new tests (YAML load, `.yml` extension, env-var sub, default-path)
- #1001: 5 new tests (config + HTTP layer round-trip via `axum_test`)
- #1002: 14 new tests covering literal/glob/regex match + rejection
- #1003: 5 new tests (CLI flag round-trip, 3× precedence, root + probe)
- #1004: 8 new tests (4 in `route_render`, 4 in `route_ogc`) verifying
  disabled routes 404 while neighbour routes stay registered

Plus `config_schema` snapshot test validates every new field appears in
`CONFIG_SCHEMA` (caught a missing schema entry mid-bundle and forced the
fix to land before the commit).

### Verification

- `cargo fmt --all -- --check` → 0
- `cargo clippy --all-targets --all-features -- -D warnings` → 0
- `cargo clippy --all-targets --no-default-features -- -D warnings` → 0
- `cargo test --lib --all-features` → green (923+ tests)
- `pnpm --filter @tileserver-rs/docs run build` → exit 0
- Husky pre-commit (`fmt --check` + `clippy --all-features`) ran on every
  commit — every gate passed before staging.

### Docs

`apps/docs/content/1.getting-started/3.config.md` updated for every
feature (CLI flag rows, `[server]` table additions, `[cache]` table
additions, syntax tables for CORS patterns, format detection table for
YAML). Both `data/configs/example.toml` and `data/configs/example.yaml`
document the new options.

### Closes

Closes #999
Closes #1001
Closes #1002
Closes #1003
Closes #1004
