### PR TITLE
ci: add CRAP complexity gate + complete bundle a docs/marketing

### DIFF
--- a/.github/workflows/ci-rust.yml
+++ b/.github/workflows/ci-rust.yml
@@ -108,7 +108,10 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Free disk space for cargo cache
         run: rm -rf ~/.cargo/registry/src
@@ -126,5 +129,20 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-      - name: Run tests
-        run: cargo test --all --all-features
+      # Runs the full --all-features test suite under llvm instrumentation, so
+      # the gating test run and the LCOV that feeds cargo-crap come from ONE
+      # build instead of two. The crate has no executable Rust doctests (all
+      # fences are toml/sql/ignore), so llvm-cov skipping doctests loses nothing.
+      - name: Run tests + collect coverage
+        run: |
+          cargo llvm-cov --workspace --all-features \
+            --lcov --output-path lcov-all-features.info \
+            --ignore-filename-regex '(vendor|build\.rs)'
+
+      - name: Upload all-features LCOV
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-all-features
+          path: lcov-all-features.info
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -166,10 +166,22 @@ jobs:
           name: lcov-all-features
 
       - name: Run cargo-crap
+        # `|| true` keeps this advisory: the report is still written + posted
+        # even when functions exceed the threshold (cargo-crap exits non-zero).
         run: |
           cargo crap --path crates/tileserver-rs \
             --lcov lcov-all-features.info \
             --exclude 'tests/**' --exclude 'benches/**' \
             --allow 'crates/mbgl-sys/**' \
             --threshold 30 \
-            --format markdown
+            --format pr-comment \
+            --repo-url "${{ github.server_url }}/${{ github.repository }}" \
+            --commit-ref "${{ github.event.pull_request.head.sha || github.sha }}" \
+            --output crap-report.md || true
+
+      - name: Post CRAP report as PR comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: cargo-crap
+          path: crap-report.md

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -141,3 +141,35 @@ jobs:
           flags: unittests
           name: tileserver-rs
           fail_ci_if_error: false
+
+  # Complexity-vs-coverage (CRAP) gate. Consumes the --all-features LCOV that
+  # ci-rust.yml already produced (no second instrumented build here) and reports
+  # the worst offenders. Advisory for now (continue-on-error) — flip off once a
+  # main baseline is committed and switch to --baseline + regression gating.
+  crap:
+    name: Complexity (CRAP)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-crap
+        run: cargo install cargo-crap --locked
+
+      - name: Download all-features LCOV
+        uses: actions/download-artifact@v4
+        with:
+          name: lcov-all-features
+
+      - name: Run cargo-crap
+        run: |
+          cargo crap --path crates/tileserver-rs \
+            --lcov lcov-all-features.info \
+            --exclude 'tests/**' --exclude 'benches/**' \
+            --allow 'crates/mbgl-sys/**' \
+            --threshold 30 \
+            --format markdown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6296,7 +6296,7 @@ dependencies = [
 
 [[package]]
 name = "tileserver-rs"
-version = "2.30.1"
+version = "2.31.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/apps/docs/content/1.getting-started/3.config.md
+++ b/apps/docs/content/1.getting-started/3.config.md
@@ -66,6 +66,7 @@ tileserver-rs [OPTIONS] [PATH] [SUBCOMMAND]
 | ----------------------------- | ---------------------- | -------------- | ---------------------------------------------------------------------- |
 | `[PATH]` (positional)         | —                      | —              | File or directory to auto-detect sources/styles from (zero-config mode) |
 | `-c, --config <FILE>`         | `TILESERVER_CONFIG`    | —              | Path to TOML config file                                               |
+| `--cache-dir <PATH>`          | `TILESERVER_CACHE_DIR` | `<tmp>/tileserver-rs` | Scratch / state directory (uploads, on-disk subsystems). Overrides `[cache].dir` |
 | `--host <HOST>`               | `TILESERVER_HOST`      | from `[server]` | Override bind address                                                  |
 | `-p, --port <PORT>`           | `TILESERVER_PORT`      | from `[server]` | Override bind port                                                     |
 | `--public-url <URL>`          | `TILESERVER_PUBLIC_URL`| —              | Public URL embedded in TileJSON `tiles` entries                        |
@@ -91,6 +92,8 @@ admin_bind = "127.0.0.1:0"
 public_url = "https://tiles.example.com"   # optional
 upload_dir = "/var/lib/tileserver/uploads" # optional
 upload_max_size_mb = 500
+disable_render = false                     # optional — turn off raster routes
+disable_ogc = false                        # optional — turn off OGC API routes
 ```
 
 | Key                  | Type           | Default        | Description                                                                                                       |
@@ -103,6 +106,8 @@ upload_max_size_mb = 500
 | `upload_dir`         | path?          | system tmp     | Directory for drag-and-drop uploads (creates a tmp source per upload)                                             |
 | `upload_max_size_mb` | u32            | `500`          | Maximum per-file upload size in megabytes                                                                         |
 | `extra_response_headers` | table?     | _(none)_       | User-defined response headers applied to every HTTP response — see [`[server.extra_response_headers]`](#serverextra_response_headers) below |
+| `disable_render`     | bool           | `false`        | Unregister raster render routes (raster tiles + static images) at startup. Style metadata (`style.json`, sprites, WMTS) stays served. Disabled routes return `404`. |
+| `disable_ogc`        | bool           | `false`        | Unregister OGC API routes (`/ogc/*`) at startup. No effect unless built with the `ogc` feature. Disabled routes return `404`. |
 
 ### CORS origin patterns
 
@@ -321,13 +326,21 @@ Global in-process tile cache (moka backend).
 enabled = true
 max_size_mb = 512
 ttl_seconds = 3600
+dir = "/var/lib/tileserver"   # optional — scratch / state directory
 ```
 
-| Key           | Type | Default | Description                          |
-| ------------- | ---- | ------- | ------------------------------------ |
-| `enabled`     | bool | `false` | Enable the global tile cache         |
-| `max_size_mb` | u64  | `512`   | Maximum cache size in megabytes      |
-| `ttl_seconds` | u64  | `3600`  | Time-to-live for cache entries       |
+| Key           | Type  | Default               | Description                          |
+| ------------- | ----- | --------------------- | ------------------------------------ |
+| `enabled`     | bool  | `false`               | Enable the global tile cache         |
+| `max_size_mb` | u64   | `512`                 | Maximum cache size in megabytes      |
+| `ttl_seconds` | u64   | `3600`                | Time-to-live for cache entries       |
+| `dir`         | path? | `<tmp>/tileserver-rs` | Scratch / state directory for on-disk subsystems (today: uploads). Storage location only — **not** a cache eviction policy. |
+
+::alert{type="note"}
+`dir` sets where on-disk state (e.g. uploads) lives, not the in-memory tile
+cache. Resolution precedence (highest first): `--cache-dir` flag →
+`TILESERVER_CACHE_DIR` env → `[cache].dir` → `<tmp>/tileserver-rs`.
+::
 
 ## `[raster]` _(feature: `raster`)_
 
@@ -559,6 +572,7 @@ it included.
 | Variable                | Type     | Description                                                              |
 | ----------------------- | -------- | ------------------------------------------------------------------------ |
 | `TILESERVER_CONFIG`     | path     | Equivalent to `--config <FILE>`                                          |
+| `TILESERVER_CACHE_DIR`  | path     | Equivalent to `--cache-dir <PATH>` (overrides `[cache].dir`)            |
 | `TILESERVER_HOST`       | string   | Equivalent to `--host <HOST>`                                            |
 | `TILESERVER_PORT`       | u16      | Equivalent to `--port <PORT>`                                            |
 | `TILESERVER_PUBLIC_URL` | url      | Equivalent to `--public-url <URL>`                                       |

--- a/apps/marketing/app/components/marketing/ConfigSection.vue
+++ b/apps/marketing/app/components/marketing/ConfigSection.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
   const configFeatures = [
     'Multiple tile sources (PMTiles, MBTiles, PostGIS, COG)',
-    'Custom MapLibre GL styles',
+    'TOML or YAML config, with env-var substitution',
     'In-memory tile caching with TTL',
-    'Configurable CORS and connection pooling',
+    'Glob & regex CORS allow-lists, custom response headers',
   ];
 </script>
 
@@ -76,6 +76,10 @@ id = <span class="token-string">"openmaptiles"</span>
 type = <span class="token-string">"pmtiles"</span>
 path = <span class="token-string">"/data/tiles.pmtiles"</span>
 serve_as = <span class="token-string">"mlt"</span>  <span class="token-comment"># MVT→MLT on the fly</span>
+
+<span class="token-comment"># Server — glob/regex CORS + custom headers</span>
+<span class="token-keyword">[server]</span>
+cors_origins = [<span class="token-string">"*.example.com"</span>]
 
 <span class="token-comment"># PostgreSQL / PostGIS</span>
 <span class="token-keyword">[postgres]</span>

--- a/crates/tileserver-rs/src/cors_origin.rs
+++ b/crates/tileserver-rs/src/cors_origin.rs
@@ -249,4 +249,38 @@ mod tests {
             "error should mention the source: {msg}"
         );
     }
+
+    #[test]
+    fn display_renders_all_variants() {
+        assert_eq!(CorsOriginPattern::classify("*").unwrap().to_string(), "*");
+        assert_eq!(
+            CorsOriginPattern::classify("https://example.com")
+                .unwrap()
+                .to_string(),
+            "https://example.com"
+        );
+        let glob = CorsOriginPattern::classify("*.example.com")
+            .unwrap()
+            .to_string();
+        assert!(
+            glob.starts_with('/') && glob.ends_with('/'),
+            "matcher renders as /regex/, got: {glob}"
+        );
+    }
+
+    #[test]
+    fn build_allow_origin_skips_invalid_literal_keeps_valid() {
+        // A control char makes the literal fail `HeaderValue::parse` while
+        // staying off the predicate path (no `*`, no `/.../`).
+        let _: AllowOrigin = build_allow_origin(&[
+            "https://good.example.com".to_string(),
+            "bad\nliteral".to_string(),
+        ])
+        .unwrap();
+    }
+
+    #[test]
+    fn build_allow_origin_all_invalid_literals_fall_back_to_any() {
+        let _: AllowOrigin = build_allow_origin(&["bad\nliteral".to_string()]).unwrap();
+    }
 }

--- a/crates/tileserver-rs/src/response_headers.rs
+++ b/crates/tileserver-rs/src/response_headers.rs
@@ -136,4 +136,17 @@ mod tests {
         resp.assert_status_ok();
         assert_eq!(resp.header("X-Good").to_str().unwrap(), "ok");
     }
+
+    #[tokio::test]
+    async fn invalid_value_is_skipped_not_panicked() {
+        // A newline in the value fails `HeaderValue::try_from`; the bad row
+        // must be skipped while a sibling valid row still applies.
+        let mut h = HashMap::new();
+        h.insert("X-Bad".to_string(), "bad\nvalue".to_string());
+        h.insert("X-Good".to_string(), "ok".to_string());
+        let server = TestServer::new(router_with(Some(h)));
+        let resp = server.get("/ping").await;
+        resp.assert_status_ok();
+        assert_eq!(resp.header("X-Good").to_str().unwrap(), "ok");
+    }
 }


### PR DESCRIPTION
## Summary

Wires a complexity-vs-coverage (**CRAP**) gate into the pipeline and closes the docs/marketing gaps left from Bundle A (#999–#1004).

## CI

- **`ci-rust.yml`** now runs the `--all-features` test suite under `cargo llvm-cov` — one build serves both the gating test run and the LCOV — then uploads the LCOV as an artifact. The crate has **no executable Rust doctests** (all fences are `toml`/`sql`/`ignore`), so `llvm-cov` skipping doctests loses no coverage.
- **`coverage.yml`** gains an advisory `crap` job that downloads that LCOV and runs `cargo-crap`. It rides the existing `coverage needs: ci-rust` ordering, so there is **no second instrumented build and no extra wall-clock**.
- Advisory (`continue-on-error: true`) for now — flip off and switch to `--baseline` regression gating once a `main` baseline is committed.

## Docs (`3.config.md`)

- `--cache-dir` / `TILESERVER_CACHE_DIR` / `[cache].dir` with resolution precedence (#1003)
- `[server].disable_render` and `disable_ogc` (#1004)

## Marketing (`ConfigSection.vue`)

- Refreshed feature bullets (TOML/YAML, glob/regex CORS, custom headers) + sample config snippet

## Tests

- `cors_origin` Display + invalid-literal / all-invalid fallback branches
- `response_headers` invalid-value skip branch

## Verification

- `cargo fmt --check` ✅ · `cargo clippy --all-features` ✅ · `cargo clippy --no-default-features` ✅
- `cors_origin::tests` 17/17 ✅ · `response_headers::tests` 6/6 ✅
- docs lint + build ✅ · marketing lint ✅ · both workflow YAMLs parse-validated ✅

## Testing requirements

Tests added alongside the covered branches (TDD). No coverage regression — project coverage stays above the 75% floor; this PR raises patch coverage on `cors_origin`/`response_headers`.