### PR TITLE
fix: trailing-slash normalization + compression coverage tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ mbgl-sys = { path = "crates/mbgl-sys", version = "0.1.6" }
 
 # Web framework
 axum             = { version = "0.8.9", features = ["multipart"] }
-tower-http       = { version = "0.6.11", features = ["fs", "cors", "compression-gzip", "compression-br", "trace", "set-header"] }
+tower-http       = { version = "0.6.11", features = ["fs", "cors", "compression-gzip", "compression-br", "trace", "set-header", "normalize-path"] }
 
 # Async runtime
 tokio            = { version = "1.52.3", features = ["full"] }

--- a/apps/marketing/app/components/marketing/ApiSection.vue
+++ b/apps/marketing/app/components/marketing/ApiSection.vue
@@ -37,7 +37,7 @@
           Simple, standards-compliant API with a built-in OpenAPI spec —
           something neither tileserver-gl nor martin offer.
           <NuxtLink
-            to="https://demo.tileserver.app/_openapi/"
+            to="https://demo.tileserver.app/_openapi"
             external
             class="
               group ml-1 inline-flex items-center gap-1 font-mono text-xs

--- a/crates/tileserver-rs/Cargo.toml
+++ b/crates/tileserver-rs/Cargo.toml
@@ -47,6 +47,7 @@ crossbeam-channel = { workspace = true }
 regex            = { workspace = true }
 serde_yaml_ng    = { workspace = true }
 toml             = { workspace = true }
+tower            = { workspace = true }
 tower-http       = { workspace = true }
 urlencoding      = { workspace = true }
 uuid             = { workspace = true }

--- a/crates/tileserver-rs/src/compression.rs
+++ b/crates/tileserver-rs/src/compression.rs
@@ -430,6 +430,62 @@ mod tests {
     }
 
     #[test]
+    fn best_target_wildcard_accepts_brotli() {
+        // `*` matches any encoding via the quality_of wildcard branch.
+        assert_eq!(best_target_encoding("*"), TileCompression::Brotli);
+    }
+
+    #[test]
+    fn best_target_skips_empty_tokens() {
+        // Leading comma produces an empty segment that must be skipped.
+        assert_eq!(best_target_encoding(", gzip"), TileCompression::Gzip);
+    }
+
+    #[test]
+    fn negotiate_none_source_identity_refused_falls_through() {
+        let cfg = CompressionConfig::default();
+        // source None + identity;q=0 (refused) + a compressible alternative ->
+        // exercises the `None => {}` fall-through then picks the offered encoding.
+        let raw = incompressible(2048);
+        assert_eq!(
+            negotiate(
+                Some("identity;q=0, br"),
+                TileCompression::None,
+                raw.len(),
+                &cfg
+            ),
+            TileCompression::Brotli
+        );
+    }
+
+    #[test]
+    fn negotiate_wildcard_identity_acceptable_for_tiny_tile() {
+        let cfg = CompressionConfig::default();
+        // `*` makes identity acceptable via its wildcard branch; tiny tile -> None.
+        assert_eq!(
+            negotiate(Some("*"), TileCompression::Gzip, 50, &cfg),
+            TileCompression::Gzip
+        );
+    }
+
+    #[test]
+    fn negotiate_unproducible_and_identity_refused_passes_through_source() {
+        let cfg = CompressionConfig::default();
+        // Client accepts only an unknown encoding and refuses identity ->
+        // nothing we can produce, identity refused -> passthrough to source.
+        let raw = incompressible(2048);
+        assert_eq!(
+            negotiate(
+                Some("identity;q=0, unknowncodec"),
+                TileCompression::Gzip,
+                raw.len(),
+                &cfg
+            ),
+            TileCompression::Gzip
+        );
+    }
+
+    #[test]
     fn negotiate_then_recode_full_flow_to_brotli() {
         let cfg = CompressionConfig::default();
         let raw = incompressible(2048);

--- a/crates/tileserver-rs/src/error.rs
+++ b/crates/tileserver-rs/src/error.rs
@@ -300,6 +300,14 @@ mod tests {
     }
 
     #[test]
+    fn test_compression_error_display_and_status() {
+        let err = TileServerError::CompressionError("brotli encode: oom".to_string());
+        assert_eq!(err.to_string(), "compression error: brotli encode: oom");
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
     fn test_upload_error_status_code() {
         let err = TileServerError::UploadError("bad file".to_string());
         let response = err.into_response();

--- a/crates/tileserver-rs/src/main.rs
+++ b/crates/tileserver-rs/src/main.rs
@@ -1,7 +1,7 @@
 //! Server entry point for tileserver-rs.
 
 use axum::{
-    Router,
+    Router, ServiceExt,
     http::{
         Method,
         header::{ACCEPT, CONTENT_TYPE},
@@ -17,7 +17,10 @@ use axum::{
 use rust_embed::Embed;
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::net::TcpListener;
-use tower_http::{compression::CompressionLayer, cors::CorsLayer};
+use tower::Layer;
+use tower_http::{
+    compression::CompressionLayer, cors::CorsLayer, normalize_path::NormalizePathLayer,
+};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 use utoipa::OpenApi;
 
@@ -252,6 +255,14 @@ async fn main() -> anyhow::Result<()> {
         config.server.extra_response_headers.as_ref(),
     );
 
+    // Normalize trailing slashes before routing so `/_openapi/` matches the
+    // `/_openapi` route (and likewise for /health, /ping, etc.) instead of
+    // 404ing. NormalizePathLayer must wrap the Router from the OUTSIDE: routing
+    // happens before inner `.layer()` middleware, so applying it via
+    // `Router::layer()` would run too late. The resulting `NormalizePath<Router>`
+    // is served via `ServiceExt::into_make_service`.
+    let app = NormalizePathLayer::trim_trailing_slash().layer(router);
+
     let addr: SocketAddr = format!("{}:{}", config.server.host, config.server.port).parse()?;
     tracing::info!("Starting tileserver on http://{}", addr);
 
@@ -328,9 +339,12 @@ async fn main() -> anyhow::Result<()> {
         }
     }
 
-    axum::serve(listener, router)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    axum::serve(
+        listener,
+        ServiceExt::<axum::extract::Request>::into_make_service(app),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await?;
 
     telemetry::shutdown_telemetry();
 

--- a/crates/tileserver-rs/tests/route_data.rs
+++ b/crates/tileserver-rs/tests/route_data.rs
@@ -60,6 +60,37 @@ async fn pmtiles_test_server() -> TestServer {
     TestServer::new(router)
 }
 
+/// Build a [`TestServer`] whose `SourceManager` has the global tile cache
+/// enabled, so the `Accept-Encoding` transcode + cache-store + cache-hit path
+/// in `routes/data.rs` is exercised end-to-end.
+async fn compression_test_server() -> TestServer {
+    use tileserver_rs::cache::TileCache;
+
+    let config = Config::load(Some(PathBuf::from("tests/config.test.toml")))
+        .expect("load tests/config.test.toml");
+
+    let cache = Arc::new(TileCache::new(64, 3600));
+    let sources = SourceManager::from_configs(&config.sources)
+        .await
+        .expect("load tile sources from test config")
+        .with_cache(cache);
+
+    let mut state = common::minimal_app_state();
+    state.sources = Arc::new(sources);
+
+    let meta = common::minimal_meta();
+    let runtime = common::minimal_runtime();
+    let controller = Arc::new(ReloadController::new(
+        state,
+        meta,
+        Config::default(),
+        None,
+        runtime,
+    ));
+    let shared = SharedState::new(controller);
+    TestServer::new(api_router(shared))
+}
+
 // ============================================================
 // Empty-state tests — exercise the "no sources loaded" branches
 // ============================================================
@@ -508,4 +539,72 @@ async fn data_tilejson_mock_source_with_api_key_appended() {
         first.contains("key=secret-xyz"),
         "API key must be appended to tile URLs, got {first}"
     );
+}
+
+// ============================================================
+// Accept-Encoding negotiation (routes/data.rs transcode + cache path)
+// ============================================================
+
+#[tokio::test]
+async fn tile_vary_accept_encoding_header_always_present() {
+    let server = compression_test_server().await;
+    let resp = server.get("/data/protomaps/0/0/0.pbf").await;
+    if resp.status_code().as_u16() == 200 {
+        let vary = resp.headers().get("vary");
+        assert!(
+            vary.is_some_and(|v| v
+                .to_str()
+                .unwrap_or("")
+                .to_ascii_lowercase()
+                .contains("accept-encoding")),
+            "every tile response must carry Vary: Accept-Encoding (CDN poisoning guard)"
+        );
+    }
+}
+
+#[tokio::test]
+async fn tile_brotli_request_transcodes_and_caches() {
+    let server = compression_test_server().await;
+    // Two identical br requests: first transcodes + caches (transcode_miss),
+    // second is served from the encoding-keyed cache (transcode_hit). Both must
+    // succeed and, when content is present, report Content-Encoding: br.
+    for _ in 0..2 {
+        let resp = server
+            .get("/data/protomaps/0/0/0.pbf")
+            .add_header("accept-encoding", "br")
+            .await;
+        let status = resp.status_code().as_u16();
+        assert!(status < 500, "br tile request must not 5xx, got {status}");
+        if status == 200 {
+            let ce = resp
+                .headers()
+                .get("content-encoding")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("");
+            assert!(
+                ce == "br" || ce.is_empty(),
+                "br request returns br (or identity for sub-threshold tiles), got {ce:?}"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn tile_identity_request_does_not_5xx() {
+    let server = compression_test_server().await;
+    let resp = server
+        .get("/data/protomaps/0/0/0.pbf")
+        .add_header("accept-encoding", "identity")
+        .await;
+    assert!(resp.status_code().as_u16() < 500);
+}
+
+#[tokio::test]
+async fn tile_zstd_request_does_not_5xx() {
+    let server = compression_test_server().await;
+    let resp = server
+        .get("/data/protomaps/0/0/0.pbf")
+        .add_header("accept-encoding", "zstd")
+        .await;
+    assert!(resp.status_code().as_u16() < 500);
 }

--- a/crates/tileserver-rs/tests/route_data.rs
+++ b/crates/tileserver-rs/tests/route_data.rs
@@ -608,3 +608,56 @@ async fn tile_zstd_request_does_not_5xx() {
         .await;
     assert!(resp.status_code().as_u16() < 500);
 }
+
+// ============================================================
+// Trailing-slash normalization (main.rs Router::trim_trailing_slash)
+// ============================================================
+
+/// Drive a single GET `path` through the production normalization wiring
+/// (`NormalizePathLayer::trim_trailing_slash` wrapping `api_router`) and return
+/// the response status. `axum_test::TestServer` cannot host a `NormalizePath`
+/// service (no `IntoTransportLayer` impl), so we exercise the layer directly via
+/// `tower::ServiceExt::oneshot` — the same path the production `axum::serve` uses.
+async fn normalized_status(path: &str) -> axum::http::StatusCode {
+    use tower::{Layer, ServiceExt};
+    use tower_http::normalize_path::NormalizePathLayer;
+
+    let shared = SharedState::new(Arc::new(ReloadController::new(
+        common::minimal_app_state(),
+        common::minimal_meta(),
+        Config::default(),
+        None,
+        common::minimal_runtime(),
+    )));
+    let app = NormalizePathLayer::trim_trailing_slash().layer(api_router(shared));
+    let req = axum::http::Request::builder()
+        .uri(path)
+        .body(axum::body::Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    resp.status()
+}
+
+#[tokio::test]
+async fn trailing_slash_on_health_resolves() {
+    assert_eq!(
+        normalized_status("/health/").await,
+        axum::http::StatusCode::OK
+    );
+}
+
+#[tokio::test]
+async fn trailing_slash_on_data_json_resolves() {
+    assert_eq!(
+        normalized_status("/data.json/").await,
+        axum::http::StatusCode::OK
+    );
+}
+
+#[tokio::test]
+async fn no_trailing_slash_still_resolves() {
+    assert_eq!(
+        normalized_status("/health").await,
+        axum::http::StatusCode::OK
+    );
+}


### PR DESCRIPTION
## Summary

Two related follow-ups to the merged brotli/zstd compression PR (#1045):

### 1. `fix:` trailing-slash 404 (`5749c14`)

The marketing "Explore the API" link pointed at `https://demo.tileserver.app/_openapi/` (trailing slash), which **404'd** — Axum routes are registered without a trailing slash and Axum does not normalize by default.

- **`main.rs`** — wrap the served router in tower-http `NormalizePathLayer::trim_trailing_slash()` as the **outermost** layer (routing runs before inner `.layer()` middleware), served via `ServiceExt::into_make_service`. Now `/_openapi/`, `/health/`, `/ping/`, etc. all resolve for **every** client.
- **`Cargo.toml`** — enable tower-http `normalize-path` feature; promote `tower` from dev-dependency to dependency (`Layer`/`ServiceExt` now used at runtime).
- **`ApiSection.vue`** — drop the trailing slash from the marketing link so it hits the canonical URL directly.
- **`route_data.rs`** — regression tests via tower `oneshot` (`/health/`, `/data.json/` resolve; `/health` still works).

### 2. `test:` compression coverage (`05b9d40`)

Closes the patch-coverage gap Codecov flagged on #1045 (91.17% patch, 49 lines). Tests only.

- **`compression.rs`** — Accept-Encoding edge branches: wildcard `*`, empty-token, `identity;q=0` refusal, unproducible-passthrough.
- **`routes/data.rs`** — cache-enabled transcode-miss → store → hit path + `Vary: Accept-Encoding`.
- **`error.rs`** — `CompressionError` display + 500 status.

## Verification

- `cargo fmt --check` ✅ · `clippy --all-features` ✅ · `clippy --no-default-features` ✅
- route_data **43/43** · compression unit **28/28** · error test ✅

## Testing requirements

Follows the project TDD + ≥75% coverage policy. The trailing-slash fix ships with regression tests; the compression tests target the exact lines Codecov reported uncovered on #1045.