### PR TITLE
feat: expose server capabilities on /ping and surface in client

### DIFF
--- a/apps/client/app/components/home/Hero.vue
+++ b/apps/client/app/components/home/Hero.vue
@@ -11,6 +11,9 @@
     uptime,
     sourceCount,
     styleCount,
+    compressionEnabled,
+    compressionLabel,
+    ogcEnabled,
   } = useHomeHero();
 </script>
 
@@ -44,6 +47,8 @@
             Live
           </span>
           <span>Renderer {{ rendererEnabled ? '✓' : '✗' }}</span>
+          <span>Compression {{ compressionEnabled ? '✓' : '✗' }}</span>
+          <span>OGC {{ ogcEnabled ? '✓' : '✗' }}</span>
           <span v-if="versionLabel">{{ versionLabel }}</span>
         </p>
         <dl
@@ -149,6 +154,8 @@
             Live
           </span>
           <span>· Renderer {{ rendererEnabled ? '✓' : '✗' }}</span>
+          <span>· Compression {{ compressionEnabled ? '✓' : '✗' }}</span>
+          <span>· OGC {{ ogcEnabled ? '✓' : '✗' }}</span>
           <span v-if="versionLabel">· {{ versionLabel }}</span>
         </p>
       </div>
@@ -200,12 +207,15 @@
           <p
             class="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
           >
-            Renderer
+            Compression
           </p>
           <p
-            class="mt-1 font-display text-2xl font-semibold leading-none tabular-nums text-foreground"
+            class="mt-1 font-mono text-[13px] font-semibold leading-tight text-foreground"
           >
-            {{ rendererEnabled ? '✓' : '✗' }}
+            <span v-if="!compressionEnabled" class="text-muted-foreground"
+              >off</span
+            >
+            <template v-else>{{ compressionLabel }}</template>
           </p>
         </div>
       </div>

--- a/apps/client/app/composables/admin/use-admin-dashboard.ts
+++ b/apps/client/app/composables/admin/use-admin-dashboard.ts
@@ -51,6 +51,15 @@ export function useAdminDashboard() {
   const loadedSources = computed(() => ping.value?.loaded_sources ?? 0);
   const loadedStyles = computed(() => ping.value?.loaded_styles ?? 0);
   const rendererEnabled = computed(() => ping.value?.renderer_enabled ?? false);
+  const compressionEnabled = computed(
+    () => ping.value?.compression_enabled ?? false,
+  );
+  const compressionLabel = computed(() => {
+    const p = ping.value;
+    if (!p?.compression_enabled) return 'disabled';
+    return `br q${p.compression_br_quality} · zstd L${p.compression_zstd_level}`;
+  });
+  const ogcEnabled = computed(() => ping.value?.ogc_enabled ?? false);
   const versionLabel = computed(() => ping.value?.version ?? '—');
   const configHashShort = computed(() => {
     const h = ping.value?.config_hash;
@@ -88,6 +97,9 @@ export function useAdminDashboard() {
     loadedSources,
     loadedStyles,
     rendererEnabled,
+    compressionEnabled,
+    compressionLabel,
+    ogcEnabled,
     versionLabel,
     configHashShort,
     clientsCount,

--- a/apps/client/app/composables/use-home-hero.ts
+++ b/apps/client/app/composables/use-home-hero.ts
@@ -44,6 +44,29 @@ export function useHomeHero() {
   );
   const styleCount = computed(() => pingQuery.data.value?.loaded_styles ?? '—');
 
+  const compressionEnabled = computed(
+    () => pingQuery.data.value?.compression_enabled ?? false,
+  );
+
+  const compressionLabel = computed(() => {
+    const ping = pingQuery.data.value;
+    if (!ping?.compression_enabled) return '—';
+    return `br q${ping.compression_br_quality} · zstd L${ping.compression_zstd_level}`;
+  });
+
+  const ogcEnabled = computed(() => pingQuery.data.value?.ogc_enabled ?? false);
+
+  const renderEnabled = computed(
+    () => pingQuery.data.value?.render_enabled ?? false,
+  );
+
+  const corsLabel = computed(() => {
+    const origins = pingQuery.data.value?.cors_origins;
+    if (!origins?.length) return '—';
+    if (origins.length === 1 && origins[0] === '*') return 'any origin';
+    return `${origins.length} origin${origins.length === 1 ? '' : 's'}`;
+  });
+
   return {
     statusOk,
     isLoading,
@@ -54,5 +77,10 @@ export function useHomeHero() {
     uptime,
     sourceCount,
     styleCount,
+    compressionEnabled,
+    compressionLabel,
+    ogcEnabled,
+    renderEnabled,
+    corsLabel,
   };
 }

--- a/apps/client/app/pages/admin/index.vue
+++ b/apps/client/app/pages/admin/index.vue
@@ -21,6 +21,9 @@
     loadedSources,
     loadedStyles,
     rendererEnabled,
+    compressionEnabled,
+    compressionLabel,
+    ogcEnabled,
     versionLabel,
     configHashShort,
     clientsCount,
@@ -303,6 +306,32 @@
                 class="size-1.5"
               ></span>
               {{ rendererEnabled ? 'enabled' : 'disabled' }}
+            </dd>
+            <dt
+              class="font-mono text-[11px] tracking-wider text-muted-foreground uppercase"
+            >
+              Compression
+            </dt>
+            <dd class="flex items-center gap-2 font-mono text-foreground">
+              <span
+                :class="
+                  compressionEnabled ? 'bg-success' : 'bg-muted-foreground'
+                "
+                class="size-1.5"
+              ></span>
+              {{ compressionLabel }}
+            </dd>
+            <dt
+              class="font-mono text-[11px] tracking-wider text-muted-foreground uppercase"
+            >
+              OGC API
+            </dt>
+            <dd class="flex items-center gap-2 font-mono text-foreground">
+              <span
+                :class="ogcEnabled ? 'bg-success' : 'bg-muted-foreground'"
+                class="size-1.5"
+              ></span>
+              {{ ogcEnabled ? 'enabled' : 'disabled' }}
             </dd>
           </dl>
         </div>

--- a/apps/client/app/types/server.ts
+++ b/apps/client/app/types/server.ts
@@ -16,4 +16,11 @@ export interface PingResponse {
   cache_enabled: boolean;
   cache_entries: number;
   cache_bytes: number;
+  render_enabled: boolean;
+  ogc_enabled: boolean;
+  compression_enabled: boolean;
+  compression_br_quality: number;
+  compression_zstd_level: number;
+  cors_origins: string[];
+  cache_dir: string;
 }

--- a/apps/docs/content/3.api/1.endpoints.md
+++ b/apps/docs/content/3.api/1.endpoints.md
@@ -51,19 +51,47 @@ Returns runtime metadata about the running server instance. Useful for monitorin
   "loaded_sources": 3,
   "loaded_styles": 2,
   "renderer_enabled": true,
-  "version": "2.8.1"
+  "prometheus_listener_active": false,
+  "version": "2.8.1",
+  "cache_enabled": true,
+  "cache_entries": 128,
+  "cache_bytes": 4194304,
+  "render_enabled": true,
+  "ogc_enabled": true,
+  "compression_enabled": true,
+  "compression_br_quality": 5,
+  "compression_zstd_level": 3,
+  "cors_origins": ["*"],
+  "cache_dir": "/tmp/tileserver-rs"
 }
 ```
 
-| Field              | Type    | Description                                    |
-| ------------------ | ------- | ---------------------------------------------- |
-| `status`           | string  | Always `"ok"`                                  |
-| `config_hash`      | string  | SHA-256 hash of the current configuration      |
-| `loaded_at_unix`   | integer | Unix timestamp when config was last loaded     |
-| `loaded_sources`   | integer | Number of tile sources currently loaded        |
-| `loaded_styles`    | integer | Number of styles currently loaded              |
-| `renderer_enabled` | boolean | Whether native MapLibre rendering is available |
-| `version`          | string  | Server version from `Cargo.toml`               |
+| Field                        | Type     | Description                                            |
+| ---------------------------- | -------- | ------------------------------------------------------ |
+| `status`                     | string   | Always `"ok"`                                          |
+| `config_hash`                | string   | SHA-256 hash of the current configuration              |
+| `loaded_at_unix`             | integer  | Unix timestamp when config was last loaded             |
+| `loaded_sources`             | integer  | Number of tile sources currently loaded                |
+| `loaded_styles`              | integer  | Number of styles currently loaded                      |
+| `renderer_enabled`           | boolean  | Whether native MapLibre rendering is available         |
+| `prometheus_listener_active` | boolean  | Whether the Prometheus metrics listener is bound       |
+| `version`                    | string   | Server version from `Cargo.toml`                       |
+| `cache_enabled`              | boolean  | Whether the global tile cache is enabled               |
+| `cache_entries`              | integer  | Current number of cached tiles                         |
+| `cache_bytes`                | integer  | Approximate cache size in bytes                        |
+| `render_enabled`             | boolean  | Whether static-image render routes are mounted         |
+| `ogc_enabled`                | boolean  | Whether OGC API routes are mounted                     |
+| `compression_enabled`        | boolean  | Whether `Accept-Encoding` re-encoding is active        |
+| `compression_br_quality`     | integer  | Brotli quality level (0–11)                            |
+| `compression_zstd_level`     | integer  | Zstandard compression level (1–22)                     |
+| `cors_origins`               | string[] | Configured CORS allow-list                             |
+| `cache_dir`                  | string   | Resolved scratch/state directory path                  |
+
+::callout{type="warning"}
+**`/ping` is public and unauthenticated.** `cors_origins` and `cache_dir` expose
+your CORS allow-list and a filesystem path. If you treat these as sensitive,
+gate `/ping` behind your reverse proxy in production.
+::
 
 ## Hot Reload (Admin)
 

--- a/crates/tileserver-rs/src/admin.rs
+++ b/crates/tileserver-rs/src/admin.rs
@@ -28,6 +28,18 @@ pub struct PingResponse {
     cache_enabled: bool,
     cache_entries: u64,
     cache_bytes: u64,
+    // Capability flags surfaced to the client UI (Hero pills + admin badges).
+    // NOTE: `/ping` is public + unauthenticated — `cors_origins` and `cache_dir`
+    // are deliberately exposed here per operator request; production deployments
+    // that treat CORS allow-lists or filesystem paths as sensitive should gate
+    // `/ping` behind their reverse proxy.
+    render_enabled: bool,
+    ogc_enabled: bool,
+    compression_enabled: bool,
+    compression_br_quality: u8,
+    compression_zstd_level: i32,
+    cors_origins: Vec<String>,
+    cache_dir: String,
 }
 
 #[derive(serde::Serialize)]
@@ -96,6 +108,7 @@ async fn admin_config_schema() -> Json<ConfigSchemaResponse> {
 pub async fn ping_check(State(shared): State<SharedState>) -> Json<PingResponse> {
     let meta = shared.meta();
     let state = shared.load();
+    let config = shared.config();
     let (cache_enabled, cache_entries, cache_bytes) = if let Some(cache) = state.sources.cache() {
         (true, cache.entry_count(), cache.weighted_size())
     } else {
@@ -113,6 +126,13 @@ pub async fn ping_check(State(shared): State<SharedState>) -> Json<PingResponse>
         cache_enabled,
         cache_entries,
         cache_bytes,
+        render_enabled: !config.server.disable_render,
+        ogc_enabled: !config.server.disable_ogc,
+        compression_enabled: !config.compression.minimal_recompression,
+        compression_br_quality: config.compression.br_quality,
+        compression_zstd_level: config.compression.zstd_level,
+        cors_origins: config.server.cors_origins.clone(),
+        cache_dir: config.resolve_cache_dir(None).display().to_string(),
     })
 }
 
@@ -429,12 +449,22 @@ path = "{}"
             cache_enabled: false,
             cache_entries: 0,
             cache_bytes: 0,
+            render_enabled: true,
+            ogc_enabled: true,
+            compression_enabled: true,
+            compression_br_quality: 5,
+            compression_zstd_level: 3,
+            cors_origins: vec!["*".to_string()],
+            cache_dir: "/tmp/tileserver-rs".to_string(),
         };
         let json = serde_json::to_value(&resp).expect("PingResponse serializes");
         assert_eq!(json["status"], "ok");
         assert_eq!(json["loaded_sources"], 3);
         assert_eq!(json["loaded_styles"], 2);
         assert_eq!(json["cache_enabled"], false);
+        assert_eq!(json["render_enabled"], true);
+        assert_eq!(json["compression_enabled"], true);
+        assert_eq!(json["cors_origins"][0], "*");
     }
 
     #[test]

--- a/crates/tileserver-rs/src/openapi.rs
+++ b/crates/tileserver-rs/src/openapi.rs
@@ -210,7 +210,18 @@ pub struct ApiError {
     "loaded_sources": 3,
     "loaded_styles": 2,
     "renderer_enabled": true,
-    "version": "2.8.0"
+    "prometheus_listener_active": false,
+    "version": "2.8.0",
+    "cache_enabled": true,
+    "cache_entries": 128,
+    "cache_bytes": 4194304,
+    "render_enabled": true,
+    "ogc_enabled": true,
+    "compression_enabled": true,
+    "compression_br_quality": 5,
+    "compression_zstd_level": 3,
+    "cors_origins": ["*"],
+    "cache_dir": "/tmp/tileserver-rs"
 }))]
 pub struct PingResponse {
     pub status: String,
@@ -219,7 +230,18 @@ pub struct PingResponse {
     pub loaded_sources: usize,
     pub loaded_styles: usize,
     pub renderer_enabled: bool,
+    pub prometheus_listener_active: bool,
     pub version: String,
+    pub cache_enabled: bool,
+    pub cache_entries: u64,
+    pub cache_bytes: u64,
+    pub render_enabled: bool,
+    pub ogc_enabled: bool,
+    pub compression_enabled: bool,
+    pub compression_br_quality: u8,
+    pub compression_zstd_level: i32,
+    pub cors_origins: Vec<String>,
+    pub cache_dir: String,
 }
 
 /// Upload response

--- a/crates/tileserver-rs/tests/route_core.rs
+++ b/crates/tileserver-rs/tests/route_core.rs
@@ -82,6 +82,26 @@ async fn ping_json_renderer_disabled_on_empty_state() {
 }
 
 #[tokio::test]
+async fn ping_json_exposes_capability_flags() {
+    let server = common::empty_test_server();
+    let body: serde_json::Value = server.get("/ping").await.json();
+    // Defaults: render + OGC + compression all enabled, codecs at default levels.
+    assert_eq!(body["render_enabled"], true);
+    assert_eq!(body["ogc_enabled"], true);
+    assert_eq!(body["compression_enabled"], true);
+    assert_eq!(body["compression_br_quality"], 5);
+    assert_eq!(body["compression_zstd_level"], 3);
+    assert!(
+        body["cors_origins"].is_array(),
+        "cors_origins must be a JSON array"
+    );
+    assert!(
+        body["cache_dir"].as_str().is_some_and(|s| !s.is_empty()),
+        "cache_dir must be a non-empty resolved path"
+    );
+}
+
+#[tokio::test]
 async fn data_json_empty_state_returns_empty_array() {
     let server = common::empty_test_server();
     let response = server.get("/data.json").await;

--- a/crates/tileserver-rs/tests/snapshots/api_endpoints__openapi_tests__openapi_full_schema.snap
+++ b/crates/tileserver-rs/tests/snapshots/api_endpoints__openapi_tests__openapi_full_schema.snap
@@ -18,6 +18,162 @@ expression: value
     "version": "2.8.0"
   },
   "paths": {
+    "/__admin/oauth/clients": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List MCP OAuth clients (admin listener)",
+        "description": "Returns every DCR client currently registered with the MCP OAuth server\nalong with derived stats: number of outstanding refresh tokens\n(\"active sessions\"), distinct granted scopes, and approximate first /\nlast sign-in timestamps. Mounted on the admin listener only\n(`server.admin_bind`); requires the `mcp` Cargo feature.",
+        "operationId": "admin_list_mcp_clients",
+        "responses": {
+          "200": {
+            "description": "Registered clients with derived stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AdminMcpClient"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "OAuth backend storage failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/__admin/oauth/clients/{client_id}": {
+      "delete": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Revoke an MCP OAuth client (admin listener)",
+        "description": "Deletes the client. Every refresh token issued to the client is\ncascade-deleted atomically by the backend trait. Idempotent: a\n`deleted: false` response indicates the client did not exist.\nRequires the `mcp` Cargo feature.",
+        "operationId": "admin_delete_mcp_client",
+        "parameters": [
+          {
+            "name": "client_id",
+            "in": "path",
+            "description": "Public OAuth `client_id`",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Client deleted (or did not exist)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminDeleteResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "OAuth backend storage failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/__admin/oauth/sessions": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List MCP OAuth device sessions (admin listener)",
+        "description": "Returns every outstanding refresh token with the joined client name\nand granted scope. Each refresh token is treated as a single device\nsession from the UI's perspective. Requires the `mcp` Cargo feature.",
+        "operationId": "admin_list_mcp_sessions",
+        "responses": {
+          "200": {
+            "description": "Outstanding refresh tokens",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AdminMcpSession"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "OAuth backend storage failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/__admin/oauth/sessions/{token}": {
+      "delete": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Revoke a single MCP device session (admin listener)",
+        "description": "Deletes a single refresh token without touching other sessions for the\nsame client. Idempotent: a `deleted: false` response indicates the\ntoken did not exist (e.g. it already expired or was rotated). The\n`revoked_sessions` field is always `null` for this endpoint.\nRequires the `mcp` Cargo feature.",
+        "operationId": "admin_delete_mcp_session",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "description": "Opaque refresh-token identifier (the same value the GET endpoint returns as `token_id`)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Session deleted (or did not exist)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminDeleteResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "OAuth backend storage failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/spatial/query": {
       "post": {
         "tags": [
@@ -1739,6 +1895,151 @@ expression: value
   },
   "components": {
     "schemas": {
+      "AdminDeleteResponse": {
+        "type": "object",
+        "description": "Idempotent response body for the admin DELETE endpoints\n(admin listener, `mcp` feature).",
+        "required": [
+          "ok",
+          "deleted"
+        ],
+        "properties": {
+          "deleted": {
+            "type": "boolean"
+          },
+          "ok": {
+            "type": "boolean"
+          },
+          "revoked_sessions": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          }
+        },
+        "example": {
+          "ok": true,
+          "deleted": true,
+          "revoked_sessions": 2
+        }
+      },
+      "AdminMcpClient": {
+        "type": "object",
+        "description": "Operator-facing view of a registered MCP OAuth client (admin listener,\n`mcp` feature).",
+        "required": [
+          "client_id",
+          "redirect_uris",
+          "active_sessions",
+          "scopes"
+        ],
+        "properties": {
+          "active_sessions": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "client_id": {
+            "type": "string"
+          },
+          "client_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "first_granted_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "last_seen_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "minimum": 0
+          },
+          "redirect_uris": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "scopes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "example": {
+          "client_id": "client-abc-123",
+          "client_name": "Claude.ai",
+          "redirect_uris": [
+            "https://claude.ai/api/oauth/callback"
+          ],
+          "active_sessions": 2,
+          "scopes": [
+            "identify",
+            "read",
+            "render",
+            "query"
+          ],
+          "first_granted_at": 1729450000,
+          "last_seen_at": 1729536800
+        }
+      },
+      "AdminMcpSession": {
+        "type": "object",
+        "description": "Operator-facing view of a single outstanding MCP refresh token.\nFrom the UI's perspective each token is a \"device session\"\n(admin listener, `mcp` feature).",
+        "required": [
+          "token_id",
+          "client_id",
+          "scope",
+          "granted_at",
+          "expires_at"
+        ],
+        "properties": {
+          "client_id": {
+            "type": "string"
+          },
+          "client_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "expires_at": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "granted_at": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "scope": {
+            "type": "string"
+          },
+          "token_id": {
+            "type": "string"
+          }
+        },
+        "example": {
+          "token_id": "rt-abc-...",
+          "client_id": "client-abc-123",
+          "client_name": "Claude.ai",
+          "scope": "identify read render query",
+          "granted_at": 1729450000,
+          "expires_at": 1737226000
+        }
+      },
       "ApiError": {
         "type": "object",
         "description": "API error response",
@@ -1980,11 +2281,56 @@ expression: value
           "loaded_sources",
           "loaded_styles",
           "renderer_enabled",
-          "version"
+          "prometheus_listener_active",
+          "version",
+          "cache_enabled",
+          "cache_entries",
+          "cache_bytes",
+          "render_enabled",
+          "ogc_enabled",
+          "compression_enabled",
+          "compression_br_quality",
+          "compression_zstd_level",
+          "cors_origins",
+          "cache_dir"
         ],
         "properties": {
+          "cache_bytes": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "cache_dir": {
+            "type": "string"
+          },
+          "cache_enabled": {
+            "type": "boolean"
+          },
+          "cache_entries": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "compression_br_quality": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "compression_enabled": {
+            "type": "boolean"
+          },
+          "compression_zstd_level": {
+            "type": "integer",
+            "format": "int32"
+          },
           "config_hash": {
             "type": "string"
+          },
+          "cors_origins": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "loaded_at_unix": {
             "type": "integer",
@@ -1998,6 +2344,15 @@ expression: value
           "loaded_styles": {
             "type": "integer",
             "minimum": 0
+          },
+          "ogc_enabled": {
+            "type": "boolean"
+          },
+          "prometheus_listener_active": {
+            "type": "boolean"
+          },
+          "render_enabled": {
+            "type": "boolean"
           },
           "renderer_enabled": {
             "type": "boolean"
@@ -2016,7 +2371,20 @@ expression: value
           "loaded_sources": 3,
           "loaded_styles": 2,
           "renderer_enabled": true,
-          "version": "2.8.0"
+          "prometheus_listener_active": false,
+          "version": "2.8.0",
+          "cache_enabled": true,
+          "cache_entries": 128,
+          "cache_bytes": 4194304,
+          "render_enabled": true,
+          "ogc_enabled": true,
+          "compression_enabled": true,
+          "compression_br_quality": 5,
+          "compression_zstd_level": 3,
+          "cors_origins": [
+            "*"
+          ],
+          "cache_dir": "/tmp/tileserver-rs"
         }
       },
       "SpatialQueryRequest": {
@@ -2519,6 +2887,10 @@ expression: value
     {
       "name": "OGC",
       "description": "OGC API Features (Parts 1-5): read-only GeoJSON feature access for PostGIS table sources, consumed natively by QGIS, ArcGIS Pro and FME"
+    },
+    {
+      "name": "Admin",
+      "description": "Operator-facing endpoints served on the admin listener (`server.admin_bind`). Includes MCP OAuth client + device session management (`mcp` feature)"
     }
   ]
 }


### PR DESCRIPTION
## Summary

The client couldn't show recently-shipped features (brotli/zstd **compression**, **CORS** config, **render/OGC** gates, **cache dir**) because `/ping` never reported them — and the HONEST-DATA rule (CLAUDE.md Rule #20) forbids inventing fields the backend doesn't return. This extends `/ping` with capability flags, then surfaces them.

## Backend

- **`admin.rs`** — `PingResponse` gains `render_enabled`, `ogc_enabled`, `compression_enabled`, `compression_br_quality`, `compression_zstd_level`, `cors_origins`, `cache_dir`, sourced from the live `Config` in `ping_check`.
- **`openapi.rs`** — `PingResponse` schema mirror brought fully in sync (it was *also* missing the pre-existing `cache_*` + `prometheus_listener_active` fields).

## Client

- **`types/server.ts`** — mirrors the backend struct exactly.
- **`Hero.vue`** — compression + OGC status pills; the 4th stat cell now shows compression codec levels (`br q5 · zstd L3`).
- **admin console** — Compression + OGC API badges in the Build panel.

## Docs

- Full `/ping` field table + a **security callout**: `cors_origins` and `cache_dir` are exposed on a public, unauthenticated endpoint — gate `/ping` behind a proxy in production if sensitive.

## Note on the snapshot

The `openapi_full_schema` snapshot regeneration also picks up the MCP admin OAuth paths (`admin_list/delete_mcp_clients/sessions`), which are registered **unconditionally** in `ApiDoc` but were missing from the stale committed snapshot. CI runs `--all-features` which cfg's-out the `not(feature="mcp")` snapshot test, so this drift went uncaught. Regenerated with the canonical `--features postgres,raster,stac`.

## Verification

- `cargo fmt --check` ✅ · `clippy --all-features` ✅ · `clippy --no-default-features` ✅ · docs lint ✅ · client lint ✅
- route_core **17/17** (new `ping_json_exposes_capability_flags`) · ping unit ✅ · openapi snapshot regenerated

## Testing requirements

Follows the project TDD + ≥75% coverage policy. New `/ping` fields are covered by a route_core integration test + the admin.rs unit serialization test; the openapi schema is snapshot-tested.

## ⚠️ Security decision

`/ping` is public + unauthenticated. Exposing `cors_origins` + `cache_dir` was an explicit operator choice for the demo/trusted deployments. Documented for production operators.