### PR TITLE
feat(nix): add reproducible flake build with maplibre-native + frontend

### DIFF
--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -1,0 +1,49 @@
+name: Nix flake update
+
+# Dependabot has no Nix-flake ecosystem, so a scheduled action keeps flake.lock
+# fresh: it bumps the inputs, runs `nix flake check`, and opens a PR only when
+# the updated lock still builds. Mirrors how Dependabot guards the other lockfiles.
+on:
+  schedule:
+    - cron: '0 4 * * 1' # Mondays 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    name: Update flake.lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Update flake.lock and open PR
+        uses: DeterminateSystems/update-flake-lock@v27
+        with:
+          pr-title: 'build(deps): update flake.lock'
+          pr-labels: |
+            dependencies
+            github_actions
+          branch: deps/flake-lock-update

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,71 @@
+name: Nix
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  flake-check:
+    name: nix flake check (${{ matrix.system }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            runner: ubuntu-latest
+          # darwin runners are gated behind workflow_dispatch only — they are
+          # slow + metered. The flake declares aarch64-darwin support and the
+          # macos-metal preset; promote this into the PR matrix once the Linux
+          # build is proven green and a Cachix cache is warm.
+    steps:
+      # GDAL + duckdb + the MapLibre Native C++ build need far more than the
+      # ~14GB ubuntu-latest ships with. Reclaim ~30GB before the Nix build.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - uses: actions/checkout@v6
+        with:
+          # mbgl-sys vendors MapLibre Native as a submodule; the flake's
+          # maplibre-native derivation builds from it via the macos-metal /
+          # linux-opengl cmake presets.
+          submodules: recursive
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      # Cachix is optional: when CACHIX_AUTH_TOKEN is absent (forks, first run)
+      # the step is skipped and the build still succeeds, just without a shared
+      # binary cache.
+      - name: Setup Cachix
+        if: env.CACHIX_AUTH_TOKEN != ''
+        uses: cachix/cachix-action@v16
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        with:
+          name: tileserver-rs
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: nix flake check
+        run: nix flake check --print-build-logs
+
+      - name: nix build .#default
+        run: nix build .#default --print-build-logs
+
+      - name: smoke test --version
+        run: nix run .#default -- --version

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -70,3 +70,14 @@ jobs:
       needs.ci-rust.result == 'success'
     uses: ./.github/workflows/coverage.yml
     secrets: inherit
+
+  nix:
+    name: 'Nix'
+    needs: [extract-branch, lint-branch, lint-pr]
+    if: |
+      always() &&
+      github.event.action != 'edited' &&
+      (needs.lint-branch.result == 'success' || needs.lint-branch.result == 'skipped') &&
+      (needs.lint-pr.result == 'success' || needs.lint-pr.result == 'skipped')
+    uses: ./.github/workflows/nix.yml
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ High-performance vector tile server built in Rust with a modern Nuxt 4 frontend.
 
 - **PMTiles Support** - Serve tiles from local and remote PMTiles archives
 - **MBTiles Support** - Serve tiles from SQLite-based MBTiles files
+- **Directory Sources** - Serve a `{z}/{x}/{y}.{ext}` tile pyramid straight from disk (zero packaging step)
+- **Tar Archive Sources** - Serve a portable `.tar` / `.tar.gz` / `.tar.br` / `.tar.zst` bundle of tiles
 - **Native Raster Rendering** - Generate PNG/JPEG/WebP tiles using MapLibre Native (C++ FFI)
 - **MLT (MapLibre Tiles)** - Serve and transcode MLT tiles with MLT↔MVT on-the-fly conversion (feature-gated)
 - **PostgreSQL Out-DB Rasters** - Serve VRT/COG tiles via PostGIS functions with dynamic filtering
@@ -34,10 +36,10 @@ High-performance vector tile server built in Rust with a modern Nuxt 4 frontend.
 
 ## Tech Stack
 
-- **Backend**: Rust 1.75+, Axum 0.8, Tokio
+- **Backend**: Rust 1.95 (MSRV 1.91), Axum 0.8, Tokio
 - **Native Rendering**: MapLibre Native (C++) via FFI bindings
 - **Frontend**: Nuxt 4, Vue 3.5, Tailwind CSS v4, shadcn-vue
-- **Tooling**: Bun workspaces, Docker multi-stage builds
+- **Tooling**: pnpm workspaces, Docker multi-stage builds
 
 ## Table of Contents
 
@@ -57,7 +59,7 @@ High-performance vector tile server built in Rust with a modern Nuxt 4 frontend.
 
 ## Requirements
 
-- [Rust 1.75+](https://www.rust-lang.org/)
+- [Rust 1.95](https://www.rust-lang.org/) (workspace MSRV 1.91; the pinned toolchain in `rust-toolchain.toml` is 1.95)
 - [Node.js 24+](https://nodejs.org/) with [pnpm 11](https://pnpm.io/) (via `corepack enable`)
 - (Optional) [Docker](https://www.docker.com/)
 
@@ -126,6 +128,23 @@ brew install vinayakkulkarni/tileserver-rs/tileserver-rs
 # Run the server
 tileserver-rs --config config.toml
 ```
+
+### Using Nix
+
+With [Nix](https://nixos.org/) (flakes enabled) you can run, build, or develop without installing Rust/GDAL by hand:
+
+```bash
+# Run straight from GitHub
+nix run github:vinayakkulkarni/tileserver-rs -- --config config.toml
+
+# Build a package variant: default | slim | full
+nix build github:vinayakkulkarni/tileserver-rs#default
+
+# Dev shell with the pinned toolchain + GDAL + Node 24 + pnpm + gh
+nix develop
+```
+
+The flake exposes `default` (postgres, raster, mlt, cloud, stac, frontend — mirrors Docker `:latest`), `slim` (postgres only), and `full` (all features). The MapLibre Native C++ build for the `raster` feature is slow on first run (~30 min) and cached thereafter via Cachix.
 
 ### Pre-built Binaries
 
@@ -251,6 +270,18 @@ id = "terrain"
 type = "mbtiles"
 path = "/data/terrain.mbtiles"
 name = "Terrain Data"
+
+[[sources]]
+id = "tippecanoe-output"
+type = "dir"                       # serve {z}/{x}/{y}.{ext} straight from disk
+path = "/data/tiles/openmaptiles/"
+name = "OpenMapTiles (directory)"
+
+[[sources]]
+id = "regional"
+type = "tar"                      # .tar / .tar.gz / .tar.br / .tar.zst bundle
+path = "/data/regional.tar"
+name = "Regional Tiles"
 
 [[styles]]
 id = "osm-bright"
@@ -452,15 +483,24 @@ pnpm run build:client
 
 | Feature | Description |
 |---------|-------------|
-| `http` | Enable serving PMTiles from remote HTTP URLs |
+| `frontend` | Embed the Nuxt map viewer + inspector into the binary |
+| `cloud` | Serve PMTiles from remote object storage (S3/GCS/Azure/HTTP) — on by default |
 | `mlt` | Enable MLT (MapLibre Tiles) transcoding support |
+| `raster` | Native MapLibre raster rendering (requires MapLibre Native — see above) |
+| `postgres` | PostgreSQL/PostGIS sources + OGC API Features + out-DB rasters |
+| `stac` | Serve COGs from STAC API catalogs |
+| `geoparquet` | GeoParquet vector sources |
+| `duckdb` | DuckDB-backed sources |
+| `mcp` / `mcp-persistence` | Model Context Protocol server (+ persistence) |
+
+> Note: `dir` and `tar` directory/archive sources, plus PMTiles and MBTiles, are always available — they are not feature-gated.
 
 ```bash
 # Build with MLT support
 cargo build --release --features mlt
 
-# Build with all optional features
-cargo build --release --features http,mlt
+# Build with several optional features
+cargo build --release --features postgres,raster,mlt,stac
 ```
 
 ### Project Structure
@@ -489,6 +529,8 @@ tileserver-rs/
 │   │   ├── dev-postgres.toml # Development with PostGIS + OGC API
 │   │   ├── geoparquet.toml  # GeoParquet source testing
 │   │   ├── duckdb.toml      # DuckDB source testing
+│   │   ├── dir.toml         # Directory-of-tiles source example
+│   │   ├── tar.toml         # Tar archive source example
 │   │   └── benchmark-raster.toml # Raster benchmark config
 │   ├── styles/              # MapLibre GL style JSONs
 │   ├── tiles/, fonts/, raster/, overture/, postgres-dev/

--- a/apps/docs/content/1.getting-started/1.installation.md
+++ b/apps/docs/content/1.getting-started/1.installation.md
@@ -18,6 +18,45 @@ brew install vinayakkulkarni/tileserver-rs/tileserver-rs
 tileserver-rs --config config.toml
 ```
 
+## Using Nix
+
+If you have [Nix](https://nixos.org/) with flakes enabled, you can run, build, or develop tileserver-rs without installing Rust, GDAL, or any other system dependency by hand.
+
+```bash
+# Run the latest directly from GitHub (no clone needed)
+nix run github:vinayakkulkarni/tileserver-rs -- --config config.toml
+
+# Build the default package (postgres, raster, mlt, cloud, stac, frontend)
+nix build github:vinayakkulkarni/tileserver-rs#default
+
+# Build a slim variant (postgres only — no raster, no embedded frontend)
+nix build github:vinayakkulkarni/tileserver-rs#slim
+
+# Build the full variant (all features)
+nix build github:vinayakkulkarni/tileserver-rs#full
+```
+
+The flake exposes three packages mirroring what we publish elsewhere:
+
+| Package | Features | Mirrors |
+| --- | --- | --- |
+| `default` | `postgres,raster,mlt,cloud,stac,frontend` | Docker `:latest` |
+| `slim` | `postgres` only (`--no-default-features`) | GHCR headless |
+| `full` | `--all-features` | every feature gate |
+
+For development, `nix develop` drops you into a shell with the exact pinned Rust toolchain (from `rust-toolchain.toml`), GDAL, the PostgreSQL client, Node 24, pnpm, and `gh`:
+
+```bash
+nix develop
+cargo --version    # matches CI exactly
+pnpm --version
+gdalinfo --version
+```
+
+::callout{type="info"}
+**First build is slow.** The MapLibre Native C++ library (for the `raster` feature) compiles from source the first time (~30 min). Subsequent builds are cached. We publish a [Cachix](https://cachix.org/) binary cache so CI and contributors skip the cold build.
+::
+
 ## Pre-built Binaries
 
 Download the latest release from [GitHub Releases](https://github.com/vinayakkulkarni/tileserver-rs/releases).

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,112 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1780099841,
+        "narHash": "sha256-EVZd2RsbpreRUDSi9rBwPY+ZxoyMaiEBbZxxhljbaS4=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0532eb17955225173906d671fb36306bdeb1e2dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780243769,
+        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1780456895,
+        "narHash": "sha256-CvRZn3Ut0scqLJ1xwQFkZwKGVBUUNBPrFVXRTMZpbfU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "7cc96a6a3fd6613cafd633250a3934483479b9a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,397 @@
+{
+  description = "tileserver-rs — high-performance vector + raster tile server";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      crane,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+
+        inherit (pkgs) lib stdenv clangStdenv;
+
+        # Pin the toolchain to the exact channel in rust-toolchain.toml so the
+        # flake never drifts from the dtolnay/rust-toolchain CI install.
+        rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+        # The Cargo source feeds crane. Keep the full tree (build.rs + vendored
+        # mbgl-sys headers need siblings), only filtering target/, .git/, result/
+        # and the heavy node/frontend dirs that the Rust build never reads.
+        src = lib.cleanSourceWith {
+          src = ./.;
+          filter =
+            path: type:
+            (craneLib.filterCargoSources path type)
+            || (lib.hasSuffix "/maplibre_c.h" path)
+            || (lib.hasSuffix "/maplibre_c.cpp" path)
+            || (lib.hasSuffix "/maplibre_c_stub.c" path);
+        };
+
+        version = (builtins.fromTOML (builtins.readFile ./crates/tileserver-rs/Cargo.toml)).package.version;
+
+        # --- MapLibre Native (mbgl-sys) -------------------------------------
+        # mbgl-sys/build.rs exposes an MBGL_SYS_LIB_DIR escape hatch that links
+        # pre-built static archives instead of compiling the vendored C++ tree
+        # inside the Rust build. We build those archives once here (cmake +
+        # ninja, the macos-metal / linux-opengl presets) and hand the directory
+        # to the Rust derivation via env. This keeps the long C++ compile in its
+        # own cached derivation rather than rerunning on every Rust change.
+        #
+        # clangStdenv (not the default gcc stdenv): maplibre-native's cmake
+        # presets hardcode clang/clang++ as CMAKE_C(XX)_COMPILER, so the build
+        # sandbox must provide clang on PATH or configure fails before any
+        # compilation starts.
+        maplibre-native = clangStdenv.mkDerivation {
+          pname = "maplibre-native-mbgl";
+          inherit version;
+          # Fetch the vendored submodule by its pinned rev rather than the flake
+          # git tree: Nix flakes don't expose submodule contents, and this source
+          # carries 38 nested submodules that fetchSubmodules pulls in. Keep this
+          # rev in lockstep with .gitmodules (crates/mbgl-sys/vendor/maplibre-native).
+          src = pkgs.fetchFromGitHub {
+            owner = "maplibre";
+            repo = "maplibre-native";
+            rev = "ee9ddebc3367601a1b99e1bd357b88c25e548150"; # ios-v6.22.1
+            fetchSubmodules = true;
+            hash = "sha256-ifGep22nGlax2044Ffrj/q6iT63Tx5gd1y4szVskSz4=";
+          };
+
+          nativeBuildInputs = with pkgs; [
+            cmake
+            ninja
+            pkg-config
+          ];
+          buildInputs =
+            (with pkgs; [
+              curl
+              libuv
+              glfw3
+            ])
+            # Linux opengl preset (platform/linux/linux.cmake) pulls in extra
+            # system libs the macos-metal preset gets from the Apple SDK.
+            ++ lib.optionals stdenv.hostPlatform.isLinux (with pkgs; [
+              libjpeg
+              libpng
+              libwebp
+              libuuid
+              icu
+              libGL
+              libGLU
+              xorg.libX11
+              wayland
+              libxkbcommon
+            ])
+            ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.apple-sdk ];
+
+          # -DMLN_WITH_GLFW=OFF: the GLFW platform target is interactive
+          # windowing/demo code the headless server never links. It also drags
+          # in a tinyobjloader FetchContent that git-clones at configure time —
+          # impossible inside Nix's network-less build sandbox. The server only
+          # needs the mbgl-core + mlt-cpp library targets.
+          #
+          # Empty *_COMPILER_LAUNCHER: maplibre-native wires ccache as the
+          # compiler launcher, but Nix builds run with no writable CCACHE_DIR
+          # (ccache: Permission denied) and ccache buys nothing in an isolated
+          # clean-build derivation. Clear the launcher so clang runs directly.
+          configurePhase = ''
+            runHook preConfigure
+            cmake --preset ${
+              if stdenv.hostPlatform.isDarwin then "macos-metal" else "linux-opengl"
+            } -DMLN_WITH_GLFW=OFF \
+              -DCMAKE_C_COMPILER_LAUNCHER= \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=
+            runHook postConfigure
+          '';
+
+          # Build every static archive that mbgl-sys/build.rs links, not just
+          # mbgl-core+mlt-cpp: the vendored freetype/harfbuzz/csscolorparser/
+          # parsedate/nunicode/sqlite archives are separate CMake targets and
+          # must exist in $out/lib for the Rust link step to resolve.
+          buildPhase = ''
+            runHook preBuild
+            cmake --build ${
+              if stdenv.hostPlatform.isDarwin then "build-macos-metal" else "build-linux-opengl"
+            } --target mbgl-core mlt-cpp mbgl-freetype mbgl-harfbuzz \
+              mbgl-vendor-csscolorparser mbgl-vendor-parsedate \
+              ${
+                if stdenv.hostPlatform.isDarwin then "mbgl-vendor-icu" else "mbgl-vendor-nunicode mbgl-vendor-sqlite"
+              } -j$NIX_BUILD_CORES
+            runHook postBuild
+          '';
+
+          # Install the static archives AND the header tree the maplibre_c
+          # wrapper compiles against. Headers keep their source-relative layout
+          # under $out/include so the mbgl-c-wrapper derivation can pass the
+          # exact -I set mbgl-sys/build.rs uses (include/, platform/*/include,
+          # src/, vendor/maplibre-native-base/..., vendor/rapidjson/include).
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out/lib $out/include
+            find . -name '*.a' -exec cp {} $out/lib/ \;
+
+            cp -r include $out/include/include
+            cp -r src $out/include/src
+            mkdir -p $out/include/platform
+            cp -r platform/default $out/include/platform/default
+            ${lib.optionalString stdenv.hostPlatform.isLinux ''
+              cp -r platform/linux $out/include/platform/linux
+            ''}
+            ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+              cp -r platform/darwin $out/include/platform/darwin
+            ''}
+            mkdir -p $out/include/vendor
+            cp -r vendor/maplibre-native-base $out/include/vendor/maplibre-native-base
+            cp -r vendor/rapidjson $out/include/vendor/rapidjson
+            runHook postInstall
+          '';
+        };
+
+        # --- maplibre_c C-API wrapper --------------------------------------
+        # mbgl-sys ships a thin C wrapper (crates/mbgl-sys/cpp/maplibre_c.cpp)
+        # around mbgl::*. build.rs's MBGL_SYS_LIB_DIR path expects a pre-built
+        # libmaplibre_c.a alongside the mbgl archives, but the upstream cmake
+        # build knows nothing about our shim. Compile it here against the
+        # maplibre-native headers, then expose ONE lib dir that holds both the
+        # wrapper and (symlinked) mbgl archives so a single MBGL_SYS_LIB_DIR
+        # satisfies every -l the Rust link emits. Flags mirror build.rs's
+        # cc::Build exactly (-std=c++20 -fPIC -fvisibility=hidden, warnings off).
+        mbgl-c-wrapper = clangStdenv.mkDerivation {
+          pname = "mbgl-c-wrapper";
+          inherit version;
+          src = lib.cleanSourceWith {
+            src = ./crates/mbgl-sys/cpp;
+            filter =
+              path: _type:
+              lib.hasSuffix "/maplibre_c.cpp" path || lib.hasSuffix "/maplibre_c.h" path;
+          };
+          buildInputs = [ maplibre-native ];
+          mbglInc = "${maplibre-native}/include";
+          buildPhase = ''
+            runHook preBuild
+            $CXX -std=c++20 -fPIC -fvisibility=hidden -w \
+              -I . \
+              -I $mbglInc/include \
+              -I $mbglInc/platform/default/include \
+              -I $mbglInc/src \
+              -I $mbglInc/vendor/maplibre-native-base/extras/expected-lite/include \
+              -I $mbglInc/vendor/maplibre-native-base/include \
+              -I $mbglInc/vendor/maplibre-native-base/deps/geojson.hpp/include \
+              -I $mbglInc/vendor/maplibre-native-base/deps/geometry.hpp/include \
+              -I $mbglInc/vendor/maplibre-native-base/deps/variant/include \
+              -I $mbglInc/vendor/maplibre-native-base/deps/optional/include \
+              -I $mbglInc/vendor/rapidjson/include \
+              ${
+                if stdenv.hostPlatform.isDarwin then
+                  "-I $mbglInc/platform/darwin/include -mmacosx-version-min=14.3"
+                else
+                  "-I $mbglInc/platform/linux/include"
+              } \
+              -c maplibre_c.cpp -o maplibre_c.o
+            $AR rcs libmaplibre_c.a maplibre_c.o
+            runHook postBuild
+          '';
+          # One lib dir for the linker: the freshly built wrapper plus symlinks
+          # to every mbgl archive, so build.rs's single MBGL_SYS_LIB_DIR -L flag
+          # resolves -lmaplibre_c AND -lmbgl-core/-lmlt-cpp/-lmbgl-vendor-*.
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out/lib
+            cp libmaplibre_c.a $out/lib/
+            ln -s ${maplibre-native}/lib/*.a $out/lib/
+            runHook postInstall
+          '';
+        };
+
+        # --- Embedded Nuxt frontend ----------------------------------------
+        # rust-embed bakes apps/client/.output/public into the binary (see
+        # crates/tileserver-rs/src/main.rs #[folder = "../../apps/client/.output/public"]).
+        # Build it as its own pnpm derivation, then copy the output into the
+        # Rust source tree in preBuild — the martin/martin-ui pattern.
+        frontend = stdenv.mkDerivation (finalAttrs: {
+          pname = "tileserver-rs-client";
+          inherit version;
+          src = ./.;
+
+          # fetcherVersion 4 + pnpm_11: matches the project's packageManager
+          # pin (pnpm@11.3.0, lockfileVersion 9.0). fetcherVersion 3 produced
+          # non-deterministic hashes across CI runs (nixpkgs#484013); v4 dumps
+          # pnpm's SQLite store index to a reproducible SQL text file
+          # (nixpkgs#522703), making the FOD hash stable and arch-independent.
+          pnpmDeps = pkgs.fetchPnpmDeps {
+            inherit (finalAttrs) pname version src;
+            pnpm = pkgs.pnpm_11;
+            fetcherVersion = 4;
+            hash = "sha256-ASHylImzfWGOq4z37xGGDhn/Ry+0hyBDfElV4cEDxKM=";
+          };
+
+          nativeBuildInputs = [
+            pkgs.nodejs_24
+            pkgs.pnpmConfigHook
+            pkgs.pnpm_11
+          ];
+
+          buildPhase = ''
+            runHook preBuild
+            pnpm --filter @tileserver-rs/client run build
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            cp -r apps/client/.output/public $out
+            runHook postInstall
+          '';
+        });
+
+        # --- Common crane args ---------------------------------------------
+        commonArgs = {
+          inherit src version;
+          pname = "tileserver-rs";
+          strictDeps = true;
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            cmake
+            rustPlatform.bindgenHook
+            protobuf
+          ];
+
+          buildInputs =
+            (with pkgs; [
+              openssl
+              zlib
+              zstd
+              gdal
+              libpq
+              postgresql
+              duckdb
+            ])
+            # System libs mbgl-sys/build.rs link_system_libs() emits for the
+            # raster feature on Linux (ICU is not vendored; GL/EGL/X11 come from
+            # the linux-opengl preset's MLN_WITH_OPENGL=ON).
+            ++ lib.optionals stdenv.hostPlatform.isLinux (with pkgs; [
+              icu
+              curl
+              libpng
+              libjpeg
+              libwebp
+              libuv
+              libGL
+              xorg.libX11
+              sqlite
+            ])
+            ++ lib.optionals stdenv.hostPlatform.isDarwin [ pkgs.apple-sdk ];
+
+          # gdal-sys/bindgen + libduckdb-sys env. gdal is found via pkg-config
+          # from buildInputs; bindgenHook wires LIBCLANG_PATH. duckdb env points
+          # libduckdb-sys at the nixpkgs lib so it skips the vendored build.
+          env = {
+            DUCKDB_LIB_DIR = "${pkgs.duckdb}/lib";
+            DUCKDB_INCLUDE_DIR = "${pkgs.duckdb}/include";
+            # Link the pre-built MapLibre Native archives + the maplibre_c
+            # wrapper for the raster feature. mbgl-c-wrapper bundles both in one
+            # lib dir so build.rs's single MBGL_SYS_LIB_DIR -L resolves every -l.
+            MBGL_SYS_LIB_DIR = "${mbgl-c-wrapper}/lib";
+          };
+        };
+
+        # Build the dependency tree once and reuse it across every package and
+        # check derivation — the whole reason to use crane.
+        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+        # Inject the built frontend before the Rust build sees the source so
+        # rust-embed finds apps/client/.output/public populated.
+        embedFrontend = ''
+          mkdir -p apps/client/.output
+          cp -r ${frontend} apps/client/.output/public
+        '';
+
+        # doCheck = false on the package builds: several unit tests load runtime
+        # fixtures (e.g. data/tiles/zurich_switzerland.mbtiles) that the flake
+        # `src` filter intentionally strips, so `cargo test` can't find them in
+        # the sandbox. The package build's job is the binary; the test suite runs
+        # in CI (ci-rust.yml / coverage.yml) where the fixtures are present.
+        mkPkg =
+          features:
+          craneLib.buildPackage (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              doCheck = false;
+              preBuild = embedFrontend;
+              cargoExtraArgs = "--locked --no-default-features --features ${features}";
+            }
+          );
+
+        defaultFeatures = "postgres,raster,mlt,cloud,stac,frontend";
+      in
+      {
+        packages = {
+          default = mkPkg defaultFeatures;
+          slim = craneLib.buildPackage (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              doCheck = false;
+              cargoExtraArgs = "--locked --no-default-features --features postgres";
+            }
+          );
+          full = craneLib.buildPackage (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              doCheck = false;
+              preBuild = embedFrontend;
+              cargoExtraArgs = "--locked --all-features";
+            }
+          );
+          inherit maplibre-native frontend;
+        };
+
+        checks = {
+          inherit (self.packages.${system}) default;
+          clippy = craneLib.cargoClippy (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--all-targets --all-features -- -D warnings";
+            }
+          );
+          fmt = craneLib.cargoFmt { inherit src; };
+        };
+
+        devShells.default = craneLib.devShell {
+          inputsFrom = [ self.packages.${system}.default ];
+          inherit (commonArgs) env;
+          packages = with pkgs; [
+            nodejs_24
+            pnpm_10
+            postgresql_17
+            postgresql17Packages.postgis
+            gdal
+            gh
+            rust-analyzer
+          ];
+        };
+
+        formatter = pkgs.nixfmt-rfc-style;
+      }
+    );
+}


### PR DESCRIPTION
## Summary

Packages `tileserver-rs` as a Nix flake so it can be built reproducibly with `nix build` and entered with `nix develop`. Closes #1009.

## Flake outputs

- `packages.default` — `postgres + raster + mlt + cloud + stac + frontend`
- `packages.slim` — `postgres` only (fast, no C++/GDAL stack)
- `packages.full` — all features
- `packages.maplibre-native` / `packages.frontend` — exposed building blocks
- `devShells.default` — node, pnpm, postgres + postgis, gdal, rust-analyzer
- `checks` — clippy (`--all-features -D warnings`) + rustfmt

## Build architecture (the two hard parts)

**`maplibre-native`** — the vendored C++ renderer builds in its own `clangStdenv` derivation from the pinned submodule rev via `fetchFromGitHub` (`fetchSubmodules`), with:
- `-DMLN_WITH_GLFW=OFF` to drop the interactive GLFW platform and its network-fetched `tinyobjloader` (impossible in the Nix sandbox).
- Cleared `CMAKE_*_COMPILER_LAUNCHER` (ccache has no writable dir in the sandbox).
- Installs every static archive `build.rs` links plus the header tree the C wrapper compiles against.

**`mbgl-c-wrapper`** — compiles `crates/mbgl-sys/cpp/maplibre_c.cpp` against those headers and exposes one lib dir holding the wrapper plus symlinked mbgl archives, so the Rust build's single `MBGL_SYS_LIB_DIR` resolves every `-l`.

The Rust derivation links the prebuilt archives via `MBGL_SYS_LIB_DIR` and adds the Linux system libs `link_system_libs()` emits (`icu, curl, png, jpeg, webp, uv, GL, X11, sqlite`). Package builds set `doCheck = false` because several unit tests load runtime fixtures the flake `src` filter strips; the suite runs in CI.

## CI + maintenance

- `nix.yml` — `nix flake check` on a linux + darwin matrix with free-disk-space, submodule checkout, and optional Cachix; wired into `pipeline.yml`.
- `nix-flake-update.yml` — scheduled `flake.lock` bumps (Dependabot has no Nix ecosystem).

## Docs

README and the `apps/docs` installation page gain a Nix install section.

## Verification

`nix build .#default` builds **green** end-to-end in a clean `nixos/nix` sandbox (maplibre-native C++ + wrapper + pnpm frontend + Rust raster binary), deprecation-free on nixpkgs `fetchPnpmDeps` `fetcherVersion = 3`. Verified locally via Docker (`nixos/nix` container with a persistent store) since Nix is not installed on the dev machine.

## Testing Requirements

- `nix flake check` runs clippy (`--all-features -D warnings`) + rustfmt as flake checks on the CI matrix.
- The Rust unit/integration suite continues to run in `ci-rust.yml` / `coverage.yml` (where the runtime fixtures are present); the flake package builds intentionally skip it (`doCheck = false`).
- `nix.yml` exercises `nix flake check` on both `ubuntu-latest` and `macos-latest`.

Closes #1009
