### PR TITLE
fix(transcode): drop redundant to_vec in mvt_to_feature_collection call

### DIFF
--- a/crates/tileserver-rs/src/transcode.rs
+++ b/crates/tileserver-rs/src/transcode.rs
@@ -197,7 +197,7 @@ fn mvt_to_mlt(mvt_bytes: &[u8]) -> Result<Bytes> {
 
     use mlt_core::encoder::EncoderConfig;
 
-    let fc = mlt_core::mvt::mvt_to_feature_collection(mvt_bytes.to_vec())
+    let fc = mlt_core::mvt::mvt_to_feature_collection(mvt_bytes)
         .map_err(|e| TileServerError::MltEncodeError(format!("failed to parse MVT tile: {e}")))?;
 
     let mut layer_map: BTreeMap<String, Vec<&mlt_core::geojson::Feature>> = BTreeMap::new();


### PR DESCRIPTION
## What

One-line fix: drop the redundant `.to_vec()` in the `mvt_to_feature_collection`
call at `crates/tileserver-rs/src/transcode.rs:200`.

## Why

`mlt-core` `0.10.1` (bumped in #1133) changed `mvt_to_feature_collection` to
accept `&[u8]` directly. The old `mvt_bytes.to_vec()` clone is now flagged by
`clippy::unnecessary_to_owned` under `-D warnings`, failing
`cargo clippy --all-targets --all-features`.

#1133 was merged **before its CI run completed** (the run shows `cancelled`), so
this clippy break landed on `main` undetected — **`main` is currently red**
(latest pipeline on `13876ed` = `failure`). This restores it.

`mvt_bytes` is `&[u8]` and is reused at `mvt_bytes.len()` just below, so passing
it borrowed is correct and also avoids one allocation per MVT→MLT transcode.

## Verification

Local CI-parity gate, all green:

- `cargo fmt --all -- --check` → 0
- `cargo clippy --all-targets --all-features -- -D warnings` → 0 (the exact
  command that was failing)
- `cargo clippy --all-targets --no-default-features -- -D warnings` → 0


---

## Note: this also activates better MLT compression (not just a rename fix)

`mlt-core` `0.10.1` additionally **fixes a bug where `EncoderConfig`'s
`allow_fpf` (FastPFOR) and `allow_fsst` (FSST string compression) flags were
silently ignored** by the encode path — before `0.10.1` those toggles were
effectively dead.

Our MVT→MLT encoder at `crates/tileserver-rs/src/transcode.rs:219` calls
`TileLayer::encode(EncoderConfig::default())`, and `EncoderConfig::default()`
already enables `allow_fpf`, `allow_fsst`, `allow_shared_dict`, and both spatial
(Morton + Hilbert) sort attempts. So landing `0.10.1` means our MVT→MLT
transcode path now **actually applies FastPFOR + FSST + shared-dictionary
compression** that was previously a no-op — a free compression win on every
transcode, with zero code change beyond the version bump.

Reference: upstream `mlt-core` CHANGELOG `0.10.1` (2026-06-13).
