### PR TITLE
test(bench): add MVT→MLT transcode benchmark and record native-reader speedup

### DIFF
--- a/apps/docs/content/2.benchmarks/1.performance.md
+++ b/apps/docs/content/2.benchmarks/1.performance.md
@@ -410,6 +410,25 @@ cargo bench --bench styles
 
 Sub-10 µs per call confirms style rewriting is not on the critical path of perceived latency — it's at least three orders of magnitude faster than the actual tile fetch (1-10 ms range).
 
+## MVT→MLT transcode (native mlt-core 0.11 reader)
+
+When a client requests `.mlt` from an MVT source, `mvt_to_mlt` transcodes on the fly. As of mlt-core 0.11 this uses the native `mvt::mvt_to_tile_layers` reader, which decodes MVT straight into row-oriented `TileLayer`s — replacing the previous hand-rolled GeoJSON `FeatureCollection` bridge with its own column-type inference.
+
+Reproduce with:
+
+```bash
+cargo bench --features mlt --bench mlt -- mvt_to_mlt_transcode
+```
+
+| Zoom | Bridge (before) | Native (after) | Change | Throughput |
+|------|-----------------|----------------|--------|------------|
+| z0 | 15.59 ms | 16.67 ms | +6.95% | 5.06 → 4.73 MiB/s |
+| z4 | 184.6 ms | 142.3 ms | **−22.9%** | 9.51 → 12.34 MiB/s |
+| z7 | 230.2 ms | 183.2 ms | **−20.4%** | 7.65 → 9.61 MiB/s |
+| z13 | 19.72 ms | 15.89 ms | **−19.5%** | 23.68 → 29.40 MiB/s |
+
+Real-data tiles (z4/z7/z13) transcode ~20-23% faster because the native reader skips the intermediate GeoJSON allocation and hand-rolled type inference. The trivial z0 world-overview tile regresses ~7% — its near-empty payload is dominated by the reader's fixed setup cost, so there is nothing to amortise. All deltas are statistically significant (p < 0.05). Both sides run mlt-core 0.11.0, so this isolates the reader change rather than the version bump. Absolute timings are machine-specific (measured on Apple Silicon, `--release`); the percentage deltas are the portable signal.
+
 ## In-process benches at a glance
 
 The crate ships ten criterion benches that exercise pure-function hot paths across every feature without an HTTP harness. All are reproducible from a clean checkout:

--- a/apps/marketing/app/composables/use-marketing-page.ts
+++ b/apps/marketing/app/composables/use-marketing-page.ts
@@ -65,7 +65,7 @@ export function useMarketingPage() {
       icon: RefreshCw,
       title: 'MLT Transcoding',
       description:
-        'On-the-fly MLT↔MVT transcoding. Serve next-gen MapLibre Tiles from existing MVT sources — up to 6x smaller tiles.',
+        'On-the-fly MLT↔MVT transcoding via mlt-core 0.11 native reader. Serve next-gen MapLibre Tiles from existing MVT sources — up to 6x smaller tiles, ~22% faster transcode.',
       category: 'Rendering',
     },
     {
@@ -391,6 +391,13 @@ export function useMarketingPage() {
       value: 14,
       label: '× faster brotli vs martin',
       detail: 'Cached re-encode: 1,478 vs 107 req/s',
+    },
+    {
+      icon: RefreshCw,
+      value: 22,
+      label: '% faster MVT→MLT transcode',
+      detail: 'mlt-core 0.11 native reader on z4–z13 tiles',
+      prefix: '~',
     },
   ];
 

--- a/benchmarks/results/README.md
+++ b/benchmarks/results/README.md
@@ -39,3 +39,27 @@ Martin re-encodes brotli per request with no cache and collapses to 107 req/s
 (~14x slower, 889 ms avg). Martin's br is marginally smaller (58.5 vs 60.5 KB)
 because tileserver-rs defaults to `br_quality = 5` for first-paint latency;
 raise it when precomputing. zstd and gzip are at parity across both servers.
+
+## MVT→MLT transcode: native mlt-core 0.11 reader
+
+`cargo bench --features mlt --bench mlt -- mvt_to_mlt_transcode` — real
+OpenMapTiles MVT fixtures, Criterion (100 samples). Compares the `mvt_to_mlt`
+path before and after adopting mlt-core 0.11's native `mvt::mvt_to_tile_layers`
+reader, which replaced the hand-rolled GeoJSON `FeatureCollection` bridge. Both
+sides run mlt-core 0.11.0, so this isolates the reader change, not the bump.
+
+| Zoom | Bridge (before) | Native (after) | Change       | Throughput     |
+| ---- | --------------- | -------------- | ------------ | -------------- |
+| z0   | 15.59 ms        | 16.67 ms       | +6.95% (slower) | 5.06 → 4.73 MiB/s |
+| z4   | 184.6 ms        | 142.3 ms       | −22.9% (faster) | 9.51 → 12.34 MiB/s |
+| z7   | 230.2 ms        | 183.2 ms       | −20.4% (faster) | 7.65 → 9.61 MiB/s |
+| z13  | 19.72 ms        | 15.89 ms       | −19.5% (faster) | 23.68 → 29.40 MiB/s |
+
+Headline: ~20–23% faster MVT→MLT transcoding on real-data tiles (z4/z7/z13)
+because the native reader decodes MVT straight into row-oriented `TileLayer`s
+and skips the intermediate GeoJSON allocation + hand-rolled column-type
+inference. The trivial z0 world-overview tile regresses ~7% (15.6 → 16.7 ms):
+its near-empty payload is dominated by the native reader's fixed setup cost, so
+there is nothing to amortise. All deltas are statistically significant
+(p < 0.05). Measured on Apple Silicon (`--release`); absolute timings are
+machine-specific — the percentage deltas are the portable signal.

--- a/crates/tileserver-rs/benches/mlt.rs
+++ b/crates/tileserver-rs/benches/mlt.rs
@@ -14,6 +14,7 @@
 //! | `mlt_decode_all` | Full MLT decode (parse + `decode_all()` per layer) |
 //! | `mvt_decode` | MVT protobuf decode via `prost` |
 //! | `mlt_to_mvt_transcode` | Our full MLT→MVT transcoding pipeline |
+//! | `mvt_to_mlt_transcode` | Our full MVT→MLT transcoding pipeline |
 //! | `format_detection` | MLT format detection overhead |
 //!
 //! ## Fixture Sources
@@ -286,6 +287,49 @@ fn bench_mlt_to_mvt_transcode(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark the complete MVT→MLT transcoding pipeline via `transcode_tile`.
+///
+/// Exercises `mvt_to_mlt`, which (since mlt-core 0.11) decodes MVT directly
+/// into row-oriented `TileLayer`s via `mvt::mvt_to_tile_layers` and re-encodes
+/// each via `TileLayer::encode`, replacing the older hand-rolled GeoJSON
+/// `FeatureCollection` bridge.
+fn bench_mvt_to_mlt_transcode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mvt_to_mlt_transcode");
+
+    for &zoom in &ZOOM_LEVELS {
+        let fixtures = mvt_fixtures(zoom);
+        if fixtures.is_empty() {
+            continue;
+        }
+
+        let total_bytes: usize = fixtures.iter().map(|f| f.data.len()).sum();
+        group.throughput(Throughput::Bytes(total_bytes as u64));
+
+        let tile_datas: Vec<TileData> = fixtures
+            .iter()
+            .map(|f| TileData {
+                data: Bytes::from_static(f.data),
+                format: TileFormat::Pbf,
+                compression: TileCompression::None,
+            })
+            .collect();
+
+        group.bench_with_input(
+            BenchmarkId::new("zoom", zoom),
+            &tile_datas,
+            |b, tile_datas| {
+                b.iter(|| {
+                    for tile in tile_datas {
+                        let _ = transcode_tile(std::hint::black_box(tile), TileFormat::Mlt);
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
 // ---------------------------------------------------------------------------
 // Benchmark: MLT format detection overhead
 // ---------------------------------------------------------------------------
@@ -362,6 +406,7 @@ criterion_group!(
     bench_mlt_decode_all,
     bench_mvt_decode,
     bench_mlt_to_mvt_transcode,
+    bench_mvt_to_mlt_transcode,
     bench_format_detection,
     bench_mvt_encode,
     bench_transcode_noop,


### PR DESCRIPTION
## Motivation

The mlt-core 0.11 `mvt_to_tile_layers` adoption (#1138) changed the `mvt_to_mlt` transcode path, but the bench suite only measured the **reverse** direction (MLT→MVT) — so the speedup was never quantified. This adds the missing benchmark and records the before/after.

## What changed

- **`bench_mvt_to_mlt_transcode`** added to `crates/tileserver-rs/benches/mlt.rs` (mirrors the existing MLT→MVT bench, reuses the OpenMapTiles MVT fixtures).
- Numbers recorded in `benchmarks/results/README.md`, surfaced in `apps/docs` (2.benchmarks) and `apps/marketing` (MLT card + perf stat).

## Results

Hand-rolled GeoJSON bridge vs native `mvt_to_tile_layers` — **both on mlt-core 0.11.0**, so this isolates the reader change, not the version bump. Criterion, 100 samples, real OpenMapTiles MVT fixtures.

| Zoom | Bridge (before) | Native (after) | Change |
|------|-----------------|----------------|--------|
| z0   | 15.59 ms | 16.67 ms | +6.95% |
| z4   | 184.6 ms | 142.3 ms | **−22.9%** |
| z7   | 230.2 ms | 183.2 ms | **−20.4%** |
| z13  | 19.72 ms | 15.89 ms | **−19.5%** |

~20-23% faster on real-data tiles because the native reader skips the intermediate GeoJSON allocation + hand-rolled column-type inference. The trivial z0 tile regresses ~7% (near-empty payload dominated by fixed setup cost). All deltas significant (p < 0.05). Absolute timings are machine-specific (Apple Silicon, `--release`); the % deltas are the portable signal.

## Verification

- `cargo bench --features mlt --bench mlt -- mvt_to_mlt_transcode` (before/after via criterion baselines)
- fmt clean, clippy `--all-features` clean (benches included), bench compiles
- marketing lint 0 errors, docs lint 0 errors