### PR TITLE
fix(styles): render MLT-backed styles via transcoded MVT for native renderer

### DIFF
--- a/crates/tileserver-rs/src/styles/mod.rs
+++ b/crates/tileserver-rs/src/styles/mod.rs
@@ -406,12 +406,21 @@ fn rewrite_source(
 
     let metadata = tile_source.metadata();
 
-    // Build the tile URL template
+    // MapLibre Native has an MLT render path (maplibre-native PR #3246), but it
+    // only engages when the source carries `encoding: "mlt"`, and that hint is
+    // unreliable upstream (maplibre-native issue #4341). Our rewriter inlines
+    // `tiles` without an encoding field, so the renderer would default to the
+    // MVT decoder and fail on MLT bytes. Point its tile URL at the .pbf endpoint
+    // instead, which transparently transcodes MLT -> MVT on the fly.
+    let native_extension = if metadata.format == crate::sources::TileFormat::Mlt {
+        "pbf"
+    } else {
+        metadata.format.extension()
+    };
+
     let tile_url = format!(
         "{}/data/{}/{{z}}/{{x}}/{{y}}.{}",
-        base_url,
-        data_source_id,
-        metadata.format.extension()
+        base_url, data_source_id, native_extension
     );
 
     tracing::debug!(
@@ -421,13 +430,8 @@ fn rewrite_source(
         tile_url
     );
 
-    // Remove the URL and add tiles array
     source_obj.remove("url");
     source_obj.insert("tiles".to_string(), serde_json::json!([tile_url]));
-
-    if metadata.format == crate::sources::TileFormat::Mlt {
-        source_obj.insert("encoding".to_string(), serde_json::json!("mlt"));
-    }
 
     // Add additional metadata if not already present
     if !source_obj.contains_key("minzoom") {
@@ -648,5 +652,96 @@ mod tests {
             info.url,
             Some("http://localhost:8080/styles/my-style/style.json".to_string())
         );
+    }
+
+    use crate::sources::{TileCompression, TileData, TileFormat, TileMetadata, TileSource};
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use std::sync::Arc;
+
+    struct FmtSource(TileMetadata);
+
+    #[async_trait]
+    impl TileSource for FmtSource {
+        async fn get_tile(&self, _z: u8, _x: u32, _y: u32) -> Result<Option<TileData>> {
+            Ok(Some(TileData {
+                data: Bytes::from_static(b"x"),
+                format: self.0.format,
+                compression: TileCompression::None,
+            }))
+        }
+        fn metadata(&self) -> &TileMetadata {
+            &self.0
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    fn manager_with_source(id: &str, format: TileFormat) -> SourceManager {
+        let meta = TileMetadata {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: None,
+            attribution: None,
+            format,
+            minzoom: 0,
+            maxzoom: 14,
+            bounds: None,
+            center: None,
+            vector_layers: None,
+        };
+        let mut map: HashMap<String, Arc<dyn TileSource>> = HashMap::new();
+        map.insert(
+            id.to_string(),
+            Arc::new(FmtSource(meta)) as Arc<dyn TileSource>,
+        );
+        SourceManager::from_sources(map)
+    }
+
+    #[test]
+    fn test_rewrite_style_for_native_mlt_source_uses_pbf_extension() {
+        // MapLibre Native cannot decode MLT tiles, so an MLT source must be
+        // rewritten to the .pbf (transcoded MVT) endpoint and must NOT carry
+        // an `encoding: mlt` hint — the renderer receives standard MVT.
+        let mgr = manager_with_source("india-mlt", TileFormat::Mlt);
+        let style = json!({
+            "version": 8,
+            "sources": {
+                "india-mlt": { "type": "vector", "url": "/data/india-mlt" }
+            }
+        });
+
+        let result = rewrite_style_for_native(&style, "http://localhost:8080", &mgr);
+        let src = &result["sources"]["india-mlt"];
+
+        let tiles = src["tiles"].as_array().unwrap();
+        assert_eq!(
+            tiles[0],
+            "http://localhost:8080/data/india-mlt/{z}/{x}/{y}.pbf"
+        );
+        assert!(
+            src.get("encoding").is_none(),
+            "native MLT rewrite must not emit an encoding hint, got: {:?}",
+            src.get("encoding")
+        );
+    }
+
+    #[test]
+    fn test_rewrite_style_for_native_pbf_source_unchanged() {
+        let mgr = manager_with_source("osm", TileFormat::Pbf);
+        let style = json!({
+            "version": 8,
+            "sources": {
+                "osm": { "type": "vector", "url": "/data/osm" }
+            }
+        });
+
+        let result = rewrite_style_for_native(&style, "http://localhost:8080", &mgr);
+        let src = &result["sources"]["osm"];
+
+        let tiles = src["tiles"].as_array().unwrap();
+        assert_eq!(tiles[0], "http://localhost:8080/data/osm/{z}/{x}/{y}.pbf");
+        assert!(src.get("encoding").is_none());
     }
 }


### PR DESCRIPTION
## Problem

Server-rendered raster tiles for **MLT-backed styles** come back blank — a 2135-byte empty PNG — while their non-MLT twins render full ~131 KB tiles. On the live demo this shows as the four `*-mlt` style thumbnails (`india-dark-mlt`, `india-light-mlt`, `protomaps-dark-mlt`, `protomaps-light-mlt`) appearing grey/empty in the client's "Map styles" grid.

| Style | `/styles/{id}/3/5/3.png` | |
|---|---|---|
| `india-dark` | 200, **131 KB** | ✅ |
| `india-dark-mlt` | 200, **2135 B** | ⚠️ blank |
| `protomaps-dark` | 200, **131 KB** | ✅ |
| `protomaps-dark-mlt` | 200, **2135 B** | ⚠️ blank |

## Root cause

`rewrite_style_for_native` builds the native renderer's tile URL from `metadata.format.extension()`. For an MLT source that yields a `.mlt` URL and tags the source `"encoding": "mlt"`. The native renderer (MapLibre Native, via `mbgl-sys`) **cannot decode MLT** — it fetches the `.mlt` bytes (confirmed in container logs: `GET /data/india-mlt/4/11/6.mlt 200 "MapLibreNative/1.0"`) and renders nothing.

This is **pre-existing** (not a v2.33.0 regression) — MLT-native rendering was never functional.

## Fix (Option A)

When a source is MLT, point the **native-render** tile URL at the `.pbf` endpoint, which transparently transcodes MLT → MVT on the fly (a path already proven in production: `india-mlt/{z}/{x}/{y}.pbf` → 200, 80 KB `application/x-protobuf`). The misleading `encoding: mlt` hint is dropped since the renderer now receives standard MVT.

**Scope:** only `rewrite_style_for_native` is touched. On-the-wire MLT serving for real MLT clients (the `.mlt` data endpoint, the `rewrite_style_for_api` browser path) is **unchanged**.

## Testing

- `test_rewrite_style_for_native_mlt_source_uses_pbf_extension` — RED-verified (failed with `.mlt` before the fix), asserts MLT source → `.pbf` tiles + no `encoding` hint
- `test_rewrite_style_for_native_pbf_source_unchanged` — regression guard for plain vector sources
- 12/12 `styles::` lib tests pass
- Gate green: `fmt`, `clippy --all-features`, `clippy --no-default-features`

End-to-end render verification (`*-mlt` style renders non-blank) will be confirmed against the live demo once this deploys — the demo has real MLT sources wired to the `*-mlt` styles that local configs lack.
