### PR TITLE
ci(mbgl-sys): add trusted-publishing workflow for crates.io

### DIFF
--- a/.github/workflows/publish-mbgl-sys.yml
+++ b/.github/workflows/publish-mbgl-sys.yml
@@ -1,0 +1,48 @@
+name: "Publish mbgl-sys to crates.io"
+
+# Publishes the mbgl-sys crate to crates.io via Trusted Publishing (OIDC).
+#
+# The crate has "Require trusted publishing for all new versions" enabled on
+# crates.io, so token-based `cargo publish` is rejected (403). This workflow is
+# the ONLY sanctioned publish path: crates.io mints a short-lived OIDC token
+# scoped to this exact repo + workflow filename + environment.
+#
+# IMPORTANT: the crates.io Trusted Publisher entry MUST reference this file's
+# basename (`publish-mbgl-sys.yml`) and the `crates-io` environment below, or
+# the OIDC exchange is refused. The pre-existing entries pointing at
+# release-please.yml / release-plz.yml do NOT publish and must be replaced.
+#
+# mbgl-sys publishes the STUB build (build.rs falls back when the vendored
+# maplibre-native submodule is absent); the `include` list in Cargo.toml omits
+# the submodule, so no `submodules: recursive` checkout is needed.
+on:
+  push:
+    tags:
+      - "mbgl-sys-v*" # e.g. mbgl-sys-v0.1.7
+  workflow_dispatch: # manual retry without re-tagging
+
+permissions:
+  contents: read
+  id-token: write # required for the crates.io OIDC token exchange
+
+jobs:
+  publish:
+    name: "Publish to crates.io"
+    runs-on: ubuntu-latest
+    # Must match the Environment configured on the crates.io Trusted Publisher.
+    environment: crates-io
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate with crates.io (Trusted Publishing / OIDC)
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Publish mbgl-sys
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --locked -p mbgl-sys


### PR DESCRIPTION
## Problem

`cargo publish` for `mbgl-sys` 0.1.7 returns **403 Forbidden**:

> New versions of this crate can only be published using Trusted Publishing

The crate's crates.io settings have **"Require trusted publishing for all new versions"** enabled, but the two configured trusted-publisher entries point at:

- `release-please.yml` — does not run `cargo publish`
- `release-plz.yml` — **does not exist** in this repo (we use release-please)

So there is no workflow that can actually mint the OIDC token and publish.

## Fix

Add `.github/workflows/publish-mbgl-sys.yml`:

- Triggers on `mbgl-sys-v*` tags + `workflow_dispatch` (manual retry of 0.1.7)
- `permissions: id-token: write` for the crates.io OIDC exchange
- `rust-lang/crates-io-auth-action@v1` mints a short-lived token
- `cargo publish --locked -p mbgl-sys` from the workspace root
- Runs in the `crates-io` GitHub environment
- No submodule checkout — the crate publishes the stub build (build.rs falls back; `include` omits the submodule), verified via clean `cargo publish --dry-run` (264 files / 381 KiB)

## Required crates.io config change (manual, by @vinayakkulkarni)

On https://crates.io/crates/mbgl-sys/settings → Trusted Publishing:

1. **Remove** the stale `release-please.yml` and `release-plz.yml` entries
2. **Add** a GitHub publisher:
   - Repository owner: `vinayakkulkarni`
   - Repository name: `tileserver-rs`
   - Workflow filename: `publish-mbgl-sys.yml`
   - Environment: `crates-io`
3. Create a GitHub Environment named `crates-io` (repo Settings → Environments)

After merge + config, trigger the publish via **workflow_dispatch** (tag `mbgl-sys-v0.1.7` already exists).