### PR TITLE
fix(ci): drop --locked from mbgl-sys publish step

### DIFF
--- a/.github/workflows/publish-mbgl-sys.yml
+++ b/.github/workflows/publish-mbgl-sys.yml
@@ -45,4 +45,8 @@ jobs:
       - name: Publish mbgl-sys
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish --locked -p mbgl-sys
+        # No --locked: the workspace Cargo.lock is not part of the published
+        # package, and on a clean runner cargo must refresh the index/lockfile
+        # during verify. --locked forbids that refresh and fails with
+        # "cannot update the lock file ... because --locked was passed".
+        run: cargo publish -p mbgl-sys


### PR DESCRIPTION
## Problem

The first `publish-mbgl-sys` run ([27793752304](https://github.com/vinayakkulkarni/tileserver-rs/actions/runs/27793752304)) failed:

```
error: cannot update the lock file /home/runner/.../Cargo.lock because --locked was passed to prevent this
```

On a clean runner, `cargo publish` must refresh the crates.io index + lockfile during verification. The workspace `Cargo.lock` is not part of the published `mbgl-sys` package, so `--locked` has nothing valid to pin against and aborts.

## Fix

Drop `--locked` from the publish command (`cargo publish -p mbgl-sys`). Added a comment so a future maintainer doesn't re-add it and reintroduce this failure.

After merge, re-trigger via `workflow_dispatch` to publish 0.1.7.