### PR TITLE
fix(routing): preserve trailing slash on SPA viewer routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6400,7 +6400,7 @@ dependencies = [
 
 [[package]]
 name = "tileserver-rs"
-version = "2.33.0"
+version = "2.33.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/tileserver-rs/src/lib.rs
+++ b/crates/tileserver-rs/src/lib.rs
@@ -24,6 +24,7 @@ pub mod routes;
 pub mod sources;
 pub mod startup;
 pub mod styles;
+pub mod trailing_slash;
 #[cfg(feature = "mlt")]
 pub mod transcode;
 pub mod upload;

--- a/crates/tileserver-rs/src/main.rs
+++ b/crates/tileserver-rs/src/main.rs
@@ -16,11 +16,10 @@ use axum::{
 #[cfg(feature = "frontend")]
 use rust_embed::Embed;
 use std::{net::SocketAddr, sync::Arc, time::Duration};
+use tileserver_rs::trailing_slash::SelectiveTrailingSlashLayer;
 use tokio::net::TcpListener;
 use tower::Layer;
-use tower_http::{
-    compression::CompressionLayer, cors::CorsLayer, normalize_path::NormalizePathLayer,
-};
+use tower_http::{compression::CompressionLayer, cors::CorsLayer};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 use utoipa::OpenApi;
 
@@ -257,11 +256,14 @@ async fn main() -> anyhow::Result<()> {
 
     // Normalize trailing slashes before routing so `/_openapi/` matches the
     // `/_openapi` route (and likewise for /health, /ping, etc.) instead of
-    // 404ing. NormalizePathLayer must wrap the Router from the OUTSIDE: routing
-    // happens before inner `.layer()` middleware, so applying it via
-    // `Router::layer()` would run too late. The resulting `NormalizePath<Router>`
-    // is served via `ServiceExt::into_make_service`.
-    let app = NormalizePathLayer::trim_trailing_slash().layer(router);
+    // 404ing — EXCEPT the SPA viewer routes `/styles/{id}/` and `/data/{id}/`,
+    // whose trailing slash is load-bearing (it selects the embedded UI over the
+    // greedy `/styles/{style_json}` / `/data/{source}` API routes). A blanket
+    // trim collapsed every viewer link onto the API and 404'd it. The layer must
+    // wrap the Router from the OUTSIDE: routing happens before inner `.layer()`
+    // middleware, so applying it via `Router::layer()` would run too late. The
+    // resulting service is served via `ServiceExt::into_make_service`.
+    let app = SelectiveTrailingSlashLayer.layer(router);
 
     let addr: SocketAddr = format!("{}:{}", config.server.host, config.server.port).parse()?;
     tracing::info!("Starting tileserver on http://{}", addr);

--- a/crates/tileserver-rs/src/trailing_slash.rs
+++ b/crates/tileserver-rs/src/trailing_slash.rs
@@ -1,0 +1,260 @@
+//! Selective trailing-slash normalization.
+//!
+//! A blanket [`tower_http::normalize_path::NormalizePathLayer::trim_trailing_slash`]
+//! is WRONG for this server because the trailing slash is *meaningful* on the
+//! SPA viewer routes. `/data/protomaps` is the TileJSON **API**; `/data/protomaps/`
+//! is the embedded **inspector UI** (served by the SPA fallback). Likewise
+//! `/styles/{id}/` is the map viewer UI while `/styles/{id}.json` /
+//! `/styles/{id}/style.json` are API endpoints. Blanket trimming collapsed every
+//! `/styles/{id}/` and `/data/{id}/` UI link onto the greedy `/styles/{style_json}`
+//! / `/data/{source}` API routes, 404ing every "Open in viewer" / "Inspect"
+//! link from the home page.
+//!
+//! This module trims the trailing slash for *every* path EXCEPT the two SPA
+//! viewer families, preserving the API hardening (`/health/`, `/ping/`,
+//! `/_openapi/` all still resolve) without breaking the web UI. Like
+//! `NormalizePathLayer`, [`SelectiveTrailingSlashLayer`] must wrap the router
+//! from the OUTSIDE (routing happens before inner `.layer()` middleware) and is
+//! served via `ServiceExt::into_make_service`.
+
+use std::task::{Context, Poll};
+
+use axum::extract::Request;
+use axum::http::Uri;
+use axum::http::uri::PathAndQuery;
+use tower::{Layer, Service};
+
+/// Returns the trailing-slash-trimmed form of `path` when it is eligible for
+/// trimming, or `None` when the path must be preserved as-is.
+///
+/// Preserved (returns `None`): the SPA viewer routes `/styles/{id}/` and
+/// `/data/{id}/` (single id segment + trailing slash), plus any path without a
+/// trailing slash and the bare root `/`.
+pub fn trim_path_if_eligible(path: &str) -> Option<String> {
+    if path.len() <= 1 || !path.ends_with('/') {
+        return None;
+    }
+    if is_spa_viewer_path(path) {
+        return None;
+    }
+    let trimmed = path.trim_end_matches('/');
+    // A path that was only slashes (e.g. "//") trims to empty — leave it for
+    // the router to 404 rather than synthesizing an empty URI.
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(trimmed.to_owned())
+}
+
+/// True when `path` is exactly `/styles/{id}/` or `/data/{id}/` — one id
+/// segment followed by a trailing slash. These are the SPA viewer surfaces
+/// whose trailing slash is load-bearing (it selects the UI over the API).
+fn is_spa_viewer_path(path: &str) -> bool {
+    let mut segments = path.split('/').filter(|s| !s.is_empty());
+    matches!(
+        (segments.next(), segments.next(), segments.next()),
+        (Some("styles" | "data"), Some(_), None)
+    )
+}
+
+/// Tower layer applying [`SelectiveTrailingSlash`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SelectiveTrailingSlashLayer;
+
+impl<S> Layer<S> for SelectiveTrailingSlashLayer {
+    type Service = SelectiveTrailingSlash<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        SelectiveTrailingSlash { inner }
+    }
+}
+
+/// Service that trims a request's trailing slash unless the path is an SPA
+/// viewer route (see [`trim_path_if_eligible`]). Must wrap the router from the
+/// OUTSIDE so it runs before routing.
+#[derive(Clone, Debug)]
+pub struct SelectiveTrailingSlash<S> {
+    inner: S,
+}
+
+impl<S> Service<Request> for SelectiveTrailingSlash<S>
+where
+    S: Service<Request>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request) -> Self::Future {
+        if let Some(trimmed) = trim_path_if_eligible(req.uri().path()) {
+            rewrite_request_path(&mut req, &trimmed);
+        }
+        self.inner.call(req)
+    }
+}
+
+/// Rewrite `req`'s URI path to `new_path`, preserving the query string. A
+/// malformed rebuild leaves the request untouched (the inner router then sees
+/// the original URI), so this never drops a request.
+fn rewrite_request_path(req: &mut Request, new_path: &str) {
+    let rebuilt = match req.uri().query() {
+        Some(query) => format!("{new_path}?{query}"),
+        None => new_path.to_owned(),
+    };
+    let Ok(path_and_query) = PathAndQuery::try_from(rebuilt) else {
+        return;
+    };
+    let mut parts = req.uri().clone().into_parts();
+    parts.path_and_query = Some(path_and_query);
+    if let Ok(uri) = Uri::from_parts(parts) {
+        *req.uri_mut() = uri;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use tower::{ServiceExt, service_fn};
+
+    // ---- pure: trim_path_if_eligible ------------------------------------
+
+    #[test]
+    fn trims_api_trailing_slash() {
+        assert_eq!(
+            trim_path_if_eligible("/health/").as_deref(),
+            Some("/health")
+        );
+        assert_eq!(trim_path_if_eligible("/ping/").as_deref(), Some("/ping"));
+        assert_eq!(
+            trim_path_if_eligible("/_openapi/").as_deref(),
+            Some("/_openapi")
+        );
+        assert_eq!(
+            trim_path_if_eligible("/data.json/").as_deref(),
+            Some("/data.json")
+        );
+    }
+
+    #[test]
+    fn preserves_spa_viewer_routes() {
+        assert_eq!(trim_path_if_eligible("/styles/india-dark-mlt/"), None);
+        assert_eq!(trim_path_if_eligible("/data/protomaps/"), None);
+    }
+
+    #[test]
+    fn trims_deeper_style_and_data_api_paths() {
+        // Two+ segments after the prefix are API routes, not the SPA viewer.
+        assert_eq!(
+            trim_path_if_eligible("/styles/foo/style.json/").as_deref(),
+            Some("/styles/foo/style.json")
+        );
+        assert_eq!(
+            trim_path_if_eligible("/styles/foo/0/0/0.png/").as_deref(),
+            Some("/styles/foo/0/0/0.png")
+        );
+        assert_eq!(
+            trim_path_if_eligible("/data/foo/0/0/0.pbf/").as_deref(),
+            Some("/data/foo/0/0/0.pbf")
+        );
+        assert_eq!(
+            trim_path_if_eligible("/styles/foo/sprite/").as_deref(),
+            Some("/styles/foo/sprite")
+        );
+    }
+
+    #[test]
+    fn preserves_paths_without_trailing_slash() {
+        assert_eq!(trim_path_if_eligible("/health"), None);
+        assert_eq!(trim_path_if_eligible("/styles/foo"), None);
+        assert_eq!(trim_path_if_eligible("/data/protomaps"), None);
+    }
+
+    #[test]
+    fn preserves_root_and_slash_only_paths() {
+        assert_eq!(trim_path_if_eligible("/"), None);
+        assert_eq!(trim_path_if_eligible("//"), None);
+    }
+
+    #[test]
+    fn bare_prefix_with_slash_is_trimmed() {
+        // "/styles/" has no id segment, so it is not a viewer route.
+        assert_eq!(
+            trim_path_if_eligible("/styles/").as_deref(),
+            Some("/styles")
+        );
+        assert_eq!(trim_path_if_eligible("/data/").as_deref(), Some("/data"));
+    }
+
+    // ---- pure: is_spa_viewer_path ---------------------------------------
+
+    #[test]
+    fn spa_viewer_path_classification() {
+        assert!(is_spa_viewer_path("/styles/x/"));
+        assert!(is_spa_viewer_path("/data/x/"));
+        assert!(is_spa_viewer_path("/styles/india-dark-mlt/"));
+        // Not viewer routes:
+        assert!(!is_spa_viewer_path("/styles/x/y/"));
+        assert!(!is_spa_viewer_path("/health/"));
+        assert!(!is_spa_viewer_path("/styles/"));
+        assert!(!is_spa_viewer_path("/fonts/x/"));
+    }
+
+    // ---- service: SelectiveTrailingSlash --------------------------------
+
+    /// Echo the (possibly rewritten) request URI back as the response body so
+    /// tests can assert exactly what the inner service received.
+    async fn echo_uri(path: &str) -> String {
+        let svc = SelectiveTrailingSlashLayer.layer(service_fn(|req: Request| async move {
+            Ok::<_, std::convert::Infallible>(axum::response::Response::new(Body::from(
+                req.uri().to_string(),
+            )))
+        }));
+        let req = Request::builder()
+            .uri(path)
+            .body(Body::empty())
+            .expect("valid request");
+        let resp = svc.oneshot(req).await.expect("service ok");
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        String::from_utf8(bytes.to_vec()).expect("utf8")
+    }
+
+    #[tokio::test]
+    async fn service_trims_api_path() {
+        assert_eq!(echo_uri("/health/").await, "/health");
+    }
+
+    #[tokio::test]
+    async fn service_preserves_spa_path() {
+        assert_eq!(
+            echo_uri("/styles/india-dark-mlt/").await,
+            "/styles/india-dark-mlt/"
+        );
+        assert_eq!(echo_uri("/data/protomaps/").await, "/data/protomaps/");
+    }
+
+    #[tokio::test]
+    async fn service_preserves_query_string_when_trimming() {
+        // The trailing slash is trimmed but ?raster (and any query) survives.
+        assert_eq!(echo_uri("/_openapi/?foo=bar").await, "/_openapi?foo=bar");
+    }
+
+    #[tokio::test]
+    async fn service_preserves_query_on_spa_path() {
+        assert_eq!(
+            echo_uri("/styles/india-dark-mlt/?raster").await,
+            "/styles/india-dark-mlt/?raster"
+        );
+    }
+
+    #[tokio::test]
+    async fn service_passes_through_non_slash_path() {
+        assert_eq!(echo_uri("/health").await, "/health");
+    }
+}

--- a/crates/tileserver-rs/tests/route_data.rs
+++ b/crates/tileserver-rs/tests/route_data.rs
@@ -689,13 +689,15 @@ async fn tile_zstd_request_does_not_5xx() {
 // ============================================================
 
 /// Drive a single GET `path` through the production normalization wiring
-/// (`NormalizePathLayer::trim_trailing_slash` wrapping `api_router`) and return
-/// the response status. `axum_test::TestServer` cannot host a `NormalizePath`
-/// service (no `IntoTransportLayer` impl), so we exercise the layer directly via
+/// (`SelectiveTrailingSlashLayer` wrapping `api_router`) and return the response
+/// status + body text. A sentinel `SPA` fallback stands in for the embedded web
+/// UI so we can assert whether a request reached the SPA fallback (preserved
+/// trailing slash) or an API route (trimmed). `axum_test::TestServer` cannot host
+/// the wrapping service, so we exercise the layer directly via
 /// `tower::ServiceExt::oneshot` — the same path the production `axum::serve` uses.
-async fn normalized_status(path: &str) -> axum::http::StatusCode {
+async fn normalized(path: &str) -> (axum::http::StatusCode, String) {
+    use tileserver_rs::trailing_slash::SelectiveTrailingSlashLayer;
     use tower::{Layer, ServiceExt};
-    use tower_http::normalize_path::NormalizePathLayer;
 
     let shared = SharedState::new(Arc::new(ReloadController::new(
         common::minimal_app_state(),
@@ -704,35 +706,65 @@ async fn normalized_status(path: &str) -> axum::http::StatusCode {
         None,
         common::minimal_runtime(),
     )));
-    let app = NormalizePathLayer::trim_trailing_slash().layer(api_router(shared));
+    let router = api_router(shared).fallback(|| async { "SPA" });
+    let app = SelectiveTrailingSlashLayer.layer(router);
     let req = axum::http::Request::builder()
         .uri(path)
         .body(axum::body::Body::empty())
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
-    resp.status()
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    (status, String::from_utf8(bytes.to_vec()).unwrap())
 }
 
 #[tokio::test]
 async fn trailing_slash_on_health_resolves() {
-    assert_eq!(
-        normalized_status("/health/").await,
-        axum::http::StatusCode::OK
-    );
+    let (status, _) = normalized("/health/").await;
+    assert_eq!(status, axum::http::StatusCode::OK);
 }
 
 #[tokio::test]
 async fn trailing_slash_on_data_json_resolves() {
-    assert_eq!(
-        normalized_status("/data.json/").await,
-        axum::http::StatusCode::OK
-    );
+    let (status, body) = normalized("/data.json/").await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert_ne!(body, "SPA");
 }
 
 #[tokio::test]
 async fn no_trailing_slash_still_resolves() {
-    assert_eq!(
-        normalized_status("/health").await,
-        axum::http::StatusCode::OK
-    );
+    let (status, _) = normalized("/health").await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn style_viewer_trailing_slash_reaches_spa_not_tilejson() {
+    // Regression: a blanket trim collapsed `/styles/{id}/` onto the greedy
+    // `/styles/{style_json}` API route, 404ing every "Open in viewer" link.
+    let (status, body) = normalized("/styles/india-dark-mlt/").await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert_eq!(body, "SPA");
+}
+
+#[tokio::test]
+async fn data_inspector_trailing_slash_reaches_spa_not_tilejson() {
+    let (status, body) = normalized("/data/protomaps/").await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert_eq!(body, "SPA");
+}
+
+#[tokio::test]
+async fn style_viewer_preserves_raster_query() {
+    let (status, body) = normalized("/styles/india-dark-mlt/?raster").await;
+    assert_eq!(status, axum::http::StatusCode::OK);
+    assert_eq!(body, "SPA");
+}
+
+#[tokio::test]
+async fn style_json_trailing_slash_still_trims_to_api() {
+    let (status, body) = normalized("/styles/whatever/style.json/").await;
+    assert_ne!(body, "SPA");
+    assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
 }


### PR DESCRIPTION
## Problem

Every "Open in viewer" (`/styles/{id}/`) and "Inspect" (`/data/{id}/`) link from the home page returns a backend **404 "style not found"** / wrong JSON, on every `frontend`-enabled deployment. The styles/sources exist (they list in `/styles.json`, `style.json` resolves, tiles render) — but the SPA viewer route 404s.

Reproduced live on demo.tileserver.app:
- `/styles/india-dark-mlt/?raster` → `404 style not found: india-dark-mlt`
- `/styles/india-dark/?raster` (non-MLT twin) → identical 404
- `/data/protomaps/` → serves raw TileJSON instead of the inspector UI

## Root cause

PR #1047 added a blanket `NormalizePathLayer::trim_trailing_slash()` wrapping the router from the outside. It trims `/styles/{id}/` → `/styles/{id}` **before routing**, so the trimmed path matches the greedy `/styles/{style_json}` tilejson API route → `strip_suffix(".json")` fails → `StyleNotFound` → 404.

Before #1047, `/styles/{id}/` (with slash) matched no API route and fell through to the SPA `fallback(serve_spa)`. The trailing slash is **load-bearing** — the frontend deliberately links with it (`StyleCard.vue`, `DataCard.vue`) to select the embedded UI over the API. `/data/protomaps` is the TileJSON API; `/data/protomaps/` is the inspector UI. Blanket trimming is fundamentally incompatible with this.

## Fix

Replace the blanket layer with a selective `SelectiveTrailingSlashLayer` (new `trailing_slash` module) that trims trailing slashes everywhere **except** the two SPA viewer families `/styles/{id}/` and `/data/{id}/`. This preserves the #1047 API hardening (`/health/`, `/ping/`, `/_openapi/` still resolve) **and** restores the web UI.

## Tests

- **12 unit tests** for the pure `trim_path_if_eligible` + `is_spa_viewer_path` + the tower `Service` (query-string preservation, deeper API paths still trim, root/slash-only preserved).
- **4 new route_data integration tests** guarding the regression: SPA viewer routes reach the fallback (not the tilejson API), `?raster` query preserved, deeper style API paths still trim.

## Local smoke-test (binary built with `frontend,raster,mlt`)

| Route | Result |
|---|---|
| `/styles/protomaps-light/` | 200 HTML ✅ SPA restored |
| `/styles/protomaps-light/?raster` | 200 HTML ✅ exact broken URL fixed |
| `/data/protomaps/` | 200 HTML ✅ inspector restored |
| `/health/`, `/ping/`, `/data.json/`, `/_openapi/` | 200 ✅ #1047 hardening preserved |
| `/styles/.../style.json`, `/data/protomaps` | 200 JSON ✅ no-slash API intact |

Closes the SPA-viewer 404 regression. Requires a v2.33.2 patch + demo redeploy after merge.
