### PR TITLE
fix(client): condense mobile/tablet hero into tap-to-expand disclosure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -625,6 +625,16 @@ Single sticky row directly under the hero. Two children:
 
 Chips MUST be derived from the actual loaded source/style counts — not hardcoded. Generate from grouping over `Style.type` (raster / vector) and `Data.type` (pmtiles / mlt / stac / postgis / etc.).
 
+**Responsive toolbar — chips collapse behind a "Filters" toggle on `<lg`:**
+
+Like the hero (Rule #20.A), the chip strip is pinned chrome that crowds small viewports. Split at `lg` (1024px):
+
+- **`lg+` (≥1024px)** — chips shown inline below the search, always visible (`.toolbar-filters-wrap` forced `grid-template-rows: 1fr` via `@media (width >= 64rem)`).
+- **`<lg`** — only the 44px search stays pinned. A `.filters-toggle` button (`SlidersHorizontal` + "Filters" + chevron, `lg:hidden`, `h-11`) sits beside the search and toggles the chip strip via the same `grid-template-rows: 0fr→1fr` disclosure idiom (`.toolbar-filters-wrap` / `.toolbar-filters-inner`, driven by `.toolbar.open`). Defaults collapsed.
+  - The toggle MUST badge the count of filters narrowed off `'all'` (`activeFilterCount`) so a collapsed strip still signals an active filter, and tint `border-primary text-primary` when `activeFilterCount > 0 || filtersOpen`.
+  - State (`filtersOpen` + `toggleFilters` + `activeFilterCount`) lives in `useHomeFilters()`, threaded through `useHomePage()`, NEVER as local component state; it drives ONLY the `<lg` disclosure.
+  - `aria-expanded` + `aria-controls="toolbar-filters"` on the toggle.
+
 #### C. Card hover — NO layout shift (HARD)
 
 **FORBIDDEN on any card / row / tile hover state:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -604,6 +604,18 @@ Two-column grid (single column `<md`, `1fr auto` `>=md`). Left column: kicker pi
 
 > **HONEST-DATA RULE**: NEVER show metrics `/ping` does not return — no fake `p50`, no fake `p99`, no fake region label, no fake QPS. The PingResponse fields are the entire surface. If a metric is unavailable, show `—` or omit the cell.
 
+**Responsive hero — TWO distinct treatments, split at `lg` (1024px):**
+
+The full two-column band above is the **`lg+` treatment ONLY**. On phones/tablets it eats ~30% of viewport height as permanently-pinned chrome (the app shell is `h-dvh overflow-hidden`, so the hero never scrolls away) — that is a HARD UX defect, not acceptable.
+
+- **`lg+` (≥1024px)** — the full admin-style band (`lg:grid lg:grid-cols-[3fr_2fr]`): Catalog/uptime column + 4-cell stat grid. Always fully visible.
+- **`<lg` (mobile + tablet)** — a **condense + tap-to-expand disclosure** (`.hero-compact`):
+  - **Always-visible summary line** (one mono row, zero taps): `● Live · <sources> sources · <styles> styles · v<version>`. These are the glanceable essentials.
+  - **Tap-to-expand detail** behind a chevron: capability flags (`Renderer / Compression / OGC` ✓/✗) + a 3-cell metric grid (`Cache / Uptime / Codec`). Defaults **collapsed** for maximum reclaim.
+  - The disclosure MUST reuse the section idiom: `grid-template-rows: 0fr→1fr` transition (`.hero-detail-wrap` / `.hero-detail-inner`) + chevron `rotate(180deg)` on `.hero-compact.open`, with motion tokens `--d-slow`/`--d-base`/`--ease`. Toggle button: `min-h-11` (44px), `aria-expanded` + `aria-controls="hero-detail"`.
+  - Disclosure open-state lives in `useHomeHero()` (`heroExpanded` ref + `toggleHero`), NEVER as local component state, and drives ONLY the `<lg` block — the `lg+` band ignores it.
+  - The HONEST-DATA RULE applies identically: the summary line + disclosure may only show real `/ping` fields.
+
 #### B. Sticky toolbar (search + filter chips)
 
 Single sticky row directly under the hero. Two children:

--- a/apps/client/app/assets/css/tailwind.css
+++ b/apps/client/app/assets/css/tailwind.css
@@ -367,3 +367,23 @@
   min-height: 0;
   overflow: hidden;
 }
+
+/* Mobile/tablet toolbar filter-chip disclosure — collapsed by default <lg so
+   only the 44px search stays pinned; always open at lg+ (Rule #20.B) */
+.toolbar-filters-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--d-slow) var(--ease);
+}
+.toolbar.open .toolbar-filters-wrap {
+  grid-template-rows: 1fr;
+}
+.toolbar-filters-inner {
+  min-height: 0;
+  overflow: hidden;
+}
+@media (width >= 64rem) {
+  .toolbar-filters-wrap {
+    grid-template-rows: 1fr;
+  }
+}

--- a/apps/client/app/assets/css/tailwind.css
+++ b/apps/client/app/assets/css/tailwind.css
@@ -353,3 +353,17 @@
   min-height: 0;
   overflow: hidden;
 }
+
+/* Mobile/tablet hero disclosure — same grid-rows idiom as the section (Rule #20.A) */
+.hero-detail-wrap {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--d-slow) var(--ease);
+}
+.hero-compact.open .hero-detail-wrap {
+  grid-template-rows: 1fr;
+}
+.hero-detail-inner {
+  min-height: 0;
+  overflow: hidden;
+}

--- a/apps/client/app/components/home/Hero.vue
+++ b/apps/client/app/components/home/Hero.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
   import { useHomeHero } from '~/composables/use-home-hero';
 
+  import { ChevronDown } from '@lucide/vue';
+
   const {
     statusOk,
     isLoading,
@@ -14,6 +16,8 @@
     compressionEnabled,
     compressionLabel,
     ogcEnabled,
+    heroExpanded,
+    toggleHero,
   } = useHomeHero();
 </script>
 
@@ -22,17 +26,22 @@
     class="hero shrink-0 border-b border-border"
     aria-label="Runtime status"
   >
-    <!-- Compact strip (<lg) — single horizontal row, mobile-first. -->
-    <div class="lg:hidden">
-      <div
-        class="mx-auto flex max-w-screen-2xl flex-col gap-2 px-[clamp(12px,4vw,24px)] py-3"
+    <!-- Compact disclosure (<lg) — glanceable summary line + tap-to-expand
+         detail, so pinned chrome stays small on phones/tablets. -->
+    <div class="hero-compact lg:hidden" :class="{ open: heroExpanded }">
+      <button
+        type="button"
+        class="flex min-h-11 w-full items-center justify-between gap-2.5 px-[clamp(12px,4vw,24px)] py-2.5 text-left transition-colors duration-[var(--d-fast,120ms)] hover:bg-primary/[0.04]"
+        :aria-expanded="heroExpanded"
+        aria-controls="hero-detail"
+        @click="toggleHero"
       >
-        <p
-          class="flex flex-wrap items-center gap-1.5 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground"
+        <span
+          class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[11px] font-medium tracking-[0.06em] text-muted-foreground"
         >
           <span
             v-if="!isLoading"
-            class="inline-flex items-center gap-1.5 border px-2 py-0.5 font-semibold"
+            class="inline-flex items-center gap-1.5 border px-2 py-0.5 text-[9.5px] font-semibold uppercase tracking-[0.14em]"
             :class="
               statusOk
                 ? 'border-success/30 bg-success/10 text-success'
@@ -46,70 +55,118 @@
             ></span>
             Live
           </span>
-          <span>Renderer {{ rendererEnabled ? '✓' : '✗' }}</span>
-          <span>Compression {{ compressionEnabled ? '✓' : '✗' }}</span>
-          <span>OGC {{ ogcEnabled ? '✓' : '✗' }}</span>
-          <span v-if="versionLabel">{{ versionLabel }}</span>
-        </p>
-        <dl
-          class="grid grid-cols-4 gap-x-3 text-foreground"
-          aria-label="Runtime metrics"
-        >
-          <div class="flex flex-col">
-            <dt
-              class="font-mono text-[9.5px] font-medium uppercase tracking-[0.14em] text-muted-foreground"
+          <span
+            ><span class="font-semibold tabular-nums text-foreground">{{
+              sourceCount
+            }}</span>
+            sources</span
+          >
+          <span aria-hidden="true" class="opacity-40">·</span>
+          <span
+            ><span class="font-semibold tabular-nums text-foreground">{{
+              styleCount
+            }}</span>
+            styles</span
+          >
+          <template v-if="versionLabel">
+            <span aria-hidden="true" class="opacity-40">·</span>
+            <span class="font-semibold text-foreground">{{
+              versionLabel
+            }}</span>
+          </template>
+        </span>
+        <ChevronDown
+          class="size-[18px] shrink-0 text-muted-foreground transition-transform duration-[var(--d-base,180ms)] ease-[var(--ease,cubic-bezier(0.16,1,0.3,1))]"
+          :class="{ 'rotate-180': heroExpanded }"
+          aria-hidden="true"
+        />
+      </button>
+      <div id="hero-detail" class="hero-detail-wrap">
+        <div class="hero-detail-inner">
+          <div
+            class="flex flex-col gap-2.5 border-t border-border px-[clamp(12px,4vw,24px)] pb-3 pt-3"
+          >
+            <p
+              class="flex flex-wrap items-center gap-x-3.5 gap-y-1.5 font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground"
             >
-              Sources
-            </dt>
-            <dd
-              class="font-mono text-[15px] font-semibold leading-none tabular-nums"
+              <span
+                >Renderer
+                <span
+                  :class="rendererEnabled ? 'font-semibold text-success' : ''"
+                  >{{ rendererEnabled ? '✓' : '✗' }}</span
+                ></span
+              >
+              <span
+                >Compression
+                <span
+                  :class="
+                    compressionEnabled ? 'font-semibold text-success' : ''
+                  "
+                  >{{ compressionEnabled ? '✓' : '✗' }}</span
+                ></span
+              >
+              <span
+                >OGC
+                <span :class="ogcEnabled ? 'font-semibold text-success' : ''">{{
+                  ogcEnabled ? '✓' : '✗'
+                }}</span></span
+              >
+            </p>
+            <dl
+              class="grid grid-cols-3 gap-x-3 text-foreground"
+              aria-label="Runtime metrics"
             >
-              {{ sourceCount }}
-            </dd>
-          </div>
-          <div class="flex flex-col">
-            <dt
-              class="font-mono text-[9.5px] font-medium uppercase tracking-[0.14em] text-muted-foreground"
-            >
-              Styles
-            </dt>
-            <dd
-              class="font-mono text-[15px] font-semibold leading-none tabular-nums"
-            >
-              {{ styleCount }}
-            </dd>
-          </div>
-          <div class="flex flex-col">
-            <dt
-              class="font-mono text-[9.5px] font-medium uppercase tracking-[0.14em] text-muted-foreground"
-            >
-              Cache
-            </dt>
-            <dd
-              class="flex items-baseline gap-0.5 font-mono text-[15px] font-semibold leading-none tabular-nums"
-            >
-              <span v-if="!cacheEnabled" class="text-muted-foreground">—</span>
-              <template v-else>
-                {{ cacheMb
-                }}<span class="text-[10px] font-medium text-muted-foreground"
-                  >MB</span
+              <div class="flex flex-col">
+                <dt
+                  class="font-mono text-[9.5px] font-medium uppercase tracking-[0.14em] text-muted-foreground"
                 >
-              </template>
-            </dd>
+                  Cache
+                </dt>
+                <dd
+                  class="flex items-baseline gap-0.5 font-mono text-[15px] font-semibold leading-none tabular-nums"
+                >
+                  <span v-if="!cacheEnabled" class="text-muted-foreground"
+                    >—</span
+                  >
+                  <template v-else>
+                    {{ cacheMb
+                    }}<span
+                      class="text-[10px] font-medium text-muted-foreground"
+                      >MB</span
+                    >
+                  </template>
+                </dd>
+              </div>
+              <div class="flex flex-col">
+                <dt
+                  class="font-mono text-[9.5px] font-medium uppercase tracking-[0.14em] text-muted-foreground"
+                >
+                  Uptime
+                </dt>
+                <dd
+                  class="font-mono text-[15px] font-semibold leading-none tabular-nums"
+                >
+                  {{ uptime }}
+                </dd>
+              </div>
+              <div class="flex flex-col">
+                <dt
+                  class="font-mono text-[9.5px] font-medium uppercase tracking-[0.14em] text-muted-foreground"
+                >
+                  Codec
+                </dt>
+                <dd
+                  class="font-mono text-[13px] font-semibold leading-none text-foreground"
+                >
+                  <span v-if="!compressionEnabled" class="text-muted-foreground"
+                    >off</span
+                  >
+                  <template v-else>{{ compressionLabel }}</template>
+                </dd>
+              </div>
+            </dl>
           </div>
-          <div class="flex flex-col">
-            <dt
-              class="font-mono text-[9.5px] font-medium uppercase tracking-[0.14em] text-muted-foreground"
-            >
-              Uptime
-            </dt>
-            <dd
-              class="font-mono text-[15px] font-semibold leading-none tabular-nums"
-            >
-              {{ uptime }}
-            </dd>
-          </div>
-        </dl>
+        </div>
       </div>
     </div>
 

--- a/apps/client/app/components/home/Toolbar.vue
+++ b/apps/client/app/components/home/Toolbar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { Search } from '@lucide/vue';
+  import { ChevronDown, Search, SlidersHorizontal } from '@lucide/vue';
   import HomeFilterChip from './FilterChip.vue';
   import type { FilterCategory, FilterChip } from '~/types/home-filters';
 
@@ -9,13 +9,20 @@
     sourceChips: FilterChip[];
     activeStyleFilter: FilterCategory;
     activeSourceFilter: FilterCategory;
+    activeFilterCount: number;
+    filtersOpen: boolean;
   }>();
 
   const emit = defineEmits<{
     'update:search-query': [value: string];
     'select-style-filter': [category: FilterCategory];
     'select-source-filter': [category: FilterCategory];
+    'toggle-filters': [];
   }>();
+
+  function handleToggleFilters() {
+    emit('toggle-filters');
+  }
 
   function handleSearch(value: string) {
     emit('update:search-query', value);
@@ -31,75 +38,109 @@
 </script>
 
 <template>
-  <div class="toolbar shrink-0 border-b border-border bg-background">
+  <div
+    class="toolbar shrink-0 border-b border-border bg-background"
+    :class="{ open: filtersOpen }"
+  >
     <div
       class="mx-auto flex max-w-screen-2xl flex-col gap-2.5 px-[clamp(12px,4vw,24px)] py-2.5"
     >
-      <div class="search relative">
-        <label class="sr-only" for="search-input"
-          >Search styles and data sources</label
-        >
-        <input
-          id="search-input"
-          :value="searchQuery"
-          type="text"
-          placeholder="Search styles and data sources..."
-          autocomplete="off"
-          class="h-11 w-full border border-border bg-card px-4 pl-11 text-[15px] text-foreground transition-colors duration-[var(--d-fast,120ms)] placeholder:text-muted-foreground focus:border-primary focus:bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
-          :class="searchQuery ? 'text-foreground' : 'text-muted-foreground'"
-          @input="handleSearch(($event.target as HTMLInputElement).value)"
-        />
-        <Search
-          class="pointer-events-none absolute left-3.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground transition-colors duration-[var(--d-fast,120ms)]"
-          :class="searchQuery ? 'text-primary' : 'text-muted-foreground'"
-          aria-hidden="true"
-        />
-      </div>
-      <div
-        class="filters flex flex-wrap items-center gap-x-3 gap-y-1.5 overflow-x-auto pb-0.5"
-        style="scrollbar-width: thin"
-      >
-        <div
-          v-if="styleChips.length > 0"
-          class="flex items-center gap-1.5"
-          role="group"
-          aria-label="Filter map styles"
-        >
-          <span
-            class="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
-            aria-hidden="true"
-            >Styles</span
+      <div class="flex items-center gap-2">
+        <div class="search relative flex-1">
+          <label class="sr-only" for="search-input"
+            >Search styles and data sources</label
           >
-          <HomeFilterChip
-            v-for="chip in styleChips"
-            :key="`style-${chip.category}`"
-            :label="chip.label"
-            :count="chip.count"
-            :category="chip.category"
-            :active="activeStyleFilter === chip.category"
-            @select-filter="handleStyleFilterClick"
+          <input
+            id="search-input"
+            :value="searchQuery"
+            type="text"
+            placeholder="Search styles and data sources..."
+            autocomplete="off"
+            class="h-11 w-full border border-border bg-card px-4 pl-11 text-[15px] text-foreground transition-colors duration-[var(--d-fast,120ms)] placeholder:text-muted-foreground focus:border-primary focus:bg-background focus:outline-none focus:ring-2 focus:ring-primary/20"
+            :class="searchQuery ? 'text-foreground' : 'text-muted-foreground'"
+            @input="handleSearch(($event.target as HTMLInputElement).value)"
+          />
+          <Search
+            class="pointer-events-none absolute left-3.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground transition-colors duration-[var(--d-fast,120ms)]"
+            :class="searchQuery ? 'text-primary' : 'text-muted-foreground'"
+            aria-hidden="true"
           />
         </div>
-        <div
-          v-if="sourceChips.length > 0"
-          class="flex items-center gap-1.5"
-          role="group"
-          aria-label="Filter data sources"
+        <button
+          type="button"
+          class="filters-toggle flex h-11 shrink-0 items-center gap-2 border border-border bg-card px-3.5 text-[13px] font-medium text-foreground transition-colors duration-[var(--d-fast,120ms)] hover:border-primary hover:text-primary lg:hidden"
+          :class="
+            activeFilterCount > 0 || filtersOpen
+              ? 'border-primary text-primary'
+              : ''
+          "
+          :aria-expanded="filtersOpen"
+          aria-controls="toolbar-filters"
+          @click="handleToggleFilters"
         >
+          <SlidersHorizontal class="size-4" aria-hidden="true" />
+          <span>Filters</span>
           <span
-            class="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
-            aria-hidden="true"
-            >Sources</span
+            v-if="activeFilterCount > 0"
+            class="grid size-[18px] place-items-center bg-primary text-[10px] font-semibold text-primary-foreground tabular-nums"
+            >{{ activeFilterCount }}</span
           >
-          <HomeFilterChip
-            v-for="chip in sourceChips"
-            :key="`source-${chip.category}`"
-            :label="chip.label"
-            :count="chip.count"
-            :category="chip.category"
-            :active="activeSourceFilter === chip.category"
-            @select-filter="handleSourceFilterClick"
+          <ChevronDown
+            class="size-4 transition-transform duration-[var(--d-base,180ms)] ease-[var(--ease,cubic-bezier(0.16,1,0.3,1))]"
+            :class="{ 'rotate-180': filtersOpen }"
+            aria-hidden="true"
           />
+        </button>
+      </div>
+      <div id="toolbar-filters" class="toolbar-filters-wrap">
+        <div class="toolbar-filters-inner">
+          <div
+            class="filters flex flex-wrap items-center gap-x-3 gap-y-1.5 overflow-x-auto pb-0.5 pt-2.5 lg:pt-0"
+            style="scrollbar-width: thin"
+          >
+            <div
+              v-if="styleChips.length > 0"
+              class="flex items-center gap-1.5"
+              role="group"
+              aria-label="Filter map styles"
+            >
+              <span
+                class="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
+                aria-hidden="true"
+                >Styles</span
+              >
+              <HomeFilterChip
+                v-for="chip in styleChips"
+                :key="`style-${chip.category}`"
+                :label="chip.label"
+                :count="chip.count"
+                :category="chip.category"
+                :active="activeStyleFilter === chip.category"
+                @select-filter="handleStyleFilterClick"
+              />
+            </div>
+            <div
+              v-if="sourceChips.length > 0"
+              class="flex items-center gap-1.5"
+              role="group"
+              aria-label="Filter data sources"
+            >
+              <span
+                class="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
+                aria-hidden="true"
+                >Sources</span
+              >
+              <HomeFilterChip
+                v-for="chip in sourceChips"
+                :key="`source-${chip.category}`"
+                :label="chip.label"
+                :count="chip.count"
+                :category="chip.category"
+                :active="activeSourceFilter === chip.category"
+                @select-filter="handleSourceFilterClick"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/client/app/composables/use-home-filters.ts
+++ b/apps/client/app/composables/use-home-filters.ts
@@ -123,6 +123,22 @@ export function useHomeFilters() {
     activeSourceFilter.value = filter;
   }
 
+  // Number of filters narrowed off the default 'all' — badges the <lg
+  // "Filters" toggle so a collapsed chip row still signals an active filter.
+  const activeFilterCount = computed(() => {
+    let n = 0;
+    if (activeStyleFilter.value !== 'all') n += 1;
+    if (activeSourceFilter.value !== 'all') n += 1;
+    return n;
+  });
+
+  // Drives ONLY the <lg chip disclosure (lg+ shows chips inline); collapsed
+  // by default so only the 44px search stays pinned on small viewports.
+  const filtersOpen = ref(false);
+  function toggleFilters() {
+    filtersOpen.value = !filtersOpen.value;
+  }
+
   return {
     activeStyleFilter,
     activeSourceFilter,
@@ -132,5 +148,8 @@ export function useHomeFilters() {
     filteredDataSources,
     setStyleFilter,
     setSourceFilter,
+    activeFilterCount,
+    filtersOpen,
+    toggleFilters,
   };
 }

--- a/apps/client/app/composables/use-home-hero.ts
+++ b/apps/client/app/composables/use-home-hero.ts
@@ -56,6 +56,13 @@ export function useHomeHero() {
 
   const ogcEnabled = computed(() => pingQuery.data.value?.ogc_enabled ?? false);
 
+  // Drives ONLY the <lg compact disclosure (lg+ admin band ignores it and
+  // always shows everything); defaults closed so pinned chrome stays small.
+  const heroExpanded = ref(false);
+  function toggleHero() {
+    heroExpanded.value = !heroExpanded.value;
+  }
+
   const renderEnabled = computed(
     () => pingQuery.data.value?.render_enabled ?? false,
   );
@@ -82,5 +89,7 @@ export function useHomeHero() {
     ogcEnabled,
     renderEnabled,
     corsLabel,
+    heroExpanded,
+    toggleHero,
   };
 }

--- a/apps/client/app/composables/use-home-page.ts
+++ b/apps/client/app/composables/use-home-page.ts
@@ -30,6 +30,9 @@ export function useHomePage() {
     filteredDataSources: typeFilteredDataSources,
     setStyleFilter,
     setSourceFilter,
+    activeFilterCount,
+    filtersOpen,
+    toggleFilters,
   } = useHomeFilters();
 
   const searchQuery = ref('');
@@ -129,6 +132,9 @@ export function useHomePage() {
     sourceChips,
     setStyleFilter,
     setSourceFilter,
+    activeFilterCount,
+    filtersOpen,
+    toggleFilters,
     filteredStyles,
     filteredDataSources,
 

--- a/apps/client/app/pages/index.vue
+++ b/apps/client/app/pages/index.vue
@@ -28,6 +28,9 @@
     dataOpen,
     baseUrl,
     pingQuery,
+    activeFilterCount,
+    filtersOpen,
+    toggleFilters,
   } = useHomePage();
 
   const handleSearch = (value: string) => {
@@ -56,9 +59,12 @@
       :source-chips="sourceChips"
       :active-style-filter="activeStyleFilter"
       :active-source-filter="activeSourceFilter"
+      :active-filter-count="activeFilterCount"
+      :filters-open="filtersOpen"
       @update:search-query="handleSearch"
       @select-style-filter="handleStyleFilter"
       @select-source-filter="handleSourceFilter"
+      @toggle-filters="toggleFilters"
     />
 
     <main id="main" class="w-full flex-1 overflow-y-auto" role="main">


### PR DESCRIPTION
## What

On mobile/tablet (`<lg`) the home **hero** and **toolbar filter chips**
both collapse into tap-to-expand disclosures, taking the permanently-pinned
chrome from ~28–30% of the viewport down to ~16%.

## Why

The app shell is `h-dvh overflow-hidden` with header + hero + toolbar all
`shrink-0`, so only `<main>` scrolls — the hero + toolbar were **permanently
pinned** and on a 390×844 phone consumed ~30% before any catalog content,
which read as cluttered, bad UX.

## What changed

**Commit 1 — hero (`737a611`):** `<lg` collapses the capability pills +
4-stat grid into one always-visible mono summary line (`● Live · N sources ·
N styles · vX`) with a chevron; capability flags + `Cache / Uptime / Codec`
move behind one tap.

**Commit 2 — toolbar (`7234538`):** after the hero shrank, the toolbar
(~108px) became the dominant pinned element. `<lg` now collapses the
filter-chip strip behind a 44px "Filters" toggle beside the search, leaving
only the search pinned. The toggle badges the count of filters off `'all'`
so a collapsed strip still signals an active filter.

Both reuse the same `grid-template-rows: 0fr→1fr` disclosure idiom +
chevron-rotate motion as `Section.vue`. Disclosure state lives in the
composables (`useHomeHero` / `useHomeFilters`), never in the components, and
drives **only** the `<lg` blocks. The `lg+` admin band + inline chips are
untouched (a `@media (width >= 64rem)` force-opens the chip wrap).

## Verification (real-browser QA, light + dark)

| Breakpoint | Hero | Toolbar |
|---|---|---|
| 390 (mobile) | summary line; collapsed `0px` → expanded `90.25px`, chevron + aria toggle | Filters button; chips `0px` → `80px`; badge=1 after filter; filtering works |
| 834 (tablet) | compact disclosure | Filters button, chips collapsed |
| 1440 (desktop) | original admin band, unchanged | chips inline, no Filters button |

Production `nuxt build` green; lint + format clean; `typecheck` shows only
pre-existing `llm/*` + `@tanstack/*` errors (touched files clean).

## design-discipline 5-dim critique

Hero: Typo 4 · Color 5 · Layout 4 · Components 5 · Identity 4.
Toolbar: Typo 4 · Color 5 · Layout 5 · Components 5 · Identity 4.
No dimension below 3 — passes. Only Direction-I OKLch tokens, sharp corners,
no banned fonts / gradient text / `rounded-*`.

Documented both patterns in `CLAUDE.md` Rule #20.A + #20.B.

Closes the mobile/tablet hero clutter issue.
