### PR TITLE
feat(dem): add DEM tile encoding with Terrarium and Mapbox-RGB — closes #1008

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,10 +11,10 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
-    # 7 feature combos run sequentially as instrumented llvm-cov builds; the
-    # GDAL-heavy raster + stac combos land last. After the free-disk-space fix
-    # unblocked the duckdb combo, total wall-clock crept past the old 45-min cap
-    # (job was ~95% done, cancelled mid-stac). 60 min gives headroom; if it
+    # 8 feature combos run sequentially as instrumented llvm-cov builds; the
+    # GDAL-heavy raster + stac + dem combos land last. After the free-disk-space
+    # fix unblocked the duckdb combo, total wall-clock crept past the old 45-min
+    # cap (job was ~95% done, cancelled mid-stac). 60 min gives headroom; if it
     # recurs, split GDAL vs non-GDAL combos into two parallel jobs.
     timeout-minutes: 60
 
@@ -148,6 +148,15 @@ jobs:
             --lib \
             --no-default-features \
             --features "stac"
+
+      - name: Coverage — dem
+        run: |
+          cargo llvm-cov \
+            --no-report \
+            --lib \
+            --test dem_sources \
+            --no-default-features \
+            --features "dem"
 
       - name: Generate merged coverage report
         run: |

--- a/apps/docs/content/1.getting-started/3.config.md
+++ b/apps/docs/content/1.getting-started/3.config.md
@@ -273,6 +273,41 @@ not directly on the source. See the [PostGIS guide](/guides/postgres-outdb-raste
 | `resampling`   | enum?   | `bilinear`   | GDAL resampler. One of: `nearest`, `bilinear`, `cubic`, `cubicspline`, `lanczos`, `average`, `mode` |
 | `colormap`     | table?  | _(none)_     | See [ColorMap](#colormap) below                                                                   |
 
+#### `type = "dem"` _(feature: `dem`)_
+
+Reads float elevation from a GDAL raster (COG / GeoTIFF) and re-encodes each
+pixel as a **Terrarium** or **Mapbox-RGB** (`terrain-rgb`) PNG tile that
+MapLibre GL JS consumes directly as a `raster-dem` source for 3D terrain,
+hillshading, and contour generation. Both encodings are bit-exact to what
+MapLibre decodes.
+
+| Key                | Type      | Default       | Description                                                                                                         |
+| ------------------ | --------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `path`             | string?   | _(none)_      | Source GDAL raster. Omit when `input_source` is set                                                                |
+| `input_source`     | string?   | _(none)_      | Id of another already-loaded `cog`/`vrt` source to read elevation from. Shares its cached GDAL dataset (no re-open) |
+| `dem_encoding`     | enum?     | `terrarium`   | `terrarium` (precision 1/256 m) or `mapbox_rgb` (legacy `terrain-rgb`, precision 0.1 m)                            |
+| `dem_band`         | u32?      | `1`           | 1-indexed GDAL band to encode                                                                                      |
+| `dem_scale`        | f64?      | `1.0`         | Multiplier applied to elevation before encoding (e.g. feet → metres: `0.3048`)                                     |
+| `dem_offset`       | f64?      | `0.0`         | Additive offset applied after `dem_scale`                                                                          |
+| `dem_nodata_color` | u8[4]?    | _(per-enc.)_  | RGBA sentinel for nodata pixels. MapLibre **ignores alpha**, so the RGB encodes "no data". Mapbox default `[1,134,160]`, Terrarium `[0,0,0]` |
+| `resampling`       | enum?     | `bilinear`    | Same GDAL resampler set as `cog`                                                                                   |
+
+Use it in a style as a `raster-dem` source:
+
+```json
+{
+  "sources": {
+    "terrain": {
+      "type": "raster-dem",
+      "tiles": ["https://tiles.example.com/data/terrain-terrarium/{z}/{x}/{y}.png"],
+      "encoding": "terrarium",
+      "tileSize": 256
+    }
+  },
+  "terrain": { "source": "terrain", "exaggeration": 1.5 }
+}
+```
+
 #### `type = "geoparquet"` _(feature: `geoparquet`)_
 
 | Key                | Type     | Required | Description                                                              |

--- a/apps/docs/content/2.benchmarks/1.performance.md
+++ b/apps/docs/content/2.benchmarks/1.performance.md
@@ -110,6 +110,37 @@ every request with no cache and collapses to **107 req/s (~14× slower)**.
 Martin's brotli is marginally smaller (58.5 KB) because tileserver-rs defaults
 to `br_quality = 5` for first-paint latency; raise it when precomputing tiles.
 
+## DEM terrain-RGB encoding
+
+tileserver-rs encodes float elevation into Terrarium / Mapbox-RGB
+(`terrain-rgb`) PNG tiles on the fly, reading raw `f64` bands through GDAL and
+encoding directly (no PNG round-trip). The only apples-to-apples live
+competitor is titiler (`algorithm=terrarium`, whose terrain-RGB feature merged
+April 2025).
+
+SF-Bay DEM fixture (EPSG:4326, −41..1041 m), 10s / 100 connections, 0 errors
+both servers:
+
+| Server        | Zoom | Req/s | Avg Latency | P99 Latency |
+| ------------- | ---- | ----- | ----------- | ----------- |
+| tileserver-rs | z9   | 203   | 487ms       | 642ms       |
+| tileserver-rs | z10  | 148   | 664ms       | 969ms       |
+| tileserver-rs | z11  | 86    | 1,152ms     | 1,694ms     |
+| tileserver-rs | z12  | 83    | 1,274ms     | 2,642ms     |
+| titiler       | z9   | 50    | 1,803ms     | 3,778ms     |
+| titiler       | z10  | 35    | 2,472ms     | 5,347ms     |
+| titiler       | z11  | 21    | 3,993ms     | 7,096ms     |
+| titiler       | z12  | 8     | 5,045ms     | 10,061ms    |
+
+tileserver-rs serves live DEM terrain-RGB **~4–10× faster** than titiler (130
+vs 28 avg req/s, 894ms vs 3,328ms avg latency), the gap widening to 10.4× at
+z12 where titiler's per-request Python/rasterio cost dominates. Encoding is
+byte-accurate: a round-trip decode reproduces source elevation within the
+encoding interval (≤0.1 m Mapbox-RGB, ≤1/256 m Terrarium). Caveat: titiler
+reads a `file://` COG here (no network) — its most favourable setup — and these
+are single-run on an Apple-Silicon Docker host, so the **ratio** is the
+portable result, not the absolute req/s.
+
 ## Running Benchmarks
 
 To reproduce these benchmarks with fair Docker-to-Docker comparison:

--- a/apps/marketing/app/components/marketing/ConfigSection.vue
+++ b/apps/marketing/app/components/marketing/ConfigSection.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   const configFeatures = [
-      'Multiple tile sources (PMTiles, MBTiles, dir, tar, PostGIS, COG)',
+      'Multiple tile sources (PMTiles, MBTiles, dir, tar, PostGIS, COG, DEM)',
+    'On-the-fly DEM terrain-RGB encoding (Terrarium & Mapbox-RGB)',
     'TOML or YAML config, with env-var substitution',
     'In-memory tile caching with TTL',
     'Glob & regex CORS allow-lists, custom response headers',

--- a/apps/marketing/app/composables/use-marketing-page.ts
+++ b/apps/marketing/app/composables/use-marketing-page.ts
@@ -25,6 +25,7 @@ import {
   FileCode2,
   Plug,
   FileArchive,
+  Mountain,
 } from '@lucide/vue';
 import type {
   Feature,
@@ -80,6 +81,13 @@ export function useMarketingPage() {
       title: 'Cloud Optimized GeoTIFF',
       description:
         'Serve raster tiles from COG files with on-the-fly reprojection and colormap support.',
+      category: 'Data formats',
+    },
+    {
+      icon: Mountain,
+      title: 'DEM terrain-RGB encoding',
+      description:
+        'On-the-fly Terrarium & Mapbox-RGB encoding from any GDAL DEM — ~4–10× faster than titiler, ready for MapLibre 3D terrain.',
       category: 'Data formats',
     },
     {
@@ -398,6 +406,13 @@ export function useMarketingPage() {
       label: '% faster MVT→MLT transcode',
       detail: 'mlt-core 0.11 native reader on z4–z13 tiles',
       prefix: '~',
+    },
+    {
+      icon: Mountain,
+      value: 10,
+      label: '× faster DEM terrain-RGB vs titiler',
+      detail: 'Live Terrarium encode: 130 vs 28 avg req/s',
+      prefix: 'up to ',
     },
   ];
 

--- a/benchmarks/config.docker.toml
+++ b/benchmarks/config.docker.toml
@@ -102,6 +102,14 @@ name = "Benchmark RGB COG"
 attribution = "© tileserver-rs benchmarks"
 
 [[sources]]
+id = "terrain-terrarium"
+type = "dem"
+path = "/data/raster/test-dem.cog.tif"
+name = "Benchmark DEM (Terrarium)"
+attribution = "© tileserver-rs benchmarks"
+dem_encoding = "terrarium"
+
+[[sources]]
 id = "sentinel2-static"
 type = "stac"
 path = "https://earth-search.aws.element84.com/v1"

--- a/benchmarks/results/README.md
+++ b/benchmarks/results/README.md
@@ -40,6 +40,35 @@ Martin re-encodes brotli per request with no cache and collapses to 107 req/s
 because tileserver-rs defaults to `br_quality = 5` for first-paint latency;
 raise it when precomputing. zstd and gzip are at parity across both servers.
 
+## DEM terrain-RGB encoding (#1008)
+
+`node run-benchmarks.js --type dem` — live on-the-fly DEM → Terrarium PNG
+encoding from the SF-Bay `test-dem.cog.tif` fixture (EPSG:4326, elevations
+−41..1041 m), 10s / 100 connections, 0 errors on both servers. titiler
+(`algorithm=terrarium`, the only apples-to-apples live competitor; its
+terrain-RGB feature merged Apr 2025) vs tileserver-rs.
+
+| Server        | Zoom | Req/s | Avg ms  | P99 ms  |
+| ------------- | ---- | ----- | ------- | ------- |
+| tileserver-rs | z9   | 203   | 487     | 642     |
+| tileserver-rs | z10  | 148   | 664     | 969     |
+| tileserver-rs | z11  | 86    | 1152    | 1694    |
+| tileserver-rs | z12  | 83    | 1274    | 2642    |
+| titiler       | z9   | 50    | 1803    | 3778    |
+| titiler       | z10  | 35    | 2472    | 5347    |
+| titiler       | z11  | 21    | 3993    | 7096    |
+| titiler       | z12  | 8     | 5045    | 10061   |
+
+Headline: tileserver-rs serves live DEM terrain-RGB **~4–10× faster** than
+titiler (130 vs 28 avg req/s, 894 vs 3328 ms avg latency) with **byte-accurate
+encoding** — a round-trip decode of an encoded tile reproduces the source
+elevation within the encoding interval (≤0.1 m Mapbox-RGB, ≤1/256 m Terrarium).
+The gap widens at high zoom (10.4× at z12) where titiler's per-request Python /
+rasterio cost dominates. Honest caveat: titiler reads from a `file://` COG here
+(no network), the most favourable setup for it; numbers are single-run on an
+Apple-Silicon Docker host, so treat the ratio (not the absolute req/s) as the
+portable result.
+
 ## MVT→MLT transcode: native mlt-core 0.11 reader
 
 `cargo bench --features mlt --bench mlt -- mvt_to_mlt_transcode` — real

--- a/benchmarks/run-benchmarks.js
+++ b/benchmarks/run-benchmarks.js
@@ -84,6 +84,10 @@ const SERVERS = {
       source: 'cog-rgb',
       tileUrl: (z, x, y) => `http://127.0.0.1:8901/data/cog-rgb/${z}/${x}/${y}.png`,
     },
+    dem: {
+      source: 'terrain-terrarium',
+      tileUrl: (z, x, y) => `http://127.0.0.1:8901/data/terrain-terrarium/${z}/${x}/${y}.png`,
+    },
     ogc: {
       source: 'ogc-features',
       endpointUrl: (path) => `http://127.0.0.1:8901${path}`,
@@ -125,6 +129,13 @@ const SERVERS = {
       source: 'benchmark-rgb',
       tileUrl: (z, x, y) => `http://127.0.0.1:8903/cog/tiles/WebMercatorQuad/${z}/${x}/${y}.png?url=file:///data/raster/benchmark-rgb.cog.tif`,
     },
+    // titiler's live DEM terrain-RGB algorithm (merged Apr 2025). This is the
+    // only apples-to-apples competitor for on-the-fly DEM encoding.
+    dem: {
+      source: 'test-dem',
+      tileUrl: (z, x, y) =>
+        `http://127.0.0.1:8903/cog/tiles/WebMercatorQuad/${z}/${x}/${y}.png?url=file:///data/raster/test-dem.cog.tif&algorithm=terrarium`,
+    },
     stac: {
       source: 'benchmark-rgb',
       tileUrl: (z, x, y) =>
@@ -142,6 +153,7 @@ const PROTOCOL_SUPPORT = {
   postgres: { 'tileserver-gl': '✗', 'tileserver-rs': '✓', martin: '✓', titiler: '✗' },
   postgres_function: { 'tileserver-gl': '✗', 'tileserver-rs': '✓', martin: '✓', titiler: '✗' },
   cog: { 'tileserver-gl': '✗', 'tileserver-rs': '✓', martin: '✗', titiler: '✓' },
+  dem: { 'tileserver-gl': '✗', 'tileserver-rs': '✓', martin: '✗', titiler: '✓' },
   raster: { 'tileserver-gl': '✓', 'tileserver-rs': '✓', martin: '✗', titiler: '✗' },
   ogc: { 'tileserver-gl': '✗', 'tileserver-rs': '✓', martin: '✗', titiler: '✗' },
   stac: { 'tileserver-gl': '✗', 'tileserver-rs': '✓', martin: '✗', titiler: '◐' },
@@ -200,6 +212,14 @@ const TEST_TILES = {
     { z: 2, x: 2, y: 1, desc: 'World z2' },
     { z: 3, x: 4, y: 3, desc: 'World z3' },
   ],
+  // Tiles overlapping the SF-Bay test DEM fixture (lon −122.5..−122.3,
+  // lat 37.7..37.9) — real terrain, not empty ocean, across zoom levels.
+  dem: [
+    { z: 9, x: 81, y: 197, desc: 'SF Bay z9' },
+    { z: 10, x: 163, y: 395, desc: 'SF Bay z10' },
+    { z: 11, x: 327, y: 791, desc: 'SF Bay z11' },
+    { z: 12, x: 655, y: 1582, desc: 'SF Bay z12' },
+  ],
   raster: [
     { z: 10, x: 544, y: 373, desc: 'Florence z10' },
     { z: 11, x: 1088, y: 746, desc: 'Florence z11' },
@@ -245,6 +265,10 @@ const GRID_TILES = {
     { z: 2, x: 2, y: 1, desc: 'World z2' },
     { z: 3, x: 4, y: 3, desc: 'World z3' },
     { z: 4, x: 8, y: 6, desc: 'World z4' },
+  ],
+  dem: [
+    { z: 10, x: 163, y: 395, desc: 'SF Bay z10' },
+    { z: 11, x: 327, y: 791, desc: 'SF Bay z11' },
   ],
   raster: [
     { z: 13, x: 4352, y: 2986, desc: 'Florence z13' },
@@ -1057,7 +1081,7 @@ ${generateProtocolMatrix()}### Summary
 
   md += `\n### Detailed Results\n\n`;
 
-  for (const format of ['pmtiles', 'mbtiles', 'postgres', 'postgres_function', 'cog', 'raster', 'ogc', 'stac', 'compression']) {
+  for (const format of ['pmtiles', 'mbtiles', 'postgres', 'postgres_function', 'cog', 'dem', 'raster', 'ogc', 'stac', 'compression']) {
     const filtered = results.filter((r) => r.format === format);
     if (filtered.length === 0) continue;
 
@@ -1123,7 +1147,7 @@ simultaneously to fill the viewport. This benchmark measures **time to fill one 
 
   md += `\n### Detailed Results\n\n`;
 
-  for (const format of ['pmtiles', 'mbtiles', 'postgres', 'postgres_function', 'cog', 'raster', 'ogc', 'stac', 'compression']) {
+  for (const format of ['pmtiles', 'mbtiles', 'postgres', 'postgres_function', 'cog', 'dem', 'raster', 'ogc', 'stac', 'compression']) {
     const filtered = results.filter((r) => r.format === format);
     if (filtered.length === 0) continue;
 
@@ -1168,7 +1192,7 @@ async function main() {
   program
     .option('-s, --server <server>', 'Server to test: tileserver-rs, martin, tileserver-gl, titiler, or all', 'all')
     .option('-f, --format <format>', 'Alias for --type (legacy)', undefined)
-    .option('-t, --type <type>', 'Benchmark type: pmtiles, mbtiles, postgres, postgres_function, cog, raster, ogc, stac, compression, or all', 'all')
+    .option('-t, --type <type>', 'Benchmark type: pmtiles, mbtiles, postgres, postgres_function, cog, dem, raster, ogc, stac, compression, or all', 'all')
     .option('-d, --duration <seconds>', 'Test duration in seconds (single mode)', '10')
     .option('-c, --connections <num>', 'Number of connections (single mode)', '100')
     .option('-m, --mode <mode>', 'Benchmark mode: single (throughput) or grid (viewport simulation)', 'single')
@@ -1204,7 +1228,7 @@ async function main() {
   const typeArg = opts.type ?? opts.format ?? 'all';
   const formatsToTest =
     typeArg === 'all'
-      ? ['pmtiles', 'mbtiles', 'postgres', 'postgres_function', 'cog', 'raster', 'ogc', 'stac', 'compression']
+      ? ['pmtiles', 'mbtiles', 'postgres', 'postgres_function', 'cog', 'dem', 'raster', 'ogc', 'stac', 'compression']
       : [typeArg];
 
   // Check server availability

--- a/crates/tileserver-rs/Cargo.toml
+++ b/crates/tileserver-rs/Cargo.toml
@@ -125,7 +125,7 @@ rsa              = { version = "0.9", optional = true, features = ["pem"] }
 subtle           = { workspace = true, optional = true }
 
 [features]
-default = ["postgres", "raster", "mlt", "cloud", "stac"]
+default = ["postgres", "raster", "mlt", "cloud", "stac", "dem"]
 frontend = ["rust-embed"]
 postgres = ["deadpool-postgres", "tokio-postgres", "postgres-types", "semver", "dep:ogcapi-types", "dep:geojson", "dep:cql2"]
 postgres-integration = ["postgres"]
@@ -135,6 +135,7 @@ mlt = ["mlt-core", "dep:prost", "geo-types"]
 geoparquet = ["dep:parquet", "dep:arrow-array", "dep:arrow-schema", "dep:arrow-cast", "dep:geo", "dep:prost"]
 duckdb = ["dep:duckdb", "dep:prost"]
 stac = ["raster", "dep:stac"]
+dem = ["raster"]
 # MCP server (stdio + Streamable HTTP). Opt-in to keep default builds slim
 # and avoid pulling rmcp into every `cargo build` invocation. The `subtle`
 # crate is enabled here so the OAuth bearer + PKCE comparisons in
@@ -199,6 +200,11 @@ required-features = ["stac"]
 name = "cog"
 harness = false
 required-features = ["stac"]
+
+[[bench]]
+name = "dem"
+harness = false
+required-features = ["dem"]
 
 [[bench]]
 name = "postgres"

--- a/crates/tileserver-rs/benches/dem.rs
+++ b/crates/tileserver-rs/benches/dem.rs
@@ -1,0 +1,15 @@
+//! Benchmarks for DEM (Digital Elevation Model) hot paths.
+//!
+//! Initialised as a placeholder so `cargo bench --bench dem --features dem`
+//! resolves the manifest entry. Real benchmarks for the Terrarium / Mapbox-RGB
+//! encoders + a full DEM tile encode land in a follow-up wave once the
+//! encoder pure fns settle. See `sources/dem.rs::encode_*`.
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+fn bench_placeholder(c: &mut Criterion) {
+    c.bench_function("dem_placeholder", |b| b.iter(|| 1 + 1));
+}
+
+criterion_group!(benches, bench_placeholder);
+criterion_main!(benches);

--- a/crates/tileserver-rs/benches/dem.rs
+++ b/crates/tileserver-rs/benches/dem.rs
@@ -1,15 +1,81 @@
-//! Benchmarks for DEM (Digital Elevation Model) hot paths.
+//! Benchmarks for DEM (Digital Elevation Model) encoder hot paths.
 //!
-//! Initialised as a placeholder so `cargo bench --bench dem --features dem`
-//! resolves the manifest entry. Real benchmarks for the Terrarium / Mapbox-RGB
-//! encoders + a full DEM tile encode land in a follow-up wave once the
-//! encoder pure fns settle. See `sources/dem.rs::encode_*`.
+//! Run with: `cargo bench --bench dem --features dem`
+//!
+//! Covers the two pure encoders (Terrarium / Mapbox-RGB) and a full
+//! tile-sized pixel encode, which is the per-tile cost on the serving
+//! hot path once GDAL has produced the float elevation grid.
 
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use tileserver_rs::config::DemEncoding;
+use tileserver_rs::sources::dem::{EncodeParams, encode_mapbox, encode_pixels, encode_terrarium};
 
-fn bench_placeholder(c: &mut Criterion) {
-    c.bench_function("dem_placeholder", |b| b.iter(|| 1 + 1));
+const ELEVATIONS: &[f64] = &[0.0, 100.5, 1000.5, 2523.266, 8848.86, -41.386, 407.2];
+
+fn bench_encode_terrarium(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dem_encode_terrarium");
+    group.bench_function("single", |b| {
+        b.iter(|| {
+            for &e in ELEVATIONS {
+                black_box(encode_terrarium(black_box(e)));
+            }
+        });
+    });
+    group.finish();
 }
 
-criterion_group!(benches, bench_placeholder);
+fn bench_encode_mapbox(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dem_encode_mapbox");
+    group.bench_function("single", |b| {
+        b.iter(|| {
+            for &e in ELEVATIONS {
+                black_box(encode_mapbox(black_box(e)));
+            }
+        });
+    });
+    group.finish();
+}
+
+fn bench_encode_tile(c: &mut Criterion) {
+    // 256x256 float grid sweeping the real-terrain range, ~10% nodata —
+    // representative of the per-tile encode cost after the GDAL read.
+    let pixels = 256 * 256;
+    let grid: Vec<f64> = (0..pixels)
+        .map(|i| {
+            if i % 10 == 0 {
+                f64::NAN
+            } else {
+                (i as f64 % 4000.0) - 41.0
+            }
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("dem_encode_tile_256");
+    group.throughput(Throughput::Elements(pixels as u64));
+    for encoding in [DemEncoding::Terrarium, DemEncoding::MapboxRgb] {
+        let params = EncodeParams {
+            encoding,
+            scale: 1.0,
+            offset: 0.0,
+            nodata_value: None,
+            nodata_rgba: [0, 0, 0, 0],
+        };
+        let label = match encoding {
+            DemEncoding::Terrarium => "terrarium",
+            DemEncoding::MapboxRgb => "mapbox_rgb",
+        };
+        group.bench_function(label, |b| {
+            b.iter(|| black_box(encode_pixels(black_box(&grid), black_box(&params))));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_encode_terrarium,
+    bench_encode_mapbox,
+    bench_encode_tile
+);
 criterion_main!(benches);

--- a/crates/tileserver-rs/src/autodetect.rs
+++ b/crates/tileserver-rs/src/autodetect.rs
@@ -462,6 +462,28 @@ mod tests {
     }
 
     #[test]
+    fn test_source_type_suffix_all_variants() {
+        assert_eq!(source_type_suffix(&SourceType::PMTiles), "pmtiles");
+        assert_eq!(source_type_suffix(&SourceType::MBTiles), "mbtiles");
+        assert_eq!(source_type_suffix(&SourceType::Dir), "dir");
+        assert_eq!(source_type_suffix(&SourceType::Tar), "tar");
+        #[cfg(feature = "postgres")]
+        assert_eq!(source_type_suffix(&SourceType::Postgres), "postgres");
+        #[cfg(feature = "raster")]
+        assert_eq!(source_type_suffix(&SourceType::Cog), "cog");
+        #[cfg(feature = "raster")]
+        assert_eq!(source_type_suffix(&SourceType::Vrt), "vrt");
+        #[cfg(feature = "geoparquet")]
+        assert_eq!(source_type_suffix(&SourceType::GeoParquet), "geoparquet");
+        #[cfg(feature = "duckdb")]
+        assert_eq!(source_type_suffix(&SourceType::DuckDB), "duckdb");
+        #[cfg(feature = "stac")]
+        assert_eq!(source_type_suffix(&SourceType::Stac), "stac");
+        #[cfg(feature = "dem")]
+        assert_eq!(source_type_suffix(&SourceType::Dem), "dem");
+    }
+
+    #[test]
     fn test_detect_source_type_extensions() {
         assert_eq!(
             detect_source_type(Path::new("foo.pmtiles")),

--- a/crates/tileserver-rs/src/autodetect.rs
+++ b/crates/tileserver-rs/src/autodetect.rs
@@ -56,6 +56,8 @@ fn source_type_suffix(source_type: &SourceType) -> &'static str {
         SourceType::DuckDB => "duckdb",
         #[cfg(feature = "stac")]
         SourceType::Stac => "stac",
+        #[cfg(feature = "dem")]
+        SourceType::Dem => "dem",
     }
 }
 
@@ -137,6 +139,18 @@ fn auto_source_config(id: String, source_type: SourceType, path: &Path) -> Sourc
         pixel_selection: crate::config::PixelSelectionMethod::First,
         tile_path_template: None,
         tms: false,
+        #[cfg(feature = "dem")]
+        input_source: None,
+        #[cfg(feature = "dem")]
+        dem_encoding: crate::config::DemEncoding::Terrarium,
+        #[cfg(feature = "dem")]
+        dem_scale: None,
+        #[cfg(feature = "dem")]
+        dem_offset: None,
+        #[cfg(feature = "dem")]
+        dem_band: 1,
+        #[cfg(feature = "dem")]
+        dem_nodata_color: None,
     }
 }
 

--- a/crates/tileserver-rs/src/config.rs
+++ b/crates/tileserver-rs/src/config.rs
@@ -571,6 +571,30 @@ pub struct SourceConfig {
     /// archives.
     #[serde(default)]
     pub tms: bool,
+    #[cfg(feature = "dem")]
+    #[serde(default)]
+    pub input_source: Option<String>,
+    #[cfg(feature = "dem")]
+    #[serde(default)]
+    pub dem_encoding: DemEncoding,
+    /// Per-band scalar applied before encoding as `encoded = (value * scale + offset) * precision`.
+    /// Use for unit conversion (e.g. source stores feet, consumers want metres).
+    #[cfg(feature = "dem")]
+    #[serde(default)]
+    pub dem_scale: Option<f64>,
+    #[cfg(feature = "dem")]
+    #[serde(default)]
+    pub dem_offset: Option<f64>,
+    #[cfg(feature = "dem")]
+    #[serde(default = "default_dem_band")]
+    pub dem_band: usize,
+    /// RGB triplet written for nodata pixels. MapLibre GL JS IGNORES the
+    /// tile's alpha channel — the sentinel RGB must encode "no data" in
+    /// both encodings. Default Mapbox: `(1, 134, 160)`. Default Terrarium:
+    /// `(0, 0, 0)`. See `sources/dem.rs::nodata_rgb`.
+    #[cfg(feature = "dem")]
+    #[serde(default)]
+    pub dem_nodata_color: Option<[u8; 4]>,
 }
 
 /// Pixel-selection strategy for STAC mosaic compositing.
@@ -648,6 +672,28 @@ pub enum SourceType {
     DuckDB,
     #[cfg(feature = "stac")]
     Stac,
+    /// Digital Elevation Model source. Reads float elevation from a GDAL
+    /// raster (COG / GeoTIFF, optionally referencing another already-loaded
+    /// `[[sources]]` entry) and re-encodes pixels as Terrarium or Mapbox-RGB
+    /// (`terrain-rgb`) PNG tiles MapLibre GL JS consumes as a `raster-dem`
+    /// source. See `[[sources]]` `input_source`, `dem_encoding`, `dem_scale`,
+    /// `dem_offset`, `dem_band`, `dem_nodata_color` for configuration.
+    #[cfg(feature = "dem")]
+    Dem,
+}
+
+/// Output RGB encoding for a DEM source. Both are MapLibre-GL-compatible
+/// `raster-dem` formats:
+/// - `Terrarium` (default) — `decoded = R*256 + G + B/256 - 32768`,
+///   precision 1/256 m (~0.004 m).
+/// - `MapboxRgb` — `decoded = -10000 + (R*65536 + G*256 + B) * 0.1`,
+///   precision 0.1 m.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DemEncoding {
+    #[default]
+    Terrarium,
+    MapboxRgb,
 }
 
 fn default_stac_asset_role() -> String {
@@ -656,6 +702,11 @@ fn default_stac_asset_role() -> String {
 
 fn default_stac_max_items() -> usize {
     100
+}
+
+#[cfg(feature = "dem")]
+fn default_dem_band() -> usize {
+    1
 }
 
 /// GDAL-compatible resampling algorithm for rescaling a source raster

--- a/crates/tileserver-rs/src/config.rs
+++ b/crates/tileserver-rs/src/config.rs
@@ -503,7 +503,10 @@ pub struct SourceConfig {
     /// Type of source: "pmtiles" or "mbtiles"
     #[serde(rename = "type")]
     pub source_type: SourceType,
-    /// Path to the file (local path, HTTP URL, or S3 URL)
+    /// Path to the file (local path, HTTP URL, or S3 URL). Defaults to
+    /// empty: a DEM source that sets `input_source` reads through the
+    /// referenced source and needs no path of its own.
+    #[serde(default)]
     pub path: String,
     /// Optional display name
     pub name: Option<String>,

--- a/crates/tileserver-rs/src/config_schema.rs
+++ b/crates/tileserver-rs/src/config_schema.rs
@@ -92,6 +92,7 @@ const SOURCE_TYPES: &[&str] = &[
     "geoparquet",
     "duckdb",
     "stac",
+    "dem",
 ];
 
 const PIXEL_SELECTION: &[&str] = &[
@@ -106,6 +107,8 @@ const PIXEL_SELECTION: &[&str] = &[
 ];
 
 const SERVE_AS: &[&str] = &["pbf", "mvt", "mlt", "png", "jpeg", "webp"];
+
+const DEM_ENCODINGS: &[&str] = &["terrarium", "mapbox_rgb"];
 
 const METRICS_CARDINALITY: &[&str] = &["strict", "standard", "verbose"];
 
@@ -609,6 +612,54 @@ pub static CONFIG_SCHEMA: &[ConfigSectionSchema] = &[
                 field_type: "bool",
                 default: Some("false"),
                 description: "Use TMS (south-up) addressing for dir/tar sources. Default false = XYZ.",
+                optional: true,
+                enum_values: None,
+            },
+            ConfigFieldSchema {
+                key: "input_source",
+                field_type: "string",
+                default: None,
+                description: "Reference another [[sources]] entry by id whose underlying raster tiles will be re-encoded as DEM. When set, `path` is ignored on this source. Requires the target source to load first.",
+                optional: true,
+                enum_values: None,
+            },
+            ConfigFieldSchema {
+                key: "dem_encoding",
+                field_type: "enum",
+                default: Some("\"terrarium\""),
+                description: "DEM RGB encoding for the tile PNG. `terrarium` (default) yields 1/256 m precision, `mapbox_rgb` yields 0.1 m precision and is the legacy `terrain-rgb` Mapbox tile format.",
+                optional: true,
+                enum_values: Some(DEM_ENCODINGS),
+            },
+            ConfigFieldSchema {
+                key: "dem_scale",
+                field_type: "f64",
+                default: None,
+                description: "Multiplicative scale applied to source elevation before encoding. Useful for unit conversion (e.g. feet -> metres: 0.3048).",
+                optional: true,
+                enum_values: None,
+            },
+            ConfigFieldSchema {
+                key: "dem_offset",
+                field_type: "f64",
+                default: None,
+                description: "Additive offset applied to source elevation before encoding (after scale).",
+                optional: true,
+                enum_values: None,
+            },
+            ConfigFieldSchema {
+                key: "dem_band",
+                field_type: "u32",
+                default: Some("1"),
+                description: "GDAL raster band to encode (1-indexed). Default 1.",
+                optional: true,
+                enum_values: None,
+            },
+            ConfigFieldSchema {
+                key: "dem_nodata_color",
+                field_type: "u8[4]",
+                default: None,
+                description: "RGBA sentinel for nodata pixels as [r, g, b, a]. MapLibre GL JS IGNORES alpha so the RGB must encode \"no data\". Default for mapbox_rgb: [1, 134, 160]. Default for terrarium: [0, 0, 0].",
                 optional: true,
                 enum_values: None,
             },

--- a/crates/tileserver-rs/src/sources/cog.rs
+++ b/crates/tileserver-rs/src/sources/cog.rs
@@ -102,6 +102,14 @@ impl CogSource {
         self.default_resampling
     }
 
+    /// Share this source's cached GDAL dataset handle so a wrapping source
+    /// (e.g. a DEM source whose `input_source` points here) can read the
+    /// same float bands without re-opening the file.
+    #[must_use]
+    pub fn dataset_handle(&self) -> Arc<Mutex<Dataset>> {
+        Arc::clone(&self.dataset)
+    }
+
     pub async fn get_tile_with_resampling(
         &self,
         z: u8,
@@ -289,6 +297,10 @@ fn tile_to_web_mercator_bbox(z: u8, x: u32, y: u32) -> (f64, f64, f64, f64) {
     let miny = maxy - tile_size;
 
     (minx, miny, maxx, maxy)
+}
+
+pub(crate) fn wgs84_bounds(dataset: &Dataset) -> Result<[f64; 4]> {
+    get_wgs84_bounds(dataset)
 }
 
 fn get_wgs84_bounds(dataset: &Dataset) -> Result<[f64; 4]> {

--- a/crates/tileserver-rs/src/sources/dem.rs
+++ b/crates/tileserver-rs/src/sources/dem.rs
@@ -1,0 +1,607 @@
+//! Digital Elevation Model (DEM) raster tile source.
+//!
+//! Reads float elevation from a GDAL raster (COG / GeoTIFF, optionally
+//! referencing another already-loaded `[[sources]]` entry) and re-encodes
+//! each pixel as a Terrarium or Mapbox-RGB (`terrain-rgb`) PNG tile that
+//! MapLibre GL JS consumes as a `raster-dem` source.
+//!
+//! ## Encoding correctness
+//!
+//! Both encodings are bit-exact to what MapLibre GL JS decodes
+//! (`src/data/dem_data.ts`):
+//!
+//! - **Terrarium** (`decoded = R*256 + G + B/256 - 32768`), precision
+//!   `1/256 m` (~0.0039 m). Nodata sentinel `(0, 0, 0)` = −32768 m.
+//! - **Mapbox-RGB** (`decoded = -10000 + (R*65536 + G*256 + B) * 0.1`),
+//!   precision `0.1 m`. Nodata sentinel `(1, 134, 160)` = sea level.
+//!
+//! ## The round-before-truncate rule
+//!
+//! The encoders round the scaled elevation to the nearest integer BEFORE
+//! splitting into bytes. Truncating instead produces a systematic 1-LSB
+//! (one elevation-interval) error — the classic `rio-rgbify` rounding bug.
+//! MapLibre's own `packDEMData` rounds for exactly this reason.
+//!
+//! ## Why a sentinel RGB and not alpha
+//!
+//! MapLibre's `DEMData` constructor only reads R, G, B — it IGNORES the
+//! alpha channel. A transparent pixel still decodes its RGB to a (usually
+//! garbage) elevation. So nodata pixels MUST carry a sentinel RGB that
+//! decodes to an obviously-out-of-range elevation; alpha is cosmetic only.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use gdal::Dataset;
+use gdal::raster::{Buffer, ResampleAlg};
+use gdal::spatial_ref::SpatialRef;
+use gdal::{DriverManager, raster::reproject};
+use image::{ImageBuffer, RgbaImage};
+use std::io::Cursor;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use crate::config::{DemEncoding, ResamplingMethod, SourceConfig};
+use crate::error::{Result, TileServerError};
+use crate::sources::cog::CogSource;
+use crate::sources::dataset_cache;
+use crate::sources::{TileCompression, TileData, TileFormat, TileMetadata, TileSource};
+
+const WEB_MERCATOR_EXTENT: f64 = 20037508.342789244;
+
+/// Terrarium base offset in metres (`decoded = packed - 32768`).
+const TERRARIUM_BASE: f64 = 32768.0;
+/// Mapbox-RGB base offset in metres (`decoded = -10000 + packed * 0.1`).
+const MAPBOX_BASE: f64 = -10000.0;
+/// Mapbox-RGB precision in metres per least-significant-bit.
+const MAPBOX_INTERVAL: f64 = 0.1;
+/// Largest packed value representable in 24 bits (`2^24 - 1`).
+const MAX_U24: f64 = 16_777_215.0;
+
+/// Default Terrarium nodata sentinel: `(0, 0, 0)` decodes to −32768 m.
+const TERRARIUM_NODATA: [u8; 3] = [0, 0, 0];
+/// Default Mapbox-RGB nodata sentinel: `(1, 134, 160)` decodes to 0 m
+/// (sea level), the Mapbox convention for "no data / ocean".
+const MAPBOX_NODATA: [u8; 3] = [1, 134, 160];
+
+/// Encode an elevation (metres) as a Terrarium RGB triplet.
+///
+/// `decoded = R*256 + G + B/256 - 32768`. The packed value is rounded to
+/// the nearest `1/256 m` before splitting into bytes (round-before-truncate)
+/// and clamped to `[0, 0xFFFFFF]` so absurd inputs can't wrap a byte.
+#[must_use]
+pub fn encode_terrarium(elevation: f64) -> [u8; 3] {
+    // Work in 1/256-m units so the blue byte is an exact integer; round to
+    // nearest before splitting (the round-before-truncate rule), then clamp
+    // to the 24-bit packed range [0, 256^3 - 1].
+    let units = ((elevation + TERRARIUM_BASE) * 256.0).round();
+    let packed = units.clamp(0.0, MAX_U24) as u32;
+    let r = (packed >> 16) & 0xFF;
+    let g = (packed >> 8) & 0xFF;
+    let b = packed & 0xFF;
+    [r as u8, g as u8, b as u8]
+}
+
+/// Encode an elevation (metres) as a Mapbox-RGB (`terrain-rgb`) triplet.
+///
+/// `decoded = -10000 + (R*65536 + G*256 + B) * 0.1`. Rounds to the
+/// nearest 0.1 m then clamps to the 24-bit packed range.
+#[must_use]
+pub fn encode_mapbox(elevation: f64) -> [u8; 3] {
+    let packed = ((elevation - MAPBOX_BASE) / MAPBOX_INTERVAL)
+        .round()
+        .clamp(0.0, MAX_U24) as u32;
+    let r = (packed >> 16) & 0xFF;
+    let g = (packed >> 8) & 0xFF;
+    let b = packed & 0xFF;
+    [r as u8, g as u8, b as u8]
+}
+
+/// Decode a Terrarium RGB triplet back to metres (for round-trip tests).
+#[must_use]
+pub fn decode_terrarium(rgb: [u8; 3]) -> f64 {
+    f64::from(rgb[0]) * 256.0 + f64::from(rgb[1]) + f64::from(rgb[2]) / 256.0 - TERRARIUM_BASE
+}
+
+/// Decode a Mapbox-RGB triplet back to metres (for round-trip tests).
+#[must_use]
+pub fn decode_mapbox(rgb: [u8; 3]) -> f64 {
+    MAPBOX_BASE
+        + (f64::from(rgb[0]) * 65536.0 + f64::from(rgb[1]) * 256.0 + f64::from(rgb[2]))
+            * MAPBOX_INTERVAL
+}
+
+/// Encode an elevation with the chosen encoding.
+#[must_use]
+pub fn encode_elevation(elevation: f64, encoding: DemEncoding) -> [u8; 3] {
+    match encoding {
+        DemEncoding::Terrarium => encode_terrarium(elevation),
+        DemEncoding::MapboxRgb => encode_mapbox(elevation),
+    }
+}
+
+/// Decode an RGB triplet with the chosen encoding.
+#[must_use]
+pub fn decode_elevation(rgb: [u8; 3], encoding: DemEncoding) -> f64 {
+    match encoding {
+        DemEncoding::Terrarium => decode_terrarium(rgb),
+        DemEncoding::MapboxRgb => decode_mapbox(rgb),
+    }
+}
+
+/// The RGBA sentinel written for nodata pixels.
+///
+/// `override_color` (the source's `dem_nodata_color`) wins when present;
+/// otherwise the encoding-specific default sentinel is used with a fully
+/// transparent alpha so a client that DOES honour alpha hides the pixel.
+#[must_use]
+pub fn nodata_rgba(encoding: DemEncoding, override_color: Option<[u8; 4]>) -> [u8; 4] {
+    if let Some(rgba) = override_color {
+        return rgba;
+    }
+    let [r, g, b] = match encoding {
+        DemEncoding::Terrarium => TERRARIUM_NODATA,
+        DemEncoding::MapboxRgb => MAPBOX_NODATA,
+    };
+    [r, g, b, 0]
+}
+
+/// Tunables that turn a float elevation grid into an encoded RGBA buffer.
+#[derive(Debug, Clone, Copy)]
+pub struct EncodeParams {
+    pub encoding: DemEncoding,
+    pub scale: f64,
+    pub offset: f64,
+    pub nodata_value: Option<f64>,
+    pub nodata_rgba: [u8; 4],
+}
+
+/// Encode a row-major float elevation grid into a row-major RGBA byte buffer.
+///
+/// A pixel equal to `nodata_value`, or non-finite (NaN/±inf from a GDAL
+/// masked read), is written as the nodata sentinel. Every other pixel is
+/// `(value * scale + offset)` fed through the chosen encoder with opaque alpha.
+#[must_use]
+pub fn encode_pixels(values: &[f64], params: &EncodeParams) -> Vec<u8> {
+    let mut out = Vec::with_capacity(values.len() * 4);
+    for &raw in values {
+        let is_nodata = !raw.is_finite()
+            || params
+                .nodata_value
+                .is_some_and(|nd| (raw - nd).abs() < f64::EPSILON);
+        if is_nodata {
+            out.extend_from_slice(&params.nodata_rgba);
+        } else {
+            let elevation = raw * params.scale + params.offset;
+            let [r, g, b] = encode_elevation(elevation, params.encoding);
+            out.extend_from_slice(&[r, g, b, 255]);
+        }
+    }
+    out
+}
+
+/// A DEM tile source: float elevation in, Terrarium/Mapbox-RGB PNG out.
+pub struct DemSource {
+    dataset: Arc<Mutex<Dataset>>,
+    metadata: TileMetadata,
+    resampling: ResamplingMethod,
+    band: usize,
+    params: EncodeParams,
+}
+
+impl DemSource {
+    /// Build a DEM source from config, resolving `input_source` (the id of
+    /// another already-loaded raster source) against `loaded` when present,
+    /// otherwise opening the source's own `path`.
+    pub async fn from_config(
+        config: &SourceConfig,
+        loaded: &std::collections::HashMap<String, Arc<dyn TileSource>>,
+    ) -> Result<Self> {
+        let dataset = Self::resolve_dataset(config, loaded).await?;
+
+        let dataset_for_inspect = Arc::clone(&dataset);
+        let bounds = tokio::task::spawn_blocking(move || {
+            let guard = dataset_for_inspect.blocking_lock();
+            if guard.raster_count() == 0 {
+                return Err(TileServerError::RasterError(
+                    "DEM source has no raster bands".to_string(),
+                ));
+            }
+            crate::sources::cog::wgs84_bounds(&guard)
+        })
+        .await
+        .map_err(|e| TileServerError::RasterError(format!("task failed: {e}")))??;
+
+        let encoding = config.dem_encoding;
+        let params = EncodeParams {
+            encoding,
+            scale: config.dem_scale.unwrap_or(1.0),
+            offset: config.dem_offset.unwrap_or(0.0),
+            nodata_value: None,
+            nodata_rgba: nodata_rgba(encoding, config.dem_nodata_color),
+        };
+
+        let metadata = TileMetadata {
+            id: config.id.clone(),
+            name: config
+                .name
+                .clone()
+                .unwrap_or_else(|| "DEM Source".to_string()),
+            description: None,
+            attribution: config.attribution.clone(),
+            format: TileFormat::Png,
+            minzoom: 0,
+            maxzoom: 22,
+            bounds: Some(bounds),
+            center: Some([
+                (bounds[0] + bounds[2]) / 2.0,
+                (bounds[1] + bounds[3]) / 2.0,
+                10.0,
+            ]),
+            vector_layers: None,
+        };
+
+        Ok(Self {
+            dataset,
+            metadata,
+            resampling: config.resampling.unwrap_or(ResamplingMethod::Bilinear),
+            band: config.dem_band,
+            params,
+        })
+    }
+
+    async fn resolve_dataset(
+        config: &SourceConfig,
+        loaded: &std::collections::HashMap<String, Arc<dyn TileSource>>,
+    ) -> Result<Arc<Mutex<Dataset>>> {
+        if let Some(ref input_id) = config.input_source {
+            let source = loaded.get(input_id).ok_or_else(|| {
+                TileServerError::ConfigError(format!(
+                    "DEM source '{}' references unknown input_source '{input_id}'",
+                    config.id
+                ))
+            })?;
+            let cog = source.as_any().downcast_ref::<CogSource>().ok_or_else(|| {
+                TileServerError::ConfigError(format!(
+                    "DEM source '{}' input_source '{input_id}' must be a cog/vrt raster source",
+                    config.id
+                ))
+            })?;
+            return Ok(cog.dataset_handle());
+        }
+        dataset_cache::global().get_or_open(&config.path).await
+    }
+
+    /// Render one tile, exposed directly so the manager can request a
+    /// non-default tile size without a second async hop.
+    pub async fn get_tile_sized(
+        &self,
+        z: u8,
+        x: u32,
+        y: u32,
+        tile_size: u32,
+    ) -> Result<Option<TileData>> {
+        let (minx, miny, maxx, maxy) = tile_to_web_mercator_bbox(z, x, y);
+        let dataset = self.dataset.clone();
+        let band = self.band;
+        let resampling: ResampleAlg = self.resampling.into();
+        let params = self.params;
+
+        let png = tokio::task::spawn_blocking(move || {
+            let guard = dataset.blocking_lock();
+            render_dem_tile(
+                &guard, minx, miny, maxx, maxy, tile_size, band, resampling, &params,
+            )
+        })
+        .await
+        .map_err(|e| TileServerError::RasterError(format!("task failed: {e}")))??;
+
+        Ok(Some(TileData {
+            data: Bytes::from(png),
+            format: TileFormat::Png,
+            compression: TileCompression::None,
+        }))
+    }
+}
+
+#[async_trait]
+impl TileSource for DemSource {
+    async fn get_tile(&self, z: u8, x: u32, y: u32) -> Result<Option<TileData>> {
+        self.get_tile_sized(z, x, y, 256).await
+    }
+
+    fn metadata(&self) -> &TileMetadata {
+        &self.metadata
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+fn tile_to_web_mercator_bbox(z: u8, x: u32, y: u32) -> (f64, f64, f64, f64) {
+    let n = 2_u32.pow(u32::from(z)) as f64;
+    let span = 2.0 * WEB_MERCATOR_EXTENT / n;
+    let minx = -WEB_MERCATOR_EXTENT + f64::from(x) * span;
+    let maxy = WEB_MERCATOR_EXTENT - f64::from(y) * span;
+    (minx, maxy - span, minx + span, maxy)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_dem_tile(
+    dataset: &Dataset,
+    minx: f64,
+    miny: f64,
+    maxx: f64,
+    maxy: f64,
+    tile_size: u32,
+    band: usize,
+    resampling: ResampleAlg,
+    params: &EncodeParams,
+) -> Result<Vec<u8>> {
+    let web_mercator = SpatialRef::from_epsg(3857)
+        .map_err(|e| TileServerError::RasterError(format!("failed to create EPSG:3857: {e}")))?;
+    let mem = DriverManager::get_driver_by_name("MEM")
+        .map_err(|e| TileServerError::RasterError(format!("failed to get MEM driver: {e}")))?;
+    let mut warped = mem
+        .create_with_band_type::<f64, _>("", tile_size as usize, tile_size as usize, 1)
+        .map_err(|e| TileServerError::RasterError(format!("failed to create warp target: {e}")))?;
+
+    let px = (maxx - minx) / f64::from(tile_size);
+    let py = (maxy - miny) / f64::from(tile_size);
+    warped
+        .set_geo_transform(&[minx, px, 0.0, maxy, 0.0, -py])
+        .map_err(|e| TileServerError::RasterError(format!("failed to set geotransform: {e}")))?;
+    warped
+        .set_spatial_ref(&web_mercator)
+        .map_err(|e| TileServerError::RasterError(format!("failed to set SRS: {e}")))?;
+    reproject(dataset, &warped)
+        .map_err(|e| TileServerError::RasterError(format!("failed to reproject: {e}")))?;
+
+    let src_band = dataset
+        .rasterband(band)
+        .map_err(|e| TileServerError::RasterError(format!("failed to read band {band}: {e}")))?;
+    let nodata = src_band.no_data_value();
+
+    let out_band = warped
+        .rasterband(1)
+        .map_err(|e| TileServerError::RasterError(format!("failed to read warp band: {e}")))?;
+    let buffer: Buffer<f64> = out_band
+        .read_as::<f64>(
+            (0, 0),
+            (tile_size as usize, tile_size as usize),
+            (tile_size as usize, tile_size as usize),
+            Some(resampling),
+        )
+        .map_err(|e| TileServerError::RasterError(format!("failed to read band: {e}")))?;
+
+    let mut params = *params;
+    params.nodata_value = nodata;
+    let rgba = encode_pixels(buffer.data(), &params);
+
+    let img: RgbaImage = ImageBuffer::from_raw(tile_size, tile_size, rgba)
+        .ok_or_else(|| TileServerError::RasterError("RGBA buffer size mismatch".to_string()))?;
+    let mut png = Vec::new();
+    img.write_to(&mut Cursor::new(&mut png), image::ImageFormat::Png)
+        .map_err(|e| TileServerError::RasterError(format!("failed to encode PNG: {e}")))?;
+    Ok(png)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- Terrarium round-trip (precision 1/256 m ≈ 0.0039 m) ----
+
+    #[test]
+    fn terrarium_roundtrip_within_precision() {
+        // Spread across the full real-terrain range: Mariana Trench floor,
+        // sea level, Everest summit, plus a fractional value that exercises
+        // the blue (sub-metre) byte.
+        for &elev in &[
+            0.0_f64, 2523.266, -10994.0, 8848.86, 1000.5, -11000.0, 8900.0,
+        ] {
+            let rgb = encode_terrarium(elev);
+            let decoded = decode_terrarium(rgb);
+            assert!(
+                (decoded - elev).abs() < 0.005,
+                "terrarium roundtrip elev={elev} rgb={rgb:?} decoded={decoded} err={}",
+                (decoded - elev).abs()
+            );
+        }
+    }
+
+    #[test]
+    fn terrarium_known_vectors() {
+        // 0 m → (128, 0, 0): 128*256 + 0 + 0 - 32768 = 0.
+        assert_eq!(encode_terrarium(0.0), [128, 0, 0], "terrarium sea level");
+        // -32768 m → (0, 0, 0): the nodata sentinel elevation.
+        assert_eq!(encode_terrarium(-32768.0), [0, 0, 0], "terrarium min");
+    }
+
+    #[test]
+    fn terrarium_clamps_out_of_range() {
+        // Below the representable floor clamps to (0,0,0); above the ceiling
+        // clamps to the max triplet — never wraps a byte.
+        assert_eq!(encode_terrarium(-40000.0), [0, 0, 0], "terrarium underflow");
+        assert_eq!(
+            encode_terrarium(40000.0),
+            [255, 255, 255],
+            "terrarium overflow"
+        );
+    }
+
+    // ---- Mapbox-RGB round-trip (precision 0.1 m) ----
+
+    #[test]
+    fn mapbox_roundtrip_within_precision() {
+        for &elev in &[0.0_f64, 407.2, -10000.0, 8848.86, 1000.5, 6553.6, 1234.5] {
+            let rgb = encode_mapbox(elev);
+            let decoded = decode_mapbox(rgb);
+            assert!(
+                (decoded - elev).abs() < 0.05,
+                "mapbox roundtrip elev={elev} rgb={rgb:?} decoded={decoded} err={}",
+                (decoded - elev).abs()
+            );
+        }
+    }
+
+    #[test]
+    fn mapbox_known_vectors() {
+        // -10000 m → (0,0,0): the base of the Mapbox range.
+        assert_eq!(encode_mapbox(-10000.0), [0, 0, 0], "mapbox min");
+        // 0 m → packed = 100000 = 0x0186A0 → (1, 134, 160).
+        assert_eq!(encode_mapbox(0.0), [1, 134, 160], "mapbox sea level");
+    }
+
+    #[test]
+    fn mapbox_clamps_out_of_range() {
+        // Below base clamps to (0,0,0); far above the 24-bit ceiling clamps
+        // to (255,255,255), never wraps.
+        assert_eq!(encode_mapbox(-20000.0), [0, 0, 0], "mapbox underflow");
+        let top = decode_mapbox([255, 255, 255]);
+        assert_eq!(
+            encode_mapbox(top + 1000.0),
+            [255, 255, 255],
+            "mapbox overflow"
+        );
+    }
+
+    #[test]
+    fn mapbox_round_before_truncate() {
+        // The classic rgbify bug: 1000.5 m packs to exactly 110005.0; a
+        // truncating encoder that computed 110004.999.. would lose the LSB.
+        // Round-then-split must land on the exact triplet.
+        let rgb = encode_mapbox(1000.5);
+        let decoded = decode_mapbox(rgb);
+        assert!(
+            (decoded - 1000.5).abs() < 0.001,
+            "mapbox round-before-truncate 1000.5 → {rgb:?} → {decoded}"
+        );
+    }
+
+    // ---- Dispatcher + nodata ----
+
+    #[test]
+    fn encode_dispatch_matches_concrete() {
+        assert_eq!(
+            encode_elevation(1234.5, DemEncoding::Terrarium),
+            encode_terrarium(1234.5)
+        );
+        assert_eq!(
+            encode_elevation(1234.5, DemEncoding::MapboxRgb),
+            encode_mapbox(1234.5)
+        );
+    }
+
+    #[test]
+    fn decode_dispatch_matches_concrete() {
+        assert_eq!(
+            decode_elevation([1, 134, 160], DemEncoding::MapboxRgb),
+            decode_mapbox([1, 134, 160])
+        );
+        assert_eq!(
+            decode_elevation([128, 0, 0], DemEncoding::Terrarium),
+            decode_terrarium([128, 0, 0])
+        );
+    }
+
+    #[test]
+    fn nodata_defaults_per_encoding() {
+        // Terrarium default sentinel decodes to -32768; alpha transparent.
+        assert_eq!(nodata_rgba(DemEncoding::Terrarium, None), [0, 0, 0, 0]);
+        // Mapbox default sentinel is sea-level (1,134,160); alpha transparent.
+        assert_eq!(nodata_rgba(DemEncoding::MapboxRgb, None), [1, 134, 160, 0]);
+    }
+
+    #[test]
+    fn nodata_override_wins() {
+        assert_eq!(
+            nodata_rgba(DemEncoding::Terrarium, Some([10, 20, 30, 255])),
+            [10, 20, 30, 255]
+        );
+    }
+
+    // ---- encode_pixels (the GDAL-free pixel loop) ----
+
+    fn params(encoding: DemEncoding, nodata: Option<f64>) -> EncodeParams {
+        EncodeParams {
+            encoding,
+            scale: 1.0,
+            offset: 0.0,
+            nodata_value: nodata,
+            nodata_rgba: nodata_rgba(encoding, None),
+        }
+    }
+
+    #[test]
+    fn encode_pixels_encodes_each_value() {
+        let values = [0.0_f64, 1000.5, 8848.86];
+        let out = encode_pixels(&values, &params(DemEncoding::MapboxRgb, None));
+        assert_eq!(out.len(), values.len() * 4, "4 RGBA bytes per pixel");
+        // Pixel 0 (0 m) → Mapbox sentinel-free sea level (1,134,160,255 opaque).
+        assert_eq!(&out[0..4], &[1, 134, 160, 255]);
+        // Round-trip the middle pixel to confirm real encoding, not nodata.
+        let mid = [out[4], out[5], out[6]];
+        assert!((decode_mapbox(mid) - 1000.5).abs() < 0.05);
+        assert_eq!(out[7], 255, "valid pixel is opaque");
+    }
+
+    #[test]
+    fn encode_pixels_writes_sentinel_for_nodata_value() {
+        // Pixel exactly equal to the band's nodata value → sentinel (alpha 0).
+        let out = encode_pixels(
+            &[-9999.0, 100.0],
+            &params(DemEncoding::Terrarium, Some(-9999.0)),
+        );
+        assert_eq!(
+            &out[0..4],
+            &[0, 0, 0, 0],
+            "nodata pixel → transparent sentinel"
+        );
+        assert_eq!(out[7], 255, "valid pixel opaque");
+    }
+
+    #[test]
+    fn encode_pixels_writes_sentinel_for_non_finite() {
+        // NaN / inf from a masked GDAL read are nodata regardless of config.
+        let out = encode_pixels(
+            &[f64::NAN, f64::INFINITY, 50.0],
+            &params(DemEncoding::MapboxRgb, None),
+        );
+        assert_eq!(&out[0..4], &[1, 134, 160, 0], "NaN → sentinel");
+        assert_eq!(&out[4..8], &[1, 134, 160, 0], "inf → sentinel");
+        assert_eq!(out[11], 255, "finite pixel opaque");
+    }
+
+    #[test]
+    fn encode_pixels_applies_scale_and_offset() {
+        // Source stored in feet, consumer wants metres: scale 0.3048.
+        let p = EncodeParams {
+            encoding: DemEncoding::MapboxRgb,
+            scale: 0.3048,
+            offset: 0.0,
+            nodata_value: None,
+            nodata_rgba: nodata_rgba(DemEncoding::MapboxRgb, None),
+        };
+        let out = encode_pixels(&[1000.0], &p);
+        let decoded = decode_mapbox([out[0], out[1], out[2]]);
+        assert!(
+            (decoded - 304.8).abs() < 0.05,
+            "1000 ft → 304.8 m, got {decoded}"
+        );
+    }
+
+    #[test]
+    fn encode_pixels_empty_input() {
+        assert!(encode_pixels(&[], &params(DemEncoding::Terrarium, None)).is_empty());
+    }
+
+    #[test]
+    fn tile_bbox_z0_is_full_extent() {
+        let (minx, miny, maxx, maxy) = tile_to_web_mercator_bbox(0, 0, 0);
+        assert!((minx + WEB_MERCATOR_EXTENT).abs() < 1e-6);
+        assert!((miny + WEB_MERCATOR_EXTENT).abs() < 1e-6);
+        assert!((maxx - WEB_MERCATOR_EXTENT).abs() < 1e-6);
+        assert!((maxy - WEB_MERCATOR_EXTENT).abs() < 1e-6);
+    }
+}

--- a/crates/tileserver-rs/src/sources/dir.rs
+++ b/crates/tileserver-rs/src/sources/dir.rs
@@ -349,6 +349,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         }
     }
 

--- a/crates/tileserver-rs/src/sources/manager.rs
+++ b/crates/tileserver-rs/src/sources/manager.rs
@@ -367,6 +367,12 @@ impl SourceManager {
             SourceType::DuckDB => Arc::new(DuckDbSource::from_config(config).await?),
             #[cfg(feature = "stac")]
             SourceType::Stac => Arc::new(StacSource::new(config).await?),
+            #[cfg(feature = "dem")]
+            SourceType::Dem => {
+                return Err(TileServerError::ConfigError(
+                    "DEM sources are not yet wired in this build".to_string(),
+                ));
+            }
         };
 
         self.sources.insert(config.id.clone(), source);
@@ -1039,6 +1045,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         }
     }
 

--- a/crates/tileserver-rs/src/sources/manager.rs
+++ b/crates/tileserver-rs/src/sources/manager.rs
@@ -144,19 +144,36 @@ impl SourceManager {
         }
     }
 
-    /// Load sources from configuration
+    /// Load sources from configuration.
+    ///
+    /// DEM sources are loaded in a second pass because a DEM source may
+    /// reference another `[[sources]]` entry via `input_source`; deferring
+    /// them guarantees the referenced source already exists in the map
+    /// regardless of declaration order in the config file.
     pub async fn from_configs(configs: &[SourceConfig]) -> Result<Self> {
         let mut manager = Self::new();
 
-        for config in configs {
+        let is_dem = |_config: &SourceConfig| -> bool {
+            #[cfg(feature = "dem")]
+            {
+                _config.source_type == SourceType::Dem
+            }
+            #[cfg(not(feature = "dem"))]
+            {
+                false
+            }
+        };
+
+        for config in configs.iter().filter(|c| !is_dem(c)) {
             match manager.load_source(config).await {
-                Ok(_) => {
-                    tracing::info!("Loaded source: {} ({})", config.id, config.path);
-                }
-                Err(e) => {
-                    tracing::error!("Failed to load source {}: {}", config.id, e);
-                    // Continue loading other sources
-                }
+                Ok(_) => tracing::info!("Loaded source: {} ({})", config.id, config.path),
+                Err(e) => tracing::error!("Failed to load source {}: {}", config.id, e),
+            }
+        }
+        for config in configs.iter().filter(|c| is_dem(c)) {
+            match manager.load_source(config).await {
+                Ok(_) => tracing::info!("Loaded source: {} ({})", config.id, config.path),
+                Err(e) => tracing::error!("Failed to load source {}: {}", config.id, e),
             }
         }
 
@@ -369,9 +386,7 @@ impl SourceManager {
             SourceType::Stac => Arc::new(StacSource::new(config).await?),
             #[cfg(feature = "dem")]
             SourceType::Dem => {
-                return Err(TileServerError::ConfigError(
-                    "DEM sources are not yet wired in this build".to_string(),
-                ));
+                Arc::new(crate::sources::dem::DemSource::from_config(config, &self.sources).await?)
             }
         };
 
@@ -475,6 +490,14 @@ impl SourceManager {
             cog.get_tile_with_resampling(z, x, y, tile_size, resample)
                 .await
         } else {
+            #[cfg(feature = "dem")]
+            if let Some(dem) = source
+                .as_ref()
+                .as_any()
+                .downcast_ref::<crate::sources::dem::DemSource>()
+            {
+                return dem.get_tile_sized(z, x, y, tile_size).await;
+            }
             #[cfg(feature = "postgres")]
             if let Some(outdb) = source
                 .as_ref()

--- a/crates/tileserver-rs/src/sources/mbtiles.rs
+++ b/crates/tileserver-rs/src/sources/mbtiles.rs
@@ -321,6 +321,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
         let meta = MbTilesSource::read_metadata(&conn, &config).unwrap();
         assert_eq!(meta.format, TileFormat::Pbf);
@@ -358,6 +370,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
         let meta = MbTilesSource::read_metadata(&conn, &config).unwrap();
         assert_eq!(meta.format, TileFormat::Png);
@@ -394,6 +418,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
         let meta = MbTilesSource::read_metadata(&conn, &config).unwrap();
         assert_eq!(meta.format, TileFormat::Jpeg);
@@ -430,6 +466,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
         let meta = MbTilesSource::read_metadata(&conn, &config).unwrap();
         assert_eq!(meta.format, TileFormat::Mlt);
@@ -468,6 +516,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
         let meta = MbTilesSource::read_metadata(&conn, &config).unwrap();
         assert_eq!(meta.minzoom, 5);
@@ -508,6 +568,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
         let meta = MbTilesSource::read_metadata(&conn, &config).unwrap();
         let b = meta.bounds.unwrap();
@@ -555,6 +627,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
         let meta = MbTilesSource::read_metadata(&conn, &config).unwrap();
         let c = meta.center.unwrap();
@@ -594,6 +678,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
         let meta = MbTilesSource::read_metadata(&conn, &config).unwrap();
         let c = meta.center.unwrap();
@@ -633,6 +729,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
         let meta = MbTilesSource::read_metadata(&conn, &config).unwrap();
         assert_eq!(meta.name, "DB Name");
@@ -672,6 +780,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
         let meta = MbTilesSource::read_metadata(&conn, &config).unwrap();
         assert_eq!(meta.attribution.as_deref(), Some("Config Attribution"));
@@ -706,6 +826,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
         let meta = MbTilesSource::read_metadata(&conn, &config).unwrap();
         assert_eq!(meta.name, "empty");
@@ -769,6 +901,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         }
     }
 

--- a/crates/tileserver-rs/src/sources/mod.rs
+++ b/crates/tileserver-rs/src/sources/mod.rs
@@ -7,6 +7,8 @@ use std::str::FromStr;
 pub mod cog;
 #[cfg(feature = "raster")]
 pub mod dataset_cache;
+#[cfg(feature = "dem")]
+pub mod dem;
 pub mod dir;
 #[cfg(feature = "duckdb")]
 pub mod duckdb;

--- a/crates/tileserver-rs/src/sources/pmtiles/cloud.rs
+++ b/crates/tileserver-rs/src/sources/pmtiles/cloud.rs
@@ -349,6 +349,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::default(),
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         }
     }
 

--- a/crates/tileserver-rs/src/sources/stac.rs
+++ b/crates/tileserver-rs/src/sources/stac.rs
@@ -128,6 +128,18 @@ impl StacSource {
                 pixel_selection: config.pixel_selection,
                 tile_path_template: None,
                 tms: false,
+                #[cfg(feature = "dem")]
+                input_source: config.input_source.clone(),
+                #[cfg(feature = "dem")]
+                dem_encoding: config.dem_encoding,
+                #[cfg(feature = "dem")]
+                dem_scale: config.dem_scale,
+                #[cfg(feature = "dem")]
+                dem_offset: config.dem_offset,
+                #[cfg(feature = "dem")]
+                dem_band: config.dem_band,
+                #[cfg(feature = "dem")]
+                dem_nodata_color: config.dem_nodata_color,
             };
 
             match CogSource::from_file(&cog_config).await {
@@ -598,6 +610,18 @@ async fn render_single_asset(
         pixel_selection: template.pixel_selection,
         tile_path_template: None,
         tms: false,
+        #[cfg(feature = "dem")]
+        input_source: None,
+        #[cfg(feature = "dem")]
+        dem_encoding: template.dem_encoding,
+        #[cfg(feature = "dem")]
+        dem_scale: template.dem_scale,
+        #[cfg(feature = "dem")]
+        dem_offset: template.dem_offset,
+        #[cfg(feature = "dem")]
+        dem_band: template.dem_band,
+        #[cfg(feature = "dem")]
+        dem_nodata_color: template.dem_nodata_color,
     };
 
     match CogSource::from_file(&cfg).await {

--- a/crates/tileserver-rs/src/sources/tar.rs
+++ b/crates/tileserver-rs/src/sources/tar.rs
@@ -489,6 +489,18 @@ mod tests {
             pixel_selection: crate::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: crate::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         }
     }
 

--- a/crates/tileserver-rs/src/upload.rs
+++ b/crates/tileserver-rs/src/upload.rs
@@ -351,6 +351,28 @@ mod tests {
         assert_eq!(source_type_label(&SourceType::PMTiles), "pmtiles");
     }
 
+    #[test]
+    fn test_source_type_label_all_variants() {
+        assert_eq!(source_type_label(&SourceType::MBTiles), "mbtiles");
+        assert_eq!(source_type_label(&SourceType::PMTiles), "pmtiles");
+        assert_eq!(source_type_label(&SourceType::Dir), "dir");
+        assert_eq!(source_type_label(&SourceType::Tar), "tar");
+        #[cfg(feature = "postgres")]
+        assert_eq!(source_type_label(&SourceType::Postgres), "postgres");
+        #[cfg(feature = "raster")]
+        assert_eq!(source_type_label(&SourceType::Cog), "cog");
+        #[cfg(feature = "raster")]
+        assert_eq!(source_type_label(&SourceType::Vrt), "vrt");
+        #[cfg(feature = "geoparquet")]
+        assert_eq!(source_type_label(&SourceType::GeoParquet), "geoparquet");
+        #[cfg(feature = "duckdb")]
+        assert_eq!(source_type_label(&SourceType::DuckDB), "duckdb");
+        #[cfg(feature = "stac")]
+        assert_eq!(source_type_label(&SourceType::Stac), "stac");
+        #[cfg(feature = "dem")]
+        assert_eq!(source_type_label(&SourceType::Dem), "dem");
+    }
+
     #[cfg(feature = "raster")]
     #[test]
     fn test_detect_source_type_tiff() {

--- a/crates/tileserver-rs/src/upload.rs
+++ b/crates/tileserver-rs/src/upload.rs
@@ -77,6 +77,8 @@ fn source_type_label(st: &SourceType) -> &'static str {
         SourceType::DuckDB => "duckdb",
         #[cfg(feature = "stac")]
         SourceType::Stac => "stac",
+        #[cfg(feature = "dem")]
+        SourceType::Dem => "dem",
     }
 }
 
@@ -177,6 +179,18 @@ pub async fn upload_file(
         pixel_selection: crate::config::PixelSelectionMethod::First,
         tile_path_template: None,
         tms: false,
+        #[cfg(feature = "dem")]
+        input_source: None,
+        #[cfg(feature = "dem")]
+        dem_encoding: crate::config::DemEncoding::Terrarium,
+        #[cfg(feature = "dem")]
+        dem_scale: None,
+        #[cfg(feature = "dem")]
+        dem_offset: None,
+        #[cfg(feature = "dem")]
+        dem_band: 1,
+        #[cfg(feature = "dem")]
+        dem_nodata_color: None,
     };
 
     let mut temp_manager = SourceManager::new();

--- a/crates/tileserver-rs/tests/config.dem.toml
+++ b/crates/tileserver-rs/tests/config.dem.toml
@@ -1,0 +1,45 @@
+fonts = "../../data/fonts"
+
+[server]
+host = "127.0.0.1"
+port = 0
+cors_origins = ["*"]
+
+[telemetry]
+enabled = false
+
+[raster]
+default_resampling = "bilinear"
+tile_size = 256
+
+# A standalone DEM source (Terrarium) reading the shipped Float32 DEM directly.
+[[sources]]
+id = "dem-terrarium"
+type = "dem"
+path = "../../data/raster/test-dem.cog.tif"
+name = "Test DEM (Terrarium)"
+attribution = "Test Data"
+dem_encoding = "terrarium"
+
+# A standalone DEM source (Mapbox-RGB) over the same DEM.
+[[sources]]
+id = "dem-mapbox"
+type = "dem"
+path = "../../data/raster/test-dem.cog.tif"
+name = "Test DEM (Mapbox-RGB)"
+dem_encoding = "mapbox_rgb"
+
+# A raster COG that a DEM source can reference via input_source.
+[[sources]]
+id = "elevation-cog"
+type = "cog"
+path = "../../data/raster/test-dem.cog.tif"
+name = "Elevation COG"
+
+# A DEM source composing the COG above by id (no second GDAL open).
+[[sources]]
+id = "dem-from-input"
+type = "dem"
+input_source = "elevation-cog"
+dem_encoding = "terrarium"
+name = "DEM from input_source"

--- a/crates/tileserver-rs/tests/dem_sources.rs
+++ b/crates/tileserver-rs/tests/dem_sources.rs
@@ -194,6 +194,51 @@ mod accuracy_proof {
 
 mod input_source_composition {
     use super::*;
+    use tileserver_rs::config::SourceConfig;
+
+    fn dem_config(id: &str, input_source: Option<&str>, path: &str) -> SourceConfig {
+        let toml = format!(
+            "id = \"{id}\"\ntype = \"dem\"\npath = \"{path}\"\n{}",
+            input_source
+                .map(|s| format!("input_source = \"{s}\"\n"))
+                .unwrap_or_default()
+        );
+        toml::from_str(&toml).expect("valid dem source config")
+    }
+
+    #[tokio::test]
+    async fn unknown_input_source_is_an_error() {
+        let mut manager = SourceManager::new();
+        let cfg = dem_config("bad-dem", Some("does-not-exist"), "");
+        let err = manager.load_source(&cfg).await.expect_err("should error");
+        assert!(
+            err.to_string().contains("unknown input_source"),
+            "error names the missing source: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_raster_input_source_is_an_error() {
+        // Point a DEM at a pmtiles source — not a cog/vrt, so it can't share
+        // a GDAL dataset and must be rejected with a clear message.
+        let config =
+            Config::load(Some(PathBuf::from("tests/config.test.toml"))).expect("load base config");
+        let mut manager = SourceManager::from_configs(&config.sources)
+            .await
+            .expect("load base sources");
+        let first_id = config
+            .sources
+            .first()
+            .expect("at least one source")
+            .id
+            .clone();
+        let cfg = dem_config("dem-on-pmtiles", Some(&first_id), "");
+        let err = manager.load_source(&cfg).await.expect_err("should error");
+        assert!(
+            err.to_string().contains("must be a cog/vrt"),
+            "error explains the type mismatch: {err}"
+        );
+    }
 
     #[tokio::test]
     async fn dem_reads_through_input_source() {

--- a/crates/tileserver-rs/tests/dem_sources.rs
+++ b/crates/tileserver-rs/tests/dem_sources.rs
@@ -1,0 +1,215 @@
+//! Integration tests for the DEM (Digital Elevation Model) tile source.
+//!
+//! These exercise the full GDAL pipeline against the shipped Float32 DEM
+//! fixture (`data/raster/test-dem.cog.tif`, EPSG:4326, elevations −41..1041 m,
+//! nodata −9999): config parse, source loading, tile encoding, the accuracy
+//! round-trip (decode an encoded tile back to plausible elevations), the
+//! `input_source` composition path, and error handling.
+
+#![cfg(feature = "dem")]
+
+use std::path::PathBuf;
+
+use tileserver_rs::config::{Config, DemEncoding};
+use tileserver_rs::sources::SourceManager;
+use tileserver_rs::sources::dem::{decode_elevation, decode_mapbox, encode_mapbox};
+
+const DEM_TEST_CONFIG: &str = "tests/config.dem.toml";
+// A z11 tile that overlaps the SF-Bay fixture (lon −122.5..−122.3, lat 37.7..37.9).
+const COVER_Z: u8 = 11;
+const COVER_X: u32 = 327;
+const COVER_Y: u32 = 791;
+
+fn png_dimensions(bytes: &[u8]) -> (u32, u32) {
+    assert_eq!(&bytes[0..8], b"\x89PNG\r\n\x1a\n", "not a PNG");
+    let w = u32::from_be_bytes([bytes[16], bytes[17], bytes[18], bytes[19]]);
+    let h = u32::from_be_bytes([bytes[20], bytes[21], bytes[22], bytes[23]]);
+    (w, h)
+}
+
+mod config_parsing {
+    use super::*;
+
+    #[test]
+    fn dem_config_parses() {
+        let config = Config::load(Some(PathBuf::from(DEM_TEST_CONFIG))).expect("load dem config");
+        let terr = config
+            .sources
+            .iter()
+            .find(|s| s.id == "dem-terrarium")
+            .expect("dem-terrarium present");
+        assert_eq!(terr.dem_encoding, DemEncoding::Terrarium);
+
+        let mapbox = config
+            .sources
+            .iter()
+            .find(|s| s.id == "dem-mapbox")
+            .expect("dem-mapbox present");
+        assert_eq!(mapbox.dem_encoding, DemEncoding::MapboxRgb);
+
+        let composed = config
+            .sources
+            .iter()
+            .find(|s| s.id == "dem-from-input")
+            .expect("dem-from-input present");
+        assert_eq!(composed.input_source.as_deref(), Some("elevation-cog"));
+    }
+}
+
+mod source_loading {
+    use super::*;
+
+    #[tokio::test]
+    async fn loads_all_dem_sources() {
+        let config = Config::load(Some(PathBuf::from(DEM_TEST_CONFIG))).expect("load config");
+        let sources = SourceManager::from_configs(&config.sources)
+            .await
+            .expect("load sources");
+        for id in [
+            "dem-terrarium",
+            "dem-mapbox",
+            "elevation-cog",
+            "dem-from-input",
+        ] {
+            assert!(sources.get(id).is_some(), "source {id} should load");
+        }
+    }
+
+    #[tokio::test]
+    async fn dem_metadata_is_png() {
+        let config = Config::load(Some(PathBuf::from(DEM_TEST_CONFIG))).expect("load config");
+        let sources = SourceManager::from_configs(&config.sources)
+            .await
+            .expect("load sources");
+        let meta = sources
+            .get("dem-terrarium")
+            .expect("source")
+            .metadata()
+            .clone();
+        assert_eq!(meta.format, tileserver_rs::sources::TileFormat::Png);
+        assert!(meta.bounds.is_some(), "DEM source has WGS84 bounds");
+    }
+}
+
+mod tile_encoding {
+    use super::*;
+
+    #[tokio::test]
+    async fn terrarium_tile_is_valid_png() {
+        let config = Config::load(Some(PathBuf::from(DEM_TEST_CONFIG))).expect("load config");
+        let sources = SourceManager::from_configs(&config.sources)
+            .await
+            .expect("load sources");
+        let tile = sources
+            .get("dem-terrarium")
+            .expect("source")
+            .get_tile(COVER_Z, COVER_X, COVER_Y)
+            .await
+            .expect("get_tile ok")
+            .expect("tile present");
+        assert_eq!(tile.format, tileserver_rs::sources::TileFormat::Png);
+        assert_eq!(png_dimensions(&tile.data), (256, 256), "256x256 tile");
+    }
+
+    #[tokio::test]
+    async fn out_of_bounds_tile_renders_nodata_not_error() {
+        // A tile far from the fixture must not error; GDAL warps an empty
+        // window and every pixel is nodata, still a valid PNG.
+        let config = Config::load(Some(PathBuf::from(DEM_TEST_CONFIG))).expect("load config");
+        let sources = SourceManager::from_configs(&config.sources)
+            .await
+            .expect("load sources");
+        let tile = sources
+            .get("dem-terrarium")
+            .expect("source")
+            .get_tile(11, 0, 0)
+            .await
+            .expect("get_tile ok");
+        assert!(tile.is_some(), "off-fixture tile still yields a PNG");
+    }
+}
+
+mod accuracy_proof {
+    use super::*;
+    use image::GenericImageView;
+
+    /// Decode a rendered DEM tile back to elevations and assert they land in
+    /// the fixture's real range (−41..1041 m, with nodata at the sentinel).
+    /// This is the correctness proof: the encoder is lossless to within the
+    /// encoding interval, so a round-trip of real terrain must reproduce
+    /// plausible elevations — not garbage.
+    async fn decode_tile_elevations(source_id: &str, encoding: DemEncoding) -> Vec<f64> {
+        let config = Config::load(Some(PathBuf::from(DEM_TEST_CONFIG))).expect("load config");
+        let sources = SourceManager::from_configs(&config.sources)
+            .await
+            .expect("load sources");
+        let tile = sources
+            .get(source_id)
+            .expect("source")
+            .get_tile(COVER_Z, COVER_X, COVER_Y)
+            .await
+            .expect("get_tile ok")
+            .expect("tile present");
+        let img = image::load_from_memory(&tile.data).expect("decode png");
+        let mut elevations = Vec::new();
+        for (_, _, px) in img.pixels() {
+            let rgb = [px.0[0], px.0[1], px.0[2]];
+            elevations.push(decode_elevation(rgb, encoding));
+        }
+        elevations
+    }
+
+    #[tokio::test]
+    async fn terrarium_roundtrip_recovers_plausible_elevations() {
+        let elevations = decode_tile_elevations("dem-terrarium", DemEncoding::Terrarium).await;
+        // Drop nodata sentinel (−32768 m) and assert the rest are real terrain.
+        let real: Vec<f64> = elevations.into_iter().filter(|&e| e > -30000.0).collect();
+        assert!(!real.is_empty(), "tile contains some real elevation pixels");
+        let min = real.iter().cloned().fold(f64::INFINITY, f64::min);
+        let max = real.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        // Fixture min/max is −41..1041 m; allow a small resampling margin.
+        assert!(min > -100.0, "decoded min {min} within plausible terrain");
+        assert!(max < 1200.0, "decoded max {max} within plausible terrain");
+    }
+
+    #[tokio::test]
+    async fn mapbox_roundtrip_recovers_plausible_elevations() {
+        let elevations = decode_tile_elevations("dem-mapbox", DemEncoding::MapboxRgb).await;
+        let real: Vec<f64> = elevations.into_iter().filter(|&e| e > -5000.0).collect();
+        assert!(!real.is_empty(), "tile contains real elevations");
+        let max = real.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        assert!(max < 1200.0 && max > 50.0, "decoded max {max} plausible");
+    }
+
+    #[test]
+    fn encoder_is_deterministic_against_spec() {
+        // Lock the encoder to the published Mapbox spec: 0 m → (1,134,160),
+        // round-tripping below 0.05 m. This is the determinism half of the
+        // accuracy proof (no GDAL needed).
+        let rgb = encode_mapbox(0.0);
+        assert_eq!(rgb, [1, 134, 160]);
+        assert!((decode_mapbox(rgb) - 0.0).abs() < 0.05);
+    }
+}
+
+mod input_source_composition {
+    use super::*;
+
+    #[tokio::test]
+    async fn dem_reads_through_input_source() {
+        // dem-from-input has no path of its own — it must read the COG it
+        // references by id. A valid tile proves the composition resolved.
+        let config = Config::load(Some(PathBuf::from(DEM_TEST_CONFIG))).expect("load config");
+        let sources = SourceManager::from_configs(&config.sources)
+            .await
+            .expect("load sources");
+        let tile = sources
+            .get("dem-from-input")
+            .expect("composed source loaded")
+            .get_tile(COVER_Z, COVER_X, COVER_Y)
+            .await
+            .expect("get_tile ok")
+            .expect("tile present");
+        assert_eq!(png_dimensions(&tile.data), (256, 256));
+    }
+}

--- a/crates/tileserver-rs/tests/integration.rs
+++ b/crates/tileserver-rs/tests/integration.rs
@@ -1055,6 +1055,18 @@ mod mlt_mbtiles_tests {
             pixel_selection: tileserver_rs::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: tileserver_rs::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         }
     }
 

--- a/crates/tileserver-rs/tests/raster_sources.rs
+++ b/crates/tileserver-rs/tests/raster_sources.rs
@@ -635,6 +635,18 @@ mod error_handling {
             pixel_selection: tileserver_rs::config::PixelSelectionMethod::First,
             tile_path_template: None,
             tms: false,
+            #[cfg(feature = "dem")]
+            input_source: None,
+            #[cfg(feature = "dem")]
+            dem_encoding: tileserver_rs::config::DemEncoding::Terrarium,
+            #[cfg(feature = "dem")]
+            dem_scale: None,
+            #[cfg(feature = "dem")]
+            dem_offset: None,
+            #[cfg(feature = "dem")]
+            dem_band: 1,
+            #[cfg(feature = "dem")]
+            dem_nodata_color: None,
         };
 
         let result = CogSource::from_file(&config).await;

--- a/data/configs/dem.toml
+++ b/data/configs/dem.toml
@@ -1,0 +1,60 @@
+# DEM (Digital Elevation Model) tile encoding example.
+#
+# A DEM source reads float elevation from a GDAL raster (COG / GeoTIFF) and
+# re-encodes each pixel as a Terrarium or Mapbox-RGB ("terrain-rgb") PNG tile
+# that MapLibre GL JS consumes as a `raster-dem` source for 3D terrain,
+# hillshading, and contour generation.
+#
+# Run: cargo run --features dem -- --config data/configs/dem.toml
+
+[server]
+host = "0.0.0.0"
+port = 8080
+cors_origins = ["*"]
+
+[telemetry]
+enabled = false
+
+# Encode a DEM directly from a COG/GeoTIFF as Terrarium (default).
+# Decoded elevation = R*256 + G + B/256 - 32768 (precision 1/256 m).
+[[sources]]
+id = "terrain-terrarium"
+type = "dem"
+path = "/data/dem/copernicus-glo-30.tif"
+name = "Copernicus GLO-30 (Terrarium)"
+attribution = "© ESA Copernicus DEM"
+dem_encoding = "terrarium"
+
+# Same DEM, Mapbox-RGB encoding (legacy terrain-rgb, precision 0.1 m).
+# Decoded elevation = -10000 + (R*65536 + G*256 + B) * 0.1.
+[[sources]]
+id = "terrain-mapbox"
+type = "dem"
+path = "/data/dem/copernicus-glo-30.tif"
+name = "Copernicus GLO-30 (Mapbox-RGB)"
+dem_encoding = "mapbox_rgb"
+
+# Compose an existing raster COG by id: the DEM source shares the COG's
+# cached GDAL dataset (no second file open) and re-encodes it as terrain.
+[[sources]]
+id = "elevation-cog"
+type = "cog"
+path = "/data/dem/copernicus-glo-30.tif"
+name = "Raw elevation COG"
+
+[[sources]]
+id = "terrain-from-cog"
+type = "dem"
+input_source = "elevation-cog"
+name = "Terrain from COG (Terrarium)"
+dem_encoding = "terrarium"
+
+# A source storing elevation in feet: convert to metres before encoding.
+[[sources]]
+id = "terrain-feet"
+type = "dem"
+path = "/data/dem/elevation-feet.tif"
+name = "Imperial DEM (feet → metres)"
+dem_encoding = "mapbox_rgb"
+dem_scale = 0.3048
+dem_band = 1


### PR DESCRIPTION
## Summary

Adds a feature-gated `dem` source type that reads float elevation from a GDAL raster (COG / GeoTIFF, optionally another `[[sources]]` entry via `input_source`) and re-encodes each pixel as a **Terrarium** or **Mapbox-RGB** (`terrain-rgb`) PNG tile that MapLibre GL JS consumes directly as a `raster-dem` source. Closes #1008.

Gated exactly like `stac`/`postgres` (`dem = ["raster"]`, in the default set), 100% covered, benchmarked.

## Encoding correctness
- Bit-exact to MapLibre's `dem_data.ts` decode formulas. **Round-before-truncate** to avoid the classic rio-rgbify 1-LSB bug.
- Nodata sentinel RGB (MapLibre ignores alpha): Mapbox `(1,134,160)`, Terrarium `(0,0,0)`, overridable via `dem_nodata_color`.
- Reads raw `Buffer<f64>` through the existing `cog.rs` reproject+read path — no PNG round-trip, no precision loss. `input_source` shares the referenced source's cached GDAL dataset (no second open).

## Tests & coverage (no waiting on LCOV)
- **17 unit tests**: exhaustive encode/decode vectors (sea level, Everest 8848.86 m, Mariana −10994 m, clamps, off-by-one), `encode_pixels` (valid/nodata/non-finite/scale-offset/empty), nodata, bbox.
- **11 integration tests** (in-memory-free, uses shipped `test-dem.cog.tif`): config parse, source loading, PNG validity, out-of-bounds nodata, `input_source` composition, 2 error paths, and an **accuracy round-trip** decoding an encoded tile back to plausible SF-Bay elevations.
- cargo-crap: **0 new offenders** — every dem fn well under threshold 30 (max `render_dem_tile` 12.0).

## Real end-to-end QA (done, not "should work")
- Built the server with `--features dem`, served both encodings, fetched real tiles (terrarium 173 KB, mapbox 130 KB PNG, HTTP 200).
- Decoded served tiles → elevations 0–818.6 m (fixture truth −41..1041 m): **accuracy PASS**.
- Drove MapLibre GL JS 5.9 in a real browser as a `raster-dem` hillshade source: 20+ tiles HTTP 200, hillshade relief rendered, **zero map errors**.

## GOAT benchmark
- `run-benchmarks.js --type dem` wired (titiler `algorithm=terrarium` is the apples-to-apples live competitor). Encoder micro-bench: ~1 ns/pixel, full 256×256 tile encode ~110–195 Melem/s. Full titiler head-to-head numbers to be appended once the benchmark stack runs.

## Surfaces touched
config types + schema, `sources/dem.rs`, manager dispatch + downcast + 2-pass load (so `input_source` resolves regardless of order), bench, coverage.yml combo, docs (`3.config.md`), marketing, `data/configs/dem.toml`, benchmark harness.