### PR TITLE
chore(deps): bump rmcp to 2.0 + migrate MCP to 2.0 API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -135,7 +135,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1878,7 +1878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3748,7 +3748,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5265,9 +5265,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "base64",
@@ -5296,9 +5296,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5524,7 +5524,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5583,7 +5583,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6082,7 +6082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6217,7 +6217,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6386,10 +6386,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7487,7 +7487,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/tileserver-rs/Cargo.toml
+++ b/crates/tileserver-rs/Cargo.toml
@@ -108,7 +108,7 @@ duckdb           = { workspace = true, optional = true }
 # the two transports we expose: stdio (`transport-io`) for local clients
 # like Claude Desktop and Streamable HTTP for remote clients (Cursor, MCP
 # Inspector, claude.ai via mcp-remote bridges).
-rmcp             = { version = "1.8", optional = true, features = ["transport-io", "transport-streamable-http-server"] }
+rmcp             = { version = "2.0", optional = true, features = ["transport-io", "transport-streamable-http-server"] }
 schemars         = { version = "1", optional = true }
 base64           = { version = "0.22", optional = true }
 

--- a/crates/tileserver-rs/src/mcp/error.rs
+++ b/crates/tileserver-rs/src/mcp/error.rs
@@ -25,7 +25,7 @@
 //! error is still logged server-side via `tracing::warn!` so operators can
 //! debug.
 
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::{CallToolResult, ContentBlock};
 
 use crate::error::TileServerError;
 
@@ -61,7 +61,7 @@ pub fn tile_error_to_call_result(err: TileServerError) -> CallToolResult {
         }
         _ => err.to_string(),
     };
-    CallToolResult::error(vec![Content::text(body)])
+    CallToolResult::error(vec![ContentBlock::text(body)])
 }
 
 /// Build a tool-execution error from a free-form message.
@@ -71,7 +71,7 @@ pub fn tile_error_to_call_result(err: TileServerError) -> CallToolResult {
 /// exceeds limit").
 #[must_use]
 pub fn tool_error<S: Into<String>>(message: S) -> CallToolResult {
-    CallToolResult::error(vec![Content::text(message.into())])
+    CallToolResult::error(vec![ContentBlock::text(message.into())])
 }
 
 #[cfg(test)]

--- a/crates/tileserver-rs/src/mcp/handlers.rs
+++ b/crates/tileserver-rs/src/mcp/handlers.rs
@@ -18,7 +18,7 @@ use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use rmcp::ErrorData as McpError;
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{
-    CallToolResult, Content, GetPromptRequestParams, GetPromptResult, ListPromptsResult,
+    CallToolResult, ContentBlock, GetPromptRequestParams, GetPromptResult, ListPromptsResult,
     ListResourceTemplatesResult, PaginatedRequestParams, ProtocolVersion,
     ReadResourceRequestParams, ReadResourceResult, ServerCapabilities, ServerInfo,
 };
@@ -236,7 +236,7 @@ impl McpHandler {
                 tilejsons.push(tj);
             }
         }
-        match Content::json(&tilejsons) {
+        match ContentBlock::json(&tilejsons) {
             Ok(content) => Ok(CallToolResult::success(vec![content])),
             Err(err) => Ok(tile_error_to_call_result(
                 crate::error::TileServerError::Internal(anyhow::anyhow!(
@@ -260,7 +260,7 @@ impl McpHandler {
                 crate::error::TileServerError::SourceNotFound(source_id),
             ));
         };
-        match Content::json(&tj) {
+        match ContentBlock::json(&tj) {
             Ok(c) => Ok(CallToolResult::success(vec![c])),
             Err(e) => Ok(tile_error_to_call_result(
                 crate::error::TileServerError::Internal(anyhow::anyhow!(
@@ -279,7 +279,7 @@ impl McpHandler {
         _params: Parameters<EmptyArgs>,
     ) -> Result<CallToolResult, McpError> {
         let infos = self.state.styles.all_infos(&self.state.base_url);
-        match Content::json(&infos) {
+        match ContentBlock::json(&infos) {
             Ok(c) => Ok(CallToolResult::success(vec![c])),
             Err(e) => Ok(tile_error_to_call_result(
                 crate::error::TileServerError::Internal(anyhow::anyhow!(
@@ -303,7 +303,7 @@ impl McpHandler {
                 crate::error::TileServerError::StyleNotFound(style_id),
             ));
         };
-        match Content::json(&style.style_json) {
+        match ContentBlock::json(&style.style_json) {
             Ok(c) => Ok(CallToolResult::success(vec![c])),
             Err(e) => Ok(tile_error_to_call_result(
                 crate::error::TileServerError::Internal(anyhow::anyhow!(
@@ -327,7 +327,7 @@ impl McpHandler {
                 crate::error::TileServerError::SourceNotFound(source_id),
             ));
         };
-        match Content::json(source.metadata()) {
+        match ContentBlock::json(source.metadata()) {
             Ok(c) => Ok(CallToolResult::success(vec![c])),
             Err(e) => Ok(tile_error_to_call_result(
                 crate::error::TileServerError::Internal(anyhow::anyhow!(
@@ -354,7 +354,7 @@ impl McpHandler {
             cache_enabled: self.state.sources.cache().is_some(),
             base_url: self.state.base_url.clone(),
         };
-        match Content::json(&payload) {
+        match ContentBlock::json(&payload) {
             Ok(c) => Ok(CallToolResult::success(vec![c])),
             Err(e) => Ok(tile_error_to_call_result(
                 crate::error::TileServerError::Internal(anyhow::anyhow!(
@@ -452,7 +452,7 @@ impl McpHandler {
         }
 
         let encoded = BASE64_STANDARD.encode(&bytes);
-        Ok(CallToolResult::success(vec![Content::image(
+        Ok(CallToolResult::success(vec![ContentBlock::image(
             encoded,
             "image/webp",
         )]))
@@ -491,7 +491,7 @@ impl McpHandler {
             "mime_type": mime,
             "data_base64": encoded,
         });
-        match Content::json(&summary) {
+        match ContentBlock::json(&summary) {
             Ok(c) => Ok(CallToolResult::success(vec![c])),
             Err(e) => Ok(tile_error_to_call_result(
                 crate::error::TileServerError::Internal(anyhow::anyhow!(
@@ -684,7 +684,7 @@ async fn point_query_postgres(
         "features": features,
         "numberReturned": features.len(),
     });
-    match Content::json(&fc) {
+    match ContentBlock::json(&fc) {
         Ok(c) => Ok(CallToolResult::success(vec![c])),
         Err(e) => Ok(tile_error_to_call_result(
             crate::error::TileServerError::Internal(anyhow::anyhow!(
@@ -752,7 +752,7 @@ async fn cql2_query_postgres(
         "numberMatched": matched,
         "numberReturned": features.len(),
     });
-    match Content::json(&fc) {
+    match ContentBlock::json(&fc) {
         Ok(c) => Ok(CallToolResult::success(vec![c])),
         Err(e) => Ok(tile_error_to_call_result(
             crate::error::TileServerError::Internal(anyhow::anyhow!(
@@ -827,7 +827,7 @@ fn stac_search(
         })).collect::<Vec<_>>(),
         "numberReturned": filtered.len(),
     });
-    match Content::json(&fc) {
+    match ContentBlock::json(&fc) {
         Ok(c) => Ok(CallToolResult::success(vec![c])),
         Err(e) => Ok(tile_error_to_call_result(
             crate::error::TileServerError::Internal(anyhow::anyhow!(

--- a/crates/tileserver-rs/src/mcp/prompts.rs
+++ b/crates/tileserver-rs/src/mcp/prompts.rs
@@ -12,7 +12,7 @@
 use rmcp::ErrorData as McpError;
 use rmcp::model::{
     GetPromptRequestParams, GetPromptResult, ListPromptsResult, Prompt, PromptArgument,
-    PromptMessage, PromptMessageRole,
+    PromptMessage, Role,
 };
 use serde_json::Value;
 
@@ -187,7 +187,7 @@ fn coerce_to_string(v: &Value) -> Option<String> {
 }
 
 fn text_prompt(description: &str, text: String) -> GetPromptResult {
-    GetPromptResult::new(vec![PromptMessage::new_text(PromptMessageRole::User, text)])
+    GetPromptResult::new(vec![PromptMessage::new_text(Role::User, text)])
         .with_description(description.to_string())
 }
 
@@ -214,7 +214,8 @@ mod tests {
             .expect("get_prompt succeeded");
         assert_eq!(r.messages.len(), 1);
         match &r.messages[0].content {
-            rmcp::model::PromptMessageContent::Text { text } => {
+            rmcp::model::ContentBlock::Text(text_content) => {
+                let text = &text_content.text;
                 assert!(text.contains("demo"), "style_id not substituted: {text}");
             }
             other => panic!("expected text content, got {other:?}"),
@@ -229,7 +230,8 @@ mod tests {
         ))
         .expect("get_prompt succeeded");
         match &r.messages[0].content {
-            rmcp::model::PromptMessageContent::Text { text } => {
+            rmcp::model::ContentBlock::Text(text_content) => {
+                let text = &text_content.text;
                 assert!(text.contains("Mumbai"));
                 assert!(text.contains("12"), "default zoom not in `{text}`");
             }
@@ -245,7 +247,8 @@ mod tests {
         ))
         .expect("get_prompt succeeded");
         match &r.messages[0].content {
-            rmcp::model::PromptMessageContent::Text { text } => {
+            rmcp::model::ContentBlock::Text(text_content) => {
+                let text = &text_content.text;
                 assert!(text.contains("5"));
             }
             other => panic!("expected text content, got {other:?}"),

--- a/crates/tileserver-rs/src/mcp/resources.rs
+++ b/crates/tileserver-rs/src/mcp/resources.rs
@@ -13,8 +13,7 @@ use std::sync::Arc;
 
 use rmcp::ErrorData as McpError;
 use rmcp::model::{
-    ListResourceTemplatesResult, RawResourceTemplate, ReadResourceResult, ResourceContents,
-    ResourceTemplate,
+    ListResourceTemplatesResult, ReadResourceResult, ResourceContents, ResourceTemplate,
 };
 
 use crate::reload::AppState;
@@ -36,27 +35,21 @@ const DATA_URI_TEMPLATE: &str = "tileserver://data/{id}.json";
 #[must_use]
 pub fn list_resource_templates() -> ListResourceTemplatesResult {
     let templates: Vec<ResourceTemplate> = vec![
-        ResourceTemplate::new(
-            RawResourceTemplate::new(STYLE_URI_TEMPLATE, "style")
-                .with_title("MapLibre style JSON")
-                .with_description(
-                    "Returns the raw style.json for a registered map style. \
-                     Substitute {id} with the style id from tileserver_list_styles.",
-                )
-                .with_mime_type("application/json"),
-            None,
-        ),
-        ResourceTemplate::new(
-            RawResourceTemplate::new(DATA_URI_TEMPLATE, "tilejson")
-                .with_title("TileJSON 3.0 metadata")
-                .with_description(
-                    "Returns TileJSON 3.0 metadata (bounds, zoom range, tile URL template) \
-                     for a registered tile source. Substitute {id} with the source id \
-                     from tileserver_list_sources.",
-                )
-                .with_mime_type("application/json"),
-            None,
-        ),
+        ResourceTemplate::new(STYLE_URI_TEMPLATE, "style")
+            .with_title("MapLibre style JSON")
+            .with_description(
+                "Returns the raw style.json for a registered map style. \
+                 Substitute {id} with the style id from tileserver_list_styles.",
+            )
+            .with_mime_type("application/json"),
+        ResourceTemplate::new(DATA_URI_TEMPLATE, "tilejson")
+            .with_title("TileJSON 3.0 metadata")
+            .with_description(
+                "Returns TileJSON 3.0 metadata (bounds, zoom range, tile URL template) \
+                 for a registered tile source. Substitute {id} with the source id \
+                 from tileserver_list_sources.",
+            )
+            .with_mime_type("application/json"),
     ];
 
     ListResourceTemplatesResult::with_all_items(templates)


### PR DESCRIPTION
## What

Supersedes #1213 (Dependabot's mechanical `rmcp 1.8.0 → 2.0.0` bump), which does **not** compile because rmcp 2.0 renamed/moved several `model` types. This PR carries the bump **plus** the API migration so CI is green.

## rmcp 2.0 API deltas fixed

| 1.x | 2.0 | Files |
|---|---|---|
| `model::Content` | `model::ContentBlock` (same `::text` / `::json` / `::image` ctors) | `error.rs`, `handlers.rs` |
| `model::PromptMessageRole` | `model::Role` | `prompts.rs` |
| `PromptMessageContent::Text { text }` | `ContentBlock::Text(TextContent)` (tuple; `.text` field) | `prompts.rs` tests |
| `RawResourceTemplate::new(..).with_*()` wrapped in `ResourceTemplate::new(inner, None)` | `ResourceTemplate::new(uri, name).with_*()` — flat, no `annotations` positional arg | `resources.rs` |

Behavior is unchanged — these are pure type-path/constructor renames.

## Verification

- `cargo fmt --all --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓ (the exact check that failed on #1213)
- `cargo clippy --all-targets --no-default-features -- -D warnings` ✓
- **15 MCP test binaries pass** (`cargo test --features mcp,mcp-persistence mcp::`)
- Migration verified against `rmcp-2.0.0` source on disk, not guessed.

Closes #1213