### PR TITLE
fix(client): condense desktop hero band to reclaim viewport

### DIFF
--- a/apps/client/app/components/home/Hero.vue
+++ b/apps/client/app/components/home/Hero.vue
@@ -170,87 +170,61 @@
       </div>
     </div>
 
-    <!-- Admin-style band (lg+) — 2-col 3fr_2fr grid mirroring /admin Operator console. -->
-    <div class="mx-auto hidden max-w-screen-2xl lg:grid lg:grid-cols-[3fr_2fr]">
-      <div
-        class="flex flex-col justify-between gap-2 border-r border-border px-[clamp(16px,4vw,32px)] py-3"
+    <!-- Dense status strip (lg+) — single horizontal row, pills on the left,
+         inline label:value metrics on the right. Linear/Vercel-status-bar dense. -->
+    <div
+      class="mx-auto hidden max-w-screen-2xl lg:flex lg:items-center lg:gap-5 px-[clamp(16px,4vw,32px)] py-2.5"
+      role="group"
+      aria-label="Runtime status"
+    >
+      <p
+        class="flex flex-wrap items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
       >
-        <p
-          class="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
-        >
-          Catalog
-        </p>
-        <p
-          v-if="isLoading"
-          class="font-display text-[32px] font-semibold leading-none tabular-nums tracking-tight text-muted-foreground"
-        >
-          —
-        </p>
-        <p
-          v-else
-          class="font-display text-[32px] font-semibold leading-none tabular-nums tracking-tight text-foreground"
-        >
-          {{ uptime }}
-        </p>
-        <p
-          class="flex flex-wrap items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+        <span
+          class="inline-flex items-center gap-1.5 border px-2 py-0.5 font-semibold"
+          :class="
+            statusOk
+              ? 'border-success/30 bg-success/10 text-success'
+              : 'border-destructive/30 bg-destructive/10 text-destructive'
+          "
         >
           <span
-            class="inline-flex items-center gap-1.5 border px-2 py-0.5 font-semibold"
-            :class="
-              statusOk
-                ? 'border-success/30 bg-success/10 text-success'
-                : 'border-destructive/30 bg-destructive/10 text-destructive'
-            "
-          >
-            <span
-              class="hero-dot size-1.5 shrink-0 bg-current"
-              aria-hidden="true"
-              style="border-radius: 50%"
-            ></span>
-            Live
-          </span>
-          <span>· Renderer {{ rendererEnabled ? '✓' : '✗' }}</span>
-          <span>· Compression {{ compressionEnabled ? '✓' : '✗' }}</span>
-          <span>· OGC {{ ogcEnabled ? '✓' : '✗' }}</span>
-          <span v-if="versionLabel">· {{ versionLabel }}</span>
-        </p>
-      </div>
+            class="hero-dot size-1.5 shrink-0 bg-current"
+            aria-hidden="true"
+            style="border-radius: 50%"
+          ></span>
+          Live
+        </span>
+        <span class="font-medium">· Renderer {{ rendererEnabled ? '✓' : '✗' }}</span>
+        <span class="font-medium">· Compression {{ compressionEnabled ? '✓' : '✗' }}</span>
+        <span class="font-medium">· OGC {{ ogcEnabled ? '✓' : '✗' }}</span>
+        <span v-if="versionLabel" class="font-semibold text-foreground">· {{ versionLabel }}</span>
+      </p>
 
-      <div class="grid grid-cols-2 grid-rows-2">
-        <div class="border-b border-border px-5 py-2.5">
-          <p
-            class="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
-          >
-            Sources
-          </p>
-          <p
-            class="mt-1 font-display text-2xl font-semibold leading-none tabular-nums text-foreground"
-          >
+      <span
+        aria-hidden="true"
+        class="hidden h-4 w-px shrink-0 bg-border lg:block"
+      ></span>
+
+      <dl
+        class="flex flex-wrap items-baseline gap-x-4 gap-y-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-muted-foreground"
+        aria-label="Runtime metrics"
+      >
+        <div class="inline-flex items-baseline gap-1.5">
+          <dt>Sources</dt>
+          <dd class="font-mono text-[13px] font-semibold leading-none tabular-nums tracking-normal text-foreground">
             {{ sourceCount }}
-          </p>
+          </dd>
         </div>
-        <div class="border-b border-l border-border px-5 py-2.5">
-          <p
-            class="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
-          >
-            Styles
-          </p>
-          <p
-            class="mt-1 font-display text-2xl font-semibold leading-none tabular-nums text-foreground"
-          >
+        <div class="inline-flex items-baseline gap-1.5">
+          <dt>Styles</dt>
+          <dd class="font-mono text-[13px] font-semibold leading-none tabular-nums tracking-normal text-foreground">
             {{ styleCount }}
-          </p>
+          </dd>
         </div>
-        <div class="px-5 py-2.5">
-          <p
-            class="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
-          >
-            Cache
-          </p>
-          <p
-            class="mt-1 flex items-baseline gap-0.5 font-display text-2xl font-semibold leading-none tabular-nums text-foreground"
-          >
+        <div class="inline-flex items-baseline gap-1.5">
+          <dt>Cache</dt>
+          <dd class="font-mono text-[13px] font-semibold leading-none tabular-nums tracking-normal text-foreground">
             <span v-if="!cacheEnabled" class="text-muted-foreground">—</span>
             <template v-else>
               {{ cacheMb
@@ -258,24 +232,15 @@
                 >MB</span
               >
             </template>
-          </p>
+          </dd>
         </div>
-        <div class="border-l border-border px-5 py-2.5">
-          <p
-            class="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground"
-          >
-            Compression
-          </p>
-          <p
-            class="mt-1 font-mono text-[13px] font-semibold leading-tight text-foreground"
-          >
-            <span v-if="!compressionEnabled" class="text-muted-foreground"
-              >off</span
-            >
-            <template v-else>{{ compressionLabel }}</template>
-          </p>
+        <div class="inline-flex items-baseline gap-1.5">
+          <dt>Uptime</dt>
+          <dd class="font-mono text-[13px] font-semibold leading-none tabular-nums tracking-normal text-foreground">
+            {{ isLoading ? '—' : uptime }}
+          </dd>
         </div>
-      </div>
+      </dl>
     </div>
   </section>
 </template>


### PR DESCRIPTION
## Problem

On lg+ desktop (worse at 1440px+), the home page's pinned chrome (Header + Hero band + Toolbar) consumed **~50% of the viewport** before any catalog card was visible. The Hero "lg+ admin band" was the offender — a tall two-column layout with a giant \`text-[32px]\` CATALOG number + a 2×2 stat-card grid (~124px).

## Fix

Replaced the lg+ band with a single compact horizontal **status strip**: capability pills (Live / Renderer / Compression / OGC / version) + inline \`label: value\` metrics (Sources · Styles · Cache · Uptime), Linear/Vercel dense-statusbar style.

## Measured result (1440×900, real browser)

| | Before | After |
|---|---|---|
| Hero band height | ~124px | **42px** |
| Total pinned chrome | ~50% viewport | **176px = 20%** |
| First catalog card | ~half-page down | visible immediately |

## No mobile regression

The \`<lg\` compact disclosure (\`hero-compact\` / \`hero-detail-wrap\` / \`heroExpanded\`/\`toggleHero\`) is **byte-unchanged**. Verified at 390×844: collapses to 45px, tap-to-expand flips \`aria-expanded\` and expands to 124px with the grid-rows animation intact.

## Constraints honored (Direction I)

- Semantic OKLch tokens only (no raw hex, no Tailwind default colors, no pure #000/#fff)
- Radius 0 (no \`rounded-*\`)
- No new components/composables; Hero.vue 281 → 246 lines
- Honest-data rule: only \`/ping\` fields, \`—\` fallbacks
- All \`useHomeHero()\` bindings preserved; a11y (aria-label, .hero-dot pulse, focus rings) intact

## Verification

- \`pnpm --filter @tileserver-rs/client run lint\` → 0 warnings, 0 errors
- \`pnpm --filter @tileserver-rs/client run build\` → ✨ Build complete
- Real-browser QA at 1440 (desktop strip) + 390 (mobile disclosure open/close)