### PR TITLE
docs: fix audit findings — dem feature, postgres defaults, mcp oauth schema, missing routes

### DIFF
--- a/apps/docs/content/1.getting-started/1.installation.md
+++ b/apps/docs/content/1.getting-started/1.installation.md
@@ -79,8 +79,8 @@ docker compose up -d
 
 ### Prerequisites
 
-- Rust 1.75 or later
-- Node.js 22 or later (for the frontend)
+- Rust 1.91 or later
+- Node.js 24 or later (for the frontend)
 - Bun (package manager)
 
 ### For Native Rendering (Optional)

--- a/apps/docs/content/1.getting-started/3.config.md
+++ b/apps/docs/content/1.getting-started/3.config.md
@@ -586,9 +586,9 @@ buffer = 64
 | Key                          | Type    | Default | Description                                                  |
 | ---------------------------- | ------- | ------- | ------------------------------------------------------------ |
 | `connection_string`          | string  | _req_   | Postgres connection URI                                      |
-| `pool_size`                  | usize   | `10`    | Connections in the pool                                      |
-| `pool_wait_timeout_ms`       | u64     | `5000`  | Max ms to wait for a free connection                         |
-| `pool_create_timeout_ms`     | u64     | `5000`  | Max ms to wait when opening a new connection                 |
+| `pool_size`                  | usize   | `20`    | Connections in the pool                                      |
+| `pool_wait_timeout_ms`       | u64     | `30000` | Max ms to wait for a free connection                         |
+| `pool_create_timeout_ms`     | u64     | `10000` | Max ms to wait when opening a new connection                 |
 | `pool_recycle_timeout_ms`    | u64     | `5000`  | Max ms to wait recycling a stale connection                  |
 | `pool_pre_warm`              | bool    | `false` | Open all pool connections at startup                         |
 | `ssl_cert`, `ssl_key`, `ssl_root_cert` | path? | _(none)_ | mTLS / verify-full SSL material                       |
@@ -726,6 +726,7 @@ The values below are the source of truth, mirrored from
 | `mlt`             | Yes     | MLT (MapLibre Tiles) ↔ MVT on-the-fly transcoding                                      |
 | `cloud`           | Yes     | Cloud PMTiles (S3 / GCS / Azure / HTTPS) via `object_store`                            |
 | `stac`            | Yes     | STAC catalog source (implies `raster`)                                                 |
+| `dem`             | Yes     | DEM terrain-RGB tile encoding — Terrarium & Mapbox-RGB (implies `raster`)              |
 | `sftp`            | No      | PMTiles over SSH (`sftp://` URLs) via russh — see [SFTP Sources](/guides/sftp)         |
 | `geoparquet`      | No      | Serve tiles from GeoParquet files on-the-fly (Arrow + Parquet)                         |
 | `duckdb`          | No      | Embedded DuckDB SQL-driven tile source                                                 |
@@ -737,7 +738,7 @@ The values below are the source of truth, mirrored from
 # Minimal API-only build (no GDAL, no Postgres, no MLT, no cloud):
 cargo build --release --no-default-features
 
-# Default features (postgres + raster + mlt + cloud + stac):
+# Default features (postgres + raster + mlt + cloud + stac + dem):
 cargo build --release
 
 # Everything, including the web UI and MCP server:

--- a/apps/docs/content/3.api/1.endpoints.md
+++ b/apps/docs/content/3.api/1.endpoints.md
@@ -141,6 +141,21 @@ On error, the server keeps the previous working configuration. No data is lost.
 You can also reload by sending `SIGHUP` to the server process: `kill -HUP <pid>`. See the [Hot Reload Guide](/guides/hot-reload) for details.
 ::
 
+## MCP OAuth Admin (Admin)
+
+```
+GET    /__admin/oauth/clients
+DELETE /__admin/oauth/clients/{client_id}
+GET    /__admin/oauth/sessions
+DELETE /__admin/oauth/sessions/{token_id}
+```
+
+Admin-listener-only REST endpoints for inspecting and revoking MCP OAuth
+clients (registered via Dynamic Client Registration) and their refresh-token
+sessions. Available when the `mcp` feature is enabled with OAuth. Deletes are
+idempotent — `{deleted: false}` is a normal success response. See the
+[MCP Admin UI guide](/guides/mcp-admin-ui) for the web UI built on these.
+
 ---
 
 ## API Key Passthrough
@@ -443,6 +458,23 @@ Returns a rendered raster tile from a vector style.
 /styles/protomaps-light/14/8192/5461@2x.png       # 1024x1024 PNG @ 2x (retina)
 /styles/protomaps-light/14/8192/5461.webp         # 512x512 WebP
 ```
+
+### Explicit tile size
+
+```
+GET /styles/{style}/{tile_size}/{z}/{x}/{y}[@{scale}x].{format}
+```
+
+An optional `tile_size` path segment (`256` or `512` only) requests a specific
+base tile edge before the scale factor is applied. Without it, tiles render at
+the default 512px base:
+
+```
+/styles/protomaps-light/256/14/8192/5461.png      # 256x256 PNG @ 1x
+/styles/protomaps-light/256/14/8192/5461@2x.png   # 512x512 PNG @ 2x
+```
+
+Any other value for `tile_size` is rejected with an error response.
 
 **Performance:**
 

--- a/apps/docs/content/4.guides/17.mcp-admin-ui.md
+++ b/apps/docs/content/4.guides/17.mcp-admin-ui.md
@@ -23,27 +23,27 @@ When the `mcp` feature is enabled with OAuth ([see the MCP Server guide](./mcp))
 - You want to audit which third-party apps have access — the **Connected apps** page shows every registered client with its scopes, redirect URIs, and last-seen timestamp.
 - A user lost a laptop — revoke just that device session (and let the user re-authenticate from their other devices).
 
-## Backend: SQLite persistence
+## Backend: OAuth store
 
-The admin UI surfaces state from the OAuth store. By default the store is in-memory (clients and tokens evaporate on restart). For a real deployment with the admin UI, enable the `mcp-persistence` feature to back the store with SQLite:
-
-```bash
-# Build with both MCP + persistence enabled
-cargo build --release --features mcp,mcp-persistence
-```
+The admin UI surfaces state from the OAuth store. The store is in-memory:
+clients and tokens evaporate on restart. The `[mcp.oauth]` keys are:
 
 ```toml
 # config.toml
 [mcp.oauth]
-issuer = "https://your-server.example.com"
-keypair_path = "/var/lib/tileserver-rs/oauth.pem"
-
-[mcp.oauth.persistence]
-# Path to a writable SQLite file. Schema is created on first launch.
-sqlite_path = "/var/lib/tileserver-rs/oauth-store.sqlite"
+enabled = true
+issuer_url = "https://your-server.example.com"
+signing_key_path = "/var/lib/tileserver-rs/oauth.pem"
+token_ttl_secs = 3600
 ```
 
-Without `mcp-persistence`, the admin UI still works against the in-memory store — but every restart resets the state, which limits its usefulness.
+::callout{type="warning"}
+**SQLite persistence is not yet configurable.** The `mcp-persistence` Cargo
+feature compiles a disk-backed SQLite store, but the config wiring to activate
+it (a `store_path` key) has not shipped yet — the server currently always uses
+the in-memory store, so a restart resets all registered clients and tokens.
+Track the wiring in the repository issues before relying on persistence.
+::
 
 ## REST API
 
@@ -66,7 +66,7 @@ The sessions endpoint reports refresh tokens only. Single-use authorization code
 
 ## Design
 
-The admin UI uses a separate "Direction I" design system (dark+violet OKLch palette, table-density layout, sharp corners) that is fully scoped to `/admin/*` via a `class="admin-theme"` overlay on the layout root. The public map viewer at `/`, `/styles/*`, and `/data/*` continues to use the existing light+blue palette — there is no token bleed between the two.
+The admin UI shares the client-wide "Direction I" design system (OKLch palette with a violet accent, table-density layout, sharp corners). The public map viewer at `/`, `/styles/*`, and `/data/*` uses the same token set, honoring the light/dark toggle across both surfaces.
 
 If you embed tileserver-rs inside a larger Nuxt app, you can disable the admin pages by removing the `admin` directory under `apps/client/app/pages/` or by reverse-proxying `/admin/*` to `404` on the public host.
 
@@ -77,7 +77,7 @@ If you embed tileserver-rs inside a larger Nuxt app, you can disable the admin p
 ::
 
 ::callout{type="info"}
-**Tokens disappear after restart.** You're running without `mcp-persistence`. Enable it in `Cargo build` and point `[mcp.oauth.persistence].sqlite_path` at a persistent volume.
+**Tokens disappear after restart.** Expected with the current in-memory store — SQLite persistence is compiled by the `mcp-persistence` feature but not yet wired to config (see the callout above). Clients simply re-register via DCR on their next connection.
 ::
 
 ::callout{type="info"}

--- a/apps/docs/content/4.guides/23.trailing-slash.md
+++ b/apps/docs/content/4.guides/23.trailing-slash.md
@@ -1,0 +1,38 @@
+---
+title: Trailing Slashes
+description: How tileserver-rs routes trailing slashes — API paths are trimmed to a canonical form, while the SPA viewer routes /styles/{id}/ and /data/{id}/ keep their slash.
+---
+
+tileserver-rs uses the trailing slash to distinguish **API endpoints** from the
+**built-in web viewer**. The same path with and without a trailing slash can be
+two different things:
+
+| Path | What it serves |
+| ---- | -------------- |
+| `/styles/protomaps-light` | Style JSON (API) |
+| `/styles/protomaps-light/` | Map viewer UI (SPA) |
+| `/data/protomaps` | TileJSON (API) |
+| `/data/protomaps/` | Data inspector UI (SPA) |
+
+## Normalization rules
+
+Every request path is normalized before routing:
+
+- **API paths are trimmed** — `/health/`, `/ping/`, `/data.json/`,
+  `/styles.json/`, `/_openapi/` and any other slashed API path serve the same
+  response as their canonical slash-less form. Curl either; both work.
+- **SPA viewer paths are preserved** — exactly two families keep their
+  trailing slash: `/styles/{id}/` and `/data/{id}/`. These fall through to the
+  embedded web UI (the `frontend` feature) instead of the greedy API routes.
+
+This means "Open in viewer" and "Inspect" links from the home page
+(`/styles/{id}/` and `/data/{id}/`) are stable, shareable URLs — including
+query flags like `/styles/{id}/?raster` — while every API consumer gets
+canonical, slash-insensitive endpoints.
+
+::alert{type="info"}
+Implementation lives in `crates/tileserver-rs/src/trailing_slash.rs` — a
+selective layer applied outside the router. A blanket trim would collapse the
+viewer routes onto the API routes and 404 every viewer link; the selective
+layer exists precisely to prevent that regression.
+::


### PR DESCRIPTION
## What

A full audit of `apps/docs` against the v2.35.0 code surface (all 17 shipped features from v2.30 → v2.35 + route registrations + Cargo features) found six drifts. This PR fixes all of them:

### 1. Missing `dem` in the Cargo features table (`3.config.md`)
The table claims to mirror `Cargo.toml` but was missing the `dem` feature (default since v2.34.0). Added the row + updated the default-build example comment.

### 2. Wrong `[postgres]` defaults (`3.config.md`)
3 of 4 pool defaults didn't match `config.rs`:
| Key | Docs said | Code says |
|---|---|---|
| `pool_size` | 10 | **20** |
| `pool_wait_timeout_ms` | 5000 | **30000** |
| `pool_create_timeout_ms` | 5000 | **10000** |

### 3. Fabricated OAuth schema in `17.mcp-admin-ui.md`
The guide documented `issuer`, `keypair_path`, and an `[mcp.oauth.persistence].sqlite_path` block — **none of which exist**. Real `McpOAuthConfig` fields: `enabled`, `issuer_url`, `signing_key_path`, `token_ttl_secs`. Verified in code: `OAuthState::from_pem` always installs `InMemoryStore`; the `mcp-persistence` SqliteStore is compiled but has **no config wiring to activate it** (even `auth.rs:217`'s doc-comment references a `store_path` field that was never added). The guide now documents the real schema + an honest callout that persistence isn't reachable yet. Also fixed the stale claim that admin uses a separate palette (Direction I is client-wide since the unification).

### 4. Stale versions in `1.installation.md`
Rust 1.75 → 1.91 (`rust-version`), Node 22 → 24 (`engines`).

### 5. Two real routes missing from `1.endpoints.md`
- `/styles/{style}/{tile_size}/{z}/{x}/{y}[@{scale}x].{format}` (explicit 256/512 tile size, registered at `routes/mod.rs`)
- `/__admin/oauth/{clients,sessions}` GET/DELETE admin REST endpoints

### 6. Trailing-slash behavior undocumented
New guide `23.trailing-slash.md`: API paths trim to canonical form; the SPA viewer families `/styles/{id}/` and `/data/{id}/` preserve the slash (the v2.33.2 selective layer).

## Not in this PR (needs a decision)
The `mcp-persistence` code gap itself — adding a real `store_path` field to `McpOAuthConfig` and wiring `SqliteStore` in `McpAuthMode::from_config` — is a **code** change, tracked separately.

## Verification
- `pnpm --filter @tileserver-rs/docs run lint` → 0 warnings, 0 errors
- `pnpm --filter @tileserver-rs/docs run build` → ✨ Build complete
- Every claim verified against code: `config.rs` defaults, `McpOAuthConfig` fields, `routes/mod.rs` registrations, `trailing_slash.rs`, `Cargo.toml` features