### PR TITLE
feat(mcp): wire [mcp.oauth].store_path to the SQLite persistence store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7389,7 +7389,7 @@ dependencies = [
 
 [[package]]
 name = "tileserver-rs"
-version = "2.34.1"
+version = "2.35.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/apps/docs/content/1.getting-started/3.config.md
+++ b/apps/docs/content/1.getting-started/3.config.md
@@ -643,6 +643,7 @@ enabled = false                       # mutually exclusive with auth_token
 issuer_url = "https://tiles.example.com"
 signing_key_path = "/etc/tileserver/mcp-jwt-key.pem"
 token_ttl_secs = 3600
+# store_path = "/var/lib/tileserver-rs/oauth-store.sqlite"  # requires mcp-persistence
 ```
 
 ### `[mcp]` root
@@ -661,6 +662,7 @@ token_ttl_secs = 3600
 | `issuer_url`       | string? | _(none)_| Required when `enabled = true`. Must match the public URL                                            |
 | `signing_key_path` | path?   | _(none)_| Required when `enabled = true`. RSA PKCS#8 PEM private key                                           |
 | `token_ttl_secs`   | u64     | `3600`  | Access-token TTL (clamped to 86400)                                                                  |
+| `store_path`       | path?   | _(none)_| SQLite file persisting OAuth state across restarts. Requires `mcp-persistence`; fails fast without it |
 
 ## Top-level fields
 

--- a/apps/docs/content/4.guides/16.mcp.md
+++ b/apps/docs/content/4.guides/16.mcp.md
@@ -213,6 +213,7 @@ Once wired in, try:
 | `[mcp.oauth].issuer_url` | `string` | unset | Public URL the server is reachable at. Required when oauth enabled. |
 | `[mcp.oauth].signing_key_path` | `path` | unset | RSA PKCS#8 private key path for RS256 JWT signing. Required when oauth enabled. |
 | `[mcp.oauth].token_ttl_secs` | `u64` | `3600` | Access token TTL in seconds. Clamped to 86400 (24h) max. |
+| `[mcp.oauth].store_path` | `path?` | unset | SQLite file persisting OAuth clients/tokens across restarts. Requires the `mcp-persistence` feature — startup fails fast if set without it. Unset = in-memory store. |
 
 The `[mcp]` block is only honored when tileserver-rs is built with `--features mcp`. Without that feature, the block is ignored and no MCP code is compiled in.
 

--- a/apps/docs/content/4.guides/17.mcp-admin-ui.md
+++ b/apps/docs/content/4.guides/17.mcp-admin-ui.md
@@ -23,10 +23,17 @@ When the `mcp` feature is enabled with OAuth ([see the MCP Server guide](./mcp))
 - You want to audit which third-party apps have access — the **Connected apps** page shows every registered client with its scopes, redirect URIs, and last-seen timestamp.
 - A user lost a laptop — revoke just that device session (and let the user re-authenticate from their other devices).
 
-## Backend: OAuth store
+## Backend: SQLite persistence
 
-The admin UI surfaces state from the OAuth store. The store is in-memory:
-clients and tokens evaporate on restart. The `[mcp.oauth]` keys are:
+The admin UI surfaces state from the OAuth store. By default the store is
+in-memory (clients and tokens evaporate on restart). For a real deployment,
+build with the `mcp-persistence` feature and point `store_path` at a writable
+SQLite file:
+
+```bash
+# Build with both MCP + persistence enabled
+cargo build --release --features mcp,mcp-persistence
+```
 
 ```toml
 # config.toml
@@ -34,16 +41,11 @@ clients and tokens evaporate on restart. The `[mcp.oauth]` keys are:
 enabled = true
 issuer_url = "https://your-server.example.com"
 signing_key_path = "/var/lib/tileserver-rs/oauth.pem"
-token_ttl_secs = 3600
+# Path to a writable SQLite file. Schema is created on first launch.
+store_path = "/var/lib/tileserver-rs/oauth-store.sqlite"
 ```
 
-::callout{type="warning"}
-**SQLite persistence is not yet configurable.** The `mcp-persistence` Cargo
-feature compiles a disk-backed SQLite store, but the config wiring to activate
-it (a `store_path` key) has not shipped yet — the server currently always uses
-the in-memory store, so a restart resets all registered clients and tokens.
-Track the wiring in the repository issues before relying on persistence.
-::
+Setting `store_path` in a binary built **without** `mcp-persistence` fails fast at startup — persistence you configured is never silently ignored. Without `store_path`, the admin UI still works against the in-memory store — but every restart resets the state, which limits its usefulness.
 
 ## REST API
 
@@ -77,7 +79,7 @@ If you embed tileserver-rs inside a larger Nuxt app, you can disable the admin p
 ::
 
 ::callout{type="info"}
-**Tokens disappear after restart.** Expected with the current in-memory store — SQLite persistence is compiled by the `mcp-persistence` feature but not yet wired to config (see the callout above). Clients simply re-register via DCR on their next connection.
+**Tokens disappear after restart.** You're running without persistence. Build with `--features mcp,mcp-persistence` and point `[mcp.oauth].store_path` at a SQLite file on a persistent volume.
 ::
 
 ::callout{type="info"}

--- a/crates/tileserver-rs/src/config.rs
+++ b/crates/tileserver-rs/src/config.rs
@@ -127,8 +127,10 @@ pub struct McpConfig {
 /// claude.ai Custom Connectors. Tokens are JWTs signed with RS256 using a
 /// key loaded from disk at startup.
 ///
-/// **Token store is in-memory only** — restarting the server invalidates
-/// all issued access and refresh tokens. Clients must re-authorize.
+/// **Token store is in-memory by default** — restarting the server
+/// invalidates all issued access and refresh tokens and clients must
+/// re-authorize. Set `store_path` (with the `mcp-persistence` feature)
+/// to persist the store in SQLite across restarts.
 #[cfg(feature = "mcp")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -148,6 +150,11 @@ pub struct McpOAuthConfig {
     /// (24 h) at startup.
     #[serde(default = "default_token_ttl_secs")]
     pub token_ttl_secs: u64,
+    /// Path to a SQLite file backing the OAuth store (clients, auth codes,
+    /// refresh tokens survive restarts). Requires the `mcp-persistence`
+    /// Cargo feature — startup fails fast if set without it. When unset,
+    /// the store is in-memory and resets on every restart.
+    pub store_path: Option<std::path::PathBuf>,
 }
 
 #[cfg(feature = "mcp")]
@@ -163,6 +170,7 @@ impl Default for McpOAuthConfig {
             issuer_url: None,
             signing_key_path: None,
             token_ttl_secs: default_token_ttl_secs(),
+            store_path: None,
         }
     }
 }

--- a/crates/tileserver-rs/src/config_schema.rs
+++ b/crates/tileserver-rs/src/config_schema.rs
@@ -1120,6 +1120,14 @@ pub static CONFIG_SCHEMA: &[ConfigSectionSchema] = &[
                 optional: false,
                 enum_values: None,
             },
+            ConfigFieldSchema {
+                key: "store_path",
+                field_type: "path",
+                default: None,
+                description: "SQLite file persisting OAuth clients/tokens across restarts. Requires the mcp-persistence feature.",
+                optional: true,
+                enum_values: None,
+            },
         ],
     },
     ConfigSectionSchema {

--- a/crates/tileserver-rs/src/mcp/transport.rs
+++ b/crates/tileserver-rs/src/mcp/transport.rs
@@ -105,6 +105,26 @@ impl McpAuthMode {
                 .ok_or_else(|| anyhow::anyhow!("`[mcp.oauth].signing_key_path` is required"))?;
             let state =
                 OAuthState::from_file(issuer.to_string(), key_path, cfg.oauth.token_ttl_secs)?;
+            let state = match cfg.oauth.store_path.as_deref() {
+                #[cfg(feature = "mcp-persistence")]
+                Some(store_path) => {
+                    let store = super::auth_store_sqlite::SqliteStore::open(store_path)
+                        .map_err(|e| anyhow::anyhow!("open `[mcp.oauth].store_path`: {e}"))?;
+                    tracing::info!(path = %store_path.display(), "MCP OAuth store: SQLite");
+                    OAuthState {
+                        store: std::sync::Arc::new(store),
+                        ..state
+                    }
+                }
+                #[cfg(not(feature = "mcp-persistence"))]
+                Some(store_path) => anyhow::bail!(
+                    "`[mcp.oauth].store_path` is set ({}) but this binary was built \
+                     without the `mcp-persistence` feature; rebuild with \
+                     `--features mcp,mcp-persistence` or unset store_path",
+                    store_path.display()
+                ),
+                None => state,
+            };
             tracing::info!(issuer = %issuer, "MCP OAuth authorization server enabled");
             Ok(Self::OAuth(Box::new(state)))
         } else if let Some(token) = cfg.auth_token.clone() {
@@ -595,6 +615,7 @@ mod tests {
                 issuer_url: Some("http://localhost:8080".to_string()),
                 signing_key_path: Some(key.path().to_path_buf()),
                 token_ttl_secs: 3600,
+                store_path: None,
             },
             ..McpConfig::default()
         };
@@ -604,6 +625,98 @@ mod tests {
         assert!(
             matches!(mode, McpAuthMode::OAuth(_)),
             "expected McpAuthMode::OAuth, got {mode:?}"
+        );
+    }
+
+    /// `store_path` + `mcp-persistence` selects the disk-backed SQLite
+    /// store instead of the in-memory default. Asserted via the store's
+    /// `Debug` representation because `OAuthState.store` is a trait object.
+    #[cfg(feature = "mcp-persistence")]
+    #[test]
+    fn from_config_oauth_uses_sqlite_store_when_store_path_set() {
+        let key = write_test_pem_to_tempfile();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store_path = dir.path().join("oauth-store.sqlite");
+        let cfg = McpConfig {
+            oauth: crate::config::McpOAuthConfig {
+                enabled: true,
+                issuer_url: Some("http://localhost:8080".to_string()),
+                signing_key_path: Some(key.path().to_path_buf()),
+                store_path: Some(store_path.clone()),
+                ..crate::config::McpOAuthConfig::default()
+            },
+            ..McpConfig::default()
+        };
+
+        let mode = McpAuthMode::from_config(&cfg).expect("oauth config with store_path builds");
+
+        let McpAuthMode::OAuth(state) = mode else {
+            panic!("expected McpAuthMode::OAuth");
+        };
+        let store_debug = format!("{:?}", state.store);
+        assert!(
+            store_debug.contains("SqliteStore"),
+            "store must be SqliteStore when store_path is set, got: {store_debug}"
+        );
+        assert!(
+            store_path.exists(),
+            "SQLite file must be created at the configured store_path"
+        );
+    }
+
+    /// Without `store_path` the store stays in-memory (the default) even
+    /// when the `mcp-persistence` feature is compiled in.
+    #[test]
+    fn from_config_oauth_uses_memory_store_without_store_path() {
+        let key = write_test_pem_to_tempfile();
+        let cfg = McpConfig {
+            oauth: crate::config::McpOAuthConfig {
+                enabled: true,
+                issuer_url: Some("http://localhost:8080".to_string()),
+                signing_key_path: Some(key.path().to_path_buf()),
+                ..crate::config::McpOAuthConfig::default()
+            },
+            ..McpConfig::default()
+        };
+
+        let mode = McpAuthMode::from_config(&cfg).expect("oauth config builds");
+
+        let McpAuthMode::OAuth(state) = mode else {
+            panic!("expected McpAuthMode::OAuth");
+        };
+        let store_debug = format!("{:?}", state.store);
+        assert!(
+            store_debug.contains("InMemoryStore"),
+            "store must default to InMemoryStore without store_path, got: {store_debug}"
+        );
+    }
+
+    /// `store_path` set but the binary was built WITHOUT `mcp-persistence`:
+    /// fail fast at startup instead of silently running in-memory — an
+    /// operator who configured persistence must not lose OAuth state to a
+    /// silently ignored key.
+    #[cfg(not(feature = "mcp-persistence"))]
+    #[test]
+    fn from_config_errors_when_store_path_set_without_persistence_feature() {
+        let key = write_test_pem_to_tempfile();
+        let cfg = McpConfig {
+            oauth: crate::config::McpOAuthConfig {
+                enabled: true,
+                issuer_url: Some("http://localhost:8080".to_string()),
+                signing_key_path: Some(key.path().to_path_buf()),
+                store_path: Some(std::path::PathBuf::from("/tmp/oauth.sqlite")),
+                ..crate::config::McpOAuthConfig::default()
+            },
+            ..McpConfig::default()
+        };
+
+        let err = McpAuthMode::from_config(&cfg)
+            .expect_err("store_path without mcp-persistence must fail fast");
+
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("mcp-persistence"),
+            "error must tell the operator to rebuild with mcp-persistence, got: {msg}"
         );
     }
 

--- a/data/configs/mcp.toml
+++ b/data/configs/mcp.toml
@@ -50,6 +50,7 @@ cors_origins = ["*"]
 # issuer_url = "https://tiles.example.com"
 # signing_key_path = "/etc/tileserver-rs/mcp-jwt-key.pem"
 # token_ttl_secs = 3600  # max 86 400 (24 h); larger values are clamped down
+# store_path = "/var/lib/tileserver-rs/oauth-store.sqlite"  # persist OAuth state (requires mcp-persistence feature)
 
 # At least one source is needed for the MCP tools to return useful results.
 # Swap the path for a real PMTiles or MBTiles file on disk.


### PR DESCRIPTION
## Problem

The `mcp-persistence` Cargo feature compiled `SqliteStore` but **nothing could activate it**: `McpOAuthConfig` had no `store_path` field and `OAuthState::from_pem` always installed `InMemoryStore`. Every deployment built with `mcp-persistence` (including the demo) has been silently running OAuth state in-memory — clients and refresh tokens evaporate on every restart. Found during the docs audit (#1254 documents the interim state honestly; this PR ships the real wiring).

## Changes

- **`config.rs`**: `McpOAuthConfig.store_path: Option<PathBuf>` — SQLite file persisting OAuth clients/auth-codes/refresh-tokens across restarts
- **`config_schema.rs`**: `store_path` entry in the `[mcp.oauth]` section (admin config editor)
- **`transport.rs` `McpAuthMode::from_config`**:
  - `store_path` set + `mcp-persistence` compiled → `SqliteStore::open` replaces the in-memory store
  - `store_path` set **without** the feature → **fail fast at startup** with a rebuild hint (configured persistence must never be silently ignored)
  - `store_path` unset → in-memory store, unchanged behavior
- **Docs**: `16.mcp.md` config table, `17.mcp-admin-ui.md` persistence section (now documents real keys), `3.config.md` `[mcp.oauth]` table + example, `data/configs/mcp.toml`

## Tests (TDD)

| Test | Feature combo | Asserts |
|---|---|---|
| `from_config_oauth_uses_sqlite_store_when_store_path_set` | `mcp,mcp-persistence` | store Debug-repr contains `SqliteStore` + the file is created |
| `from_config_oauth_uses_memory_store_without_store_path` | both | default stays `InMemoryStore` |
| `from_config_errors_when_store_path_set_without_persistence_feature` | `mcp` only | startup error mentions `mcp-persistence` |

## Verification

- `cargo test --features mcp --lib` → 7/7 from_config tests pass (incl. fail-fast branch)
- `cargo test --features mcp,mcp-persistence --lib` → 7/7 (incl. sqlite branch)
- `cargo test --all-features --lib` → **1368 passed, 0 failed**
- MCP integration binaries: route_mcp_handlers 21/21, route_mcp_http 18/18, route_mcp_oauth 17/17, route_mcp_stdio 2/2
- `route_admin_config_schema` 2/2, `api_endpoints` (openapi snapshot) 75/75 — no snapshot drift
- `cargo fmt --check`, `clippy --all-features`, `clippy --no-default-features` all clean