### PR TITLE
feat: serve GUI and API under a URL subfolder (#1385)

### DIFF
--- a/apps/client/app/components/home/DataCardServices.vue
+++ b/apps/client/app/components/home/DataCardServices.vue
@@ -26,7 +26,7 @@
       >Services:</span
     >
     <a
-      :href="`/data/${source.id}.json`"
+      :href="apiUrl(`/data/${source.id}.json`)"
       target="_blank"
       rel="noopener noreferrer"
       class="services-link text-primary font-medium transition-colors duration-(--d-fast)"

--- a/apps/client/app/components/home/StyleCard.vue
+++ b/apps/client/app/components/home/StyleCard.vue
@@ -44,7 +44,7 @@
       >
         <img
           v-if="!imgError"
-          :src="`/styles/${style.id}/static/0,0,1/160x160.png`"
+          :src="apiUrl(`/styles/${style.id}/static/0,0,1/160x160.png`)"
           :alt="style.name"
           class="size-full object-cover"
           loading="lazy"

--- a/apps/client/app/components/home/StyleCardServices.vue
+++ b/apps/client/app/components/home/StyleCardServices.vue
@@ -43,7 +43,7 @@
       >Services:</span
     >
     <a
-      :href="`/styles/${style.id}/style.json`"
+      :href="apiUrl(`/styles/${style.id}/style.json`)"
       target="_blank"
       rel="noopener noreferrer"
       class="services-link text-primary font-medium transition-colors duration-(--d-fast)"
@@ -51,7 +51,7 @@
     >
     <span class="sep text-muted-foreground opacity-50">·</span>
     <a
-      :href="`/styles/${style.id}.json`"
+      :href="apiUrl(`/styles/${style.id}.json`)"
       target="_blank"
       rel="noopener noreferrer"
       class="services-link text-primary font-medium transition-colors duration-(--d-fast)"
@@ -59,7 +59,7 @@
     >
     <span class="sep text-muted-foreground opacity-50">·</span>
     <a
-      :href="`/styles/${style.id}/wmts.xml`"
+      :href="apiUrl(`/styles/${style.id}/wmts.xml`)"
       target="_blank"
       rel="noopener noreferrer"
       class="services-link text-primary font-medium transition-colors duration-(--d-fast)"

--- a/apps/client/app/composables/use-data-inspector.ts
+++ b/apps/client/app/composables/use-data-inspector.ts
@@ -54,7 +54,7 @@ export function useDataInspector(dataId: Ref<string>) {
       sources: {
         vector_layer_: {
           type: 'vector',
-          url: `/data/${dataId.value}.json`,
+          url: apiUrl(`/data/${dataId.value}.json`),
         },
       },
       layers: [],

--- a/apps/client/app/composables/use-file-drop.ts
+++ b/apps/client/app/composables/use-file-drop.ts
@@ -116,7 +116,7 @@ export function useFileDrop(mapRef: ShallowRef<Map | null>) {
       // COG = raster source
       map.addSource(sourceId, {
         type: 'raster',
-        url: `/data/${response.source_id}.json`,
+        url: apiUrl(`/data/${response.source_id}.json`),
         tileSize: 256,
       });
 
@@ -142,7 +142,7 @@ export function useFileDrop(mapRef: ShallowRef<Map | null>) {
       // MBTiles / SQLite = vector source
       map.addSource(sourceId, {
         type: 'vector',
-        url: `/data/${response.source_id}.json`,
+        url: apiUrl(`/data/${response.source_id}.json`),
       });
 
       const layerIds = addVectorLayersFromTileJSON(

--- a/apps/client/app/composables/use-server-info.ts
+++ b/apps/client/app/composables/use-server-info.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/vue-query';
 import { pingQueryOptions } from '~/utils/api/server/queries';
 
 export function useServerInfo() {
-  const { data, error } = useFetch<PingResponse>('/ping');
+  const { data, error } = useFetch<PingResponse>(apiUrl('/ping'));
 
   const versionLabel = computed(() => {
     if (!data.value) return '';

--- a/apps/client/app/lib/map-tools.ts
+++ b/apps/client/app/lib/map-tools.ts
@@ -818,7 +818,7 @@ export function createServerClientTools() {
   const getSourceSchema = getSourceSchemaDef.client(async ({ source }) => {
     try {
       const response = await fetch(
-        `/api/spatial/schema/${encodeURIComponent(source)}`,
+        apiUrl(`/api/spatial/schema/${encodeURIComponent(source)}`),
       );
       if (!response.ok) {
         return {
@@ -846,7 +846,7 @@ export function createServerClientTools() {
   const getSourceStats = getSourceStatsDef.client(async ({ source }) => {
     try {
       const response = await fetch(
-        `/api/spatial/stats/${encodeURIComponent(source)}`,
+        apiUrl(`/api/spatial/stats/${encodeURIComponent(source)}`),
       );
       if (!response.ok) {
         return {
@@ -882,7 +882,7 @@ export function createServerClientTools() {
   const spatialQuery = spatialQueryDef.client(
     async ({ source, bbox, zoom, layers, limit }) => {
       try {
-        const response = await fetch('/api/spatial/query', {
+        const response = await fetch(apiUrl('/api/spatial/query'), {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ source, bbox, zoom, layers, limit }),

--- a/apps/client/app/utils/api-url.ts
+++ b/apps/client/app/utils/api-url.ts
@@ -1,0 +1,25 @@
+/**
+ * Build a server URL that respects the runtime base path.
+ *
+ * When tileserver-rs is deployed under a URL subfolder (e.g. `/maps`), the
+ * server rewrites the embedded SPA's runtime `app.baseURL` at startup, so
+ * `useRuntimeConfig().app.baseURL` reflects the subfolder at runtime. All
+ * direct server requests — `$fetch`, native `fetch`, MapLibre source URLs, and
+ * `:href`/`:src` asset links — must be prefixed with it so the browser requests
+ * subfolder-prefixed URLs. `<NuxtLink :to>` and chunk/asset loading are already
+ * base-aware via Nuxt's router and build config, so they must NOT be wrapped.
+ *
+ * For a root deployment `app.baseURL` is `/`, so this returns the path
+ * unchanged.
+ *
+ * @param path - A root-absolute server path, e.g. `/ping` or `/data/x.json`.
+ * @returns The path prefixed with the runtime base, e.g. `/maps/ping`.
+ */
+export function apiUrl(path: string): string {
+  const { app } = useRuntimeConfig();
+  // `app.baseURL` is `/` (root) or `/maps/` (subfolder). Drop the trailing
+  // slash so joining with a leading-slash path yields `/ping` or `/maps/ping`
+  // rather than a doubled slash.
+  const base = app.baseURL.replace(/\/$/, '');
+  return `${base}${path}`;
+}

--- a/apps/client/app/utils/api/admin-config/queries.ts
+++ b/apps/client/app/utils/api/admin-config/queries.ts
@@ -6,7 +6,7 @@ import { ADMIN_CONFIG_QUERY_KEYS } from '~/utils/query-keys/admin-config';
 export function adminConfigQueryOptions() {
   return queryOptions({
     queryKey: ADMIN_CONFIG_QUERY_KEYS.view(),
-    queryFn: () => $fetch<AdminConfigPayload>('/__admin/config'),
+    queryFn: () => $fetch<AdminConfigPayload>(apiUrl('/__admin/config')),
     staleTime: 0,
     refetchOnMount: 'always',
   });
@@ -15,7 +15,7 @@ export function adminConfigQueryOptions() {
 export function adminConfigSchemaQueryOptions() {
   return queryOptions({
     queryKey: ADMIN_CONFIG_QUERY_KEYS.schema(),
-    queryFn: () => $fetch<ConfigSchemaPayload>('/__admin/config/schema'),
+    queryFn: () => $fetch<ConfigSchemaPayload>(apiUrl('/__admin/config/schema')),
     staleTime: 1000 * 60 * 60,
   });
 }

--- a/apps/client/app/utils/api/admin-mcp/queries.ts
+++ b/apps/client/app/utils/api/admin-mcp/queries.ts
@@ -16,12 +16,12 @@ import type { AdminMcpClient, AdminMcpSession } from '~/types';
 import { ADMIN_MCP_QUERY_KEYS } from '~/utils/query-keys';
 
 export async function fetchAdminMcpClients(): Promise<AdminMcpClient[]> {
-  const result = await $fetch<AdminMcpClient[]>('/__admin/oauth/clients');
+  const result = await $fetch<AdminMcpClient[]>(apiUrl('/__admin/oauth/clients'));
   return result ?? [];
 }
 
 export async function fetchAdminMcpSessions(): Promise<AdminMcpSession[]> {
-  const result = await $fetch<AdminMcpSession[]>('/__admin/oauth/sessions');
+  const result = await $fetch<AdminMcpSession[]>(apiUrl('/__admin/oauth/sessions'));
   return result ?? [];
 }
 

--- a/apps/client/app/utils/api/admin-mcp/use-delete-client.mutation.ts
+++ b/apps/client/app/utils/api/admin-mcp/use-delete-client.mutation.ts
@@ -15,7 +15,7 @@ export function useDeleteAdminMcpClientMutation() {
   return useMutation({
     mutationFn: async (clientId: string): Promise<AdminMcpDeleteResponse> => {
       return $fetch<AdminMcpDeleteResponse>(
-        `/__admin/oauth/clients/${encodeURIComponent(clientId)}`,
+        apiUrl(`/__admin/oauth/clients/${encodeURIComponent(clientId)}`),
         {
           method: 'DELETE',
         },

--- a/apps/client/app/utils/api/admin-mcp/use-delete-session.mutation.ts
+++ b/apps/client/app/utils/api/admin-mcp/use-delete-session.mutation.ts
@@ -15,7 +15,7 @@ export function useDeleteAdminMcpSessionMutation() {
   return useMutation({
     mutationFn: async (token: string): Promise<AdminMcpDeleteResponse> => {
       return $fetch<AdminMcpDeleteResponse>(
-        `/__admin/oauth/sessions/${encodeURIComponent(token)}`,
+        apiUrl(`/__admin/oauth/sessions/${encodeURIComponent(token)}`),
         {
           method: 'DELETE',
         },

--- a/apps/client/app/utils/api/data/queries.ts
+++ b/apps/client/app/utils/api/data/queries.ts
@@ -13,12 +13,12 @@ import { DATA_SOURCES_QUERY_KEYS } from '~/utils/query-keys';
 // ============================================================================
 
 export async function fetchDataSources(): Promise<Data[]> {
-  const result = await $fetch<Data[]>('/data.json');
+  const result = await $fetch<Data[]>(apiUrl('/data.json'));
   return result ?? [];
 }
 
 export async function fetchDataSource(id: string): Promise<Data | null> {
-  const result = await $fetch<Data>(`/data/${id}.json`);
+  const result = await $fetch<Data>(apiUrl(`/data/${id}.json`));
   return result ?? null;
 }
 

--- a/apps/client/app/utils/api/server/queries.ts
+++ b/apps/client/app/utils/api/server/queries.ts
@@ -2,7 +2,7 @@ import type { PingResponse } from '~/types';
 import { SERVER_QUERY_KEYS } from '~/utils/query-keys';
 
 export async function fetchPing(): Promise<PingResponse> {
-  return await $fetch<PingResponse>('/ping');
+  return await $fetch<PingResponse>(apiUrl('/ping'));
 }
 
 export function pingQueryOptions() {

--- a/apps/client/app/utils/api/styles/queries.ts
+++ b/apps/client/app/utils/api/styles/queries.ts
@@ -34,7 +34,7 @@ export const defaultStyle: StyleSpecification = {
 // ============================================================================
 
 export async function fetchStyles(): Promise<Style[]> {
-  const result = await $fetch<Style[]>('/styles.json');
+  const result = await $fetch<Style[]>(apiUrl('/styles.json'));
   return result ?? [];
 }
 
@@ -42,7 +42,7 @@ export async function fetchVectorStyle(
   id: string,
 ): Promise<StyleSpecification> {
   const styleSpec = await $fetch<StyleSpecification>(
-    `/styles/${id}/style.json`,
+    apiUrl(`/styles/${id}/style.json`),
   );
   return styleSpec ?? defaultStyle;
 }
@@ -50,7 +50,7 @@ export async function fetchVectorStyle(
 export async function fetchRasterStyle(
   id: string,
 ): Promise<StyleSpecification> {
-  const tileJSON = await $fetch<TileJSON>(`/styles/${id}.json`);
+  const tileJSON = await $fetch<TileJSON>(apiUrl(`/styles/${id}.json`));
 
   if (!tileJSON) {
     return defaultStyle;

--- a/apps/client/app/utils/api/upload/use-delete-upload.mutation.ts
+++ b/apps/client/app/utils/api/upload/use-delete-upload.mutation.ts
@@ -13,7 +13,7 @@ export function useDeleteUploadMutation() {
 
   return useMutation({
     mutationFn: async (uploadId: string): Promise<void> => {
-      await $fetch(`/api/upload/${uploadId}`, {
+      await $fetch(apiUrl(`/api/upload/${uploadId}`), {
         method: 'DELETE',
       });
     },

--- a/apps/client/app/utils/api/upload/use-upload-file.mutation.ts
+++ b/apps/client/app/utils/api/upload/use-upload-file.mutation.ts
@@ -18,7 +18,7 @@ export function useUploadFileMutation() {
       const formData = new FormData();
       formData.append('file', file);
 
-      return $fetch<UploadResponse>('/api/upload', {
+      return $fetch<UploadResponse>(apiUrl('/api/upload'), {
         method: 'POST',
         body: formData,
       });

--- a/apps/docs/content/1.getting-started/3.config.md
+++ b/apps/docs/content/1.getting-started/3.config.md
@@ -94,6 +94,7 @@ upload_dir = "/var/lib/tileserver/uploads" # optional
 upload_max_size_mb = 500
 disable_render = false                     # optional — turn off raster routes
 disable_ogc = false                        # optional — turn off OGC API routes
+subfolder_mode = "proxy-strip"             # optional — subfolder serving mode
 ```
 
 | Key                  | Type           | Default        | Description                                                                                                       |
@@ -108,6 +109,48 @@ disable_ogc = false                        # optional — turn off OGC API route
 | `extra_response_headers` | table?     | _(none)_       | User-defined response headers applied to every HTTP response — see [`[server.extra_response_headers]`](#serverextra_response_headers) below |
 | `disable_render`     | bool           | `false`        | Unregister raster render routes (raster tiles + static images) at startup. Style metadata (`style.json`, sprites, WMTS) stays served. Disabled routes return `404`. |
 | `disable_ogc`        | bool           | `false`        | Unregister OGC API routes (`/ogc/*`) at startup. No effect unless built with the `ogc` feature. Disabled routes return `404`. |
+| `subfolder_mode`     | `"proxy-strip"` \| `"nested"` | `"proxy-strip"` | How the embedded GUI + API are served under a URL subfolder — see [Subfolder deployment](#subfolder-deployment) below. Ignored for root deployments. |
+
+### Subfolder deployment
+
+By default the server assumes it is mounted at the domain root (`https://tiles.example.com/`). To serve it under a **URL subfolder** (e.g. `https://example.com/maps/`), set the subfolder path in `public_url` — the server derives the base path from it and rebases the embedded GUI (asset URLs, API calls, and the Vue Router base) at startup, so no client rebuild is needed. A root deployment (no subfolder in `public_url`) serves byte-identical embedded assets, so this feature is a no-op unless you opt in.
+
+`subfolder_mode` chooses **where the subfolder prefix is stripped** from incoming request paths:
+
+| Mode           | Who strips the prefix | Reverse-proxy config |
+| -------------- | --------------------- | -------------------- |
+| `"proxy-strip"` _(default)_ | The reverse proxy | `proxy_pass http://backend/;` (trailing slash strips `/maps`) |
+| `"nested"`     | The server itself | `proxy_pass http://backend;` (no trailing slash — prefix forwarded intact) |
+
+**`proxy-strip` (default)** — the reverse proxy removes the `/maps` prefix before forwarding, so the server sees root paths (`/ping`, `/_nuxt/x.js`). The GUI is still rebased so the browser requests `/maps/...` URLs.
+
+```nginx
+location /maps/ {
+    proxy_pass http://127.0.0.1:8080/;   # trailing slash strips /maps
+}
+```
+
+```toml
+[server]
+public_url = "https://example.com/maps"
+# subfolder_mode defaults to "proxy-strip"
+```
+
+**`nested`** — the proxy forwards the prefix untouched and the server strips it itself. Useful when the proxy cannot rewrite the path, or for testing a subfolder locally with no proxy at all.
+
+```nginx
+location /maps/ {
+    proxy_pass http://127.0.0.1:8080;    # no trailing slash — prefix forwarded
+}
+```
+
+```toml
+[server]
+public_url = "https://example.com/maps"
+subfolder_mode = "nested"
+```
+
+With `nested` the server responds directly at `http://127.0.0.1:8080/maps/` — you can verify a subfolder deployment end-to-end with no proxy.
 
 ### CORS origin patterns
 

--- a/crates/tileserver-rs/src/base_path.rs
+++ b/crates/tileserver-rs/src/base_path.rs
@@ -1,0 +1,211 @@
+//! Base-path prefix stripping for `SubfolderMode::Nested` deployments.
+//!
+//! When the server is deployed under a URL subfolder and the reverse proxy
+//! forwards the prefix untouched (rather than stripping it), every request
+//! arrives with the subfolder prefix (e.g. `/maps/ping`, `/maps/_nuxt/x.js`).
+//! This layer strips that prefix before routing so the existing router — which
+//! is defined at the root — matches unchanged. It is the in-server equivalent
+//! of a `proxy_pass http://backend/;` prefix strip, and it reuses the whole
+//! route table, SPA fallback, and trailing-slash handling verbatim.
+//!
+//! Like [`crate::trailing_slash::SelectiveTrailingSlashLayer`], this layer must
+//! wrap the router from the OUTSIDE (routing happens before inner `.layer()`
+//! middleware) and is served via `ServiceExt::into_make_service`.
+
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum::extract::Request;
+use axum::http::Uri;
+use axum::http::uri::PathAndQuery;
+use tower::{Layer, Service};
+
+/// Strip `base` from the front of `path` at a segment boundary.
+///
+/// Returns the remainder with a leading slash (`/maps/ping` -> `/ping`,
+/// `/maps` and `/maps/` -> `/`), or `None` when `path` does not actually sit
+/// under `base` (e.g. `/mapsx/ping` is not under `/maps`), in which case the
+/// request is left untouched.
+#[must_use]
+pub fn strip_base_prefix(path: &str, base: &str) -> Option<String> {
+    // An empty base means no subfolder stripping (root or proxy-strip mode):
+    // a true no-op so the request URI is left exactly as received.
+    if base.is_empty() {
+        return None;
+    }
+    let rest = path.strip_prefix(base)?;
+    if rest.is_empty() {
+        Some("/".to_owned())
+    } else if rest.starts_with('/') {
+        Some(rest.to_owned())
+    } else {
+        None
+    }
+}
+
+/// Tower layer applying [`BasePathStrip`] for a fixed base path.
+#[derive(Clone, Debug)]
+pub struct BasePathStripLayer {
+    base: Arc<str>,
+}
+
+impl BasePathStripLayer {
+    /// Create a layer that strips `base` (a normalized subfolder such as
+    /// `/maps`, with a leading slash and no trailing slash) from every request.
+    #[must_use]
+    pub fn new(base: impl Into<Arc<str>>) -> Self {
+        Self { base: base.into() }
+    }
+}
+
+impl<S> Layer<S> for BasePathStripLayer {
+    type Service = BasePathStrip<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        BasePathStrip {
+            inner,
+            base: Arc::clone(&self.base),
+        }
+    }
+}
+
+/// Service that strips the configured base-path prefix from a request's URI
+/// before routing. Must wrap the router from the OUTSIDE so it runs first.
+#[derive(Clone, Debug)]
+pub struct BasePathStrip<S> {
+    inner: S,
+    base: Arc<str>,
+}
+
+impl<S> Service<Request> for BasePathStrip<S>
+where
+    S: Service<Request>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: Request) -> Self::Future {
+        if let Some(stripped) = strip_base_prefix(req.uri().path(), &self.base) {
+            rewrite_request_path(&mut req, &stripped);
+        }
+        self.inner.call(req)
+    }
+}
+
+/// Rewrite `req`'s URI path to `new_path`, preserving the query string. A
+/// malformed rebuild leaves the request untouched, so this never drops a
+/// request.
+fn rewrite_request_path(req: &mut Request, new_path: &str) {
+    let rebuilt = match req.uri().query() {
+        Some(query) => format!("{new_path}?{query}"),
+        None => new_path.to_owned(),
+    };
+    let Ok(path_and_query) = PathAndQuery::try_from(rebuilt) else {
+        return;
+    };
+    let mut parts = req.uri().clone().into_parts();
+    parts.path_and_query = Some(path_and_query);
+    if let Ok(uri) = Uri::from_parts(parts) {
+        *req.uri_mut() = uri;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use tower::{ServiceExt, service_fn};
+
+    // ---- pure: strip_base_prefix ----------------------------------------
+
+    #[test]
+    fn strips_prefix_at_segment_boundary() {
+        assert_eq!(
+            strip_base_prefix("/maps/ping", "/maps").as_deref(),
+            Some("/ping")
+        );
+        assert_eq!(
+            strip_base_prefix("/maps/_nuxt/x.js", "/maps").as_deref(),
+            Some("/_nuxt/x.js")
+        );
+    }
+
+    #[test]
+    fn bare_prefix_becomes_root() {
+        assert_eq!(strip_base_prefix("/maps", "/maps").as_deref(), Some("/"));
+        assert_eq!(strip_base_prefix("/maps/", "/maps").as_deref(), Some("/"));
+    }
+
+    #[test]
+    fn non_matching_prefix_is_left_untouched() {
+        // `/mapsx` is NOT under `/maps` — must not be mangled into `x/...`.
+        assert_eq!(strip_base_prefix("/mapsx/ping", "/maps"), None);
+        assert_eq!(strip_base_prefix("/other/ping", "/maps"), None);
+    }
+
+    #[test]
+    fn nested_base_path_strips_correctly() {
+        assert_eq!(
+            strip_base_prefix("/a/b/ping", "/a/b").as_deref(),
+            Some("/ping")
+        );
+    }
+
+    #[test]
+    fn empty_base_is_a_noop() {
+        // Root / proxy-strip mode: the layer must leave every path untouched.
+        assert_eq!(strip_base_prefix("/ping", ""), None);
+        assert_eq!(strip_base_prefix("/", ""), None);
+        assert_eq!(strip_base_prefix("/_nuxt/x.js", ""), None);
+    }
+
+    // ---- service: BasePathStrip -----------------------------------------
+
+    /// Echo the (possibly rewritten) request URI back so tests can assert what
+    /// the inner service received.
+    async fn echo_uri(base: &str, path: &str) -> String {
+        let svc = BasePathStripLayer::new(base).layer(service_fn(|req: Request| async move {
+            Ok::<_, std::convert::Infallible>(axum::response::Response::new(Body::from(
+                req.uri().to_string(),
+            )))
+        }));
+        let req = Request::builder()
+            .uri(path)
+            .body(Body::empty())
+            .expect("valid request");
+        let resp = svc.oneshot(req).await.expect("service ok");
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        String::from_utf8(bytes.to_vec()).expect("utf8")
+    }
+
+    #[tokio::test]
+    async fn service_strips_api_path() {
+        assert_eq!(echo_uri("/maps", "/maps/ping").await, "/ping");
+    }
+
+    #[tokio::test]
+    async fn service_maps_bare_prefix_to_root() {
+        assert_eq!(echo_uri("/maps", "/maps").await, "/");
+        assert_eq!(echo_uri("/maps", "/maps/").await, "/");
+    }
+
+    #[tokio::test]
+    async fn service_preserves_query_string() {
+        assert_eq!(
+            echo_uri("/maps", "/maps/styles/x/?raster").await,
+            "/styles/x/?raster"
+        );
+    }
+
+    #[tokio::test]
+    async fn service_leaves_non_matching_path_untouched() {
+        assert_eq!(echo_uri("/maps", "/other/ping").await, "/other/ping");
+    }
+}

--- a/crates/tileserver-rs/src/base_path.rs
+++ b/crates/tileserver-rs/src/base_path.rs
@@ -208,4 +208,33 @@ mod tests {
     async fn service_leaves_non_matching_path_untouched() {
         assert_eq!(echo_uri("/maps", "/other/ping").await, "/other/ping");
     }
+
+    // ---- rewrite_request_path: malformed rebuild ------------------------
+
+    #[test]
+    fn rewrite_with_invalid_path_leaves_request_untouched() {
+        // A `new_path` containing a control character cannot be parsed as a
+        // `PathAndQuery`, so the rebuild bails and the request keeps its
+        // original URI rather than being dropped or corrupted.
+        let mut req = Request::builder()
+            .uri("/maps/ping")
+            .body(Body::empty())
+            .expect("valid request");
+        rewrite_request_path(&mut req, "/bad\u{7f}path");
+        assert_eq!(req.uri().path(), "/maps/ping");
+    }
+
+    #[test]
+    fn rewrite_with_valid_path_preserves_query() {
+        // Happy-path direct call: the query string survives the rebuild.
+        let mut req = Request::builder()
+            .uri("/maps/styles/x?raster")
+            .body(Body::empty())
+            .expect("valid request");
+        rewrite_request_path(&mut req, "/styles/x");
+        assert_eq!(
+            req.uri().path_and_query().map(|pq| pq.as_str()),
+            Some("/styles/x?raster")
+        );
+    }
 }

--- a/crates/tileserver-rs/src/config.rs
+++ b/crates/tileserver-rs/src/config.rs
@@ -345,6 +345,29 @@ impl Default for RasterConfig {
     }
 }
 
+/// How the server serves the embedded GUI and API routes when deployed
+/// under a URL subfolder (derived from [`ServerConfig::public_url`]).
+///
+/// The subfolder itself is taken from the path component of `public_url`
+/// (e.g. `https://example.com/maps` yields the base path `/maps`). When
+/// `public_url` has no path, both modes behave identically to a root
+/// deployment and this setting has no effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum SubfolderMode {
+    /// The reverse proxy strips the subfolder prefix before forwarding
+    /// (e.g. nginx `proxy_pass http://backend/;` with a trailing slash).
+    /// The server keeps serving its routes at the root; only the embedded
+    /// GUI is rebased so the browser requests subfolder-prefixed URLs that
+    /// the proxy strips back to root. This is the default.
+    #[default]
+    ProxyStrip,
+    /// The reverse proxy forwards the subfolder prefix untouched. The server
+    /// mounts its entire router under the base path, so it serves the GUI
+    /// and API directly at `/<subfolder>/*`.
+    Nested,
+}
+
 /// Server configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
@@ -396,6 +419,45 @@ pub struct ServerConfig {
     /// binary was built with the `ogc` feature.
     #[serde(default)]
     pub disable_ogc: bool,
+    /// How to serve under a URL subfolder when [`Self::public_url`] carries a
+    /// path component. Ignored for root deployments. See [`SubfolderMode`].
+    #[serde(default)]
+    pub subfolder_mode: SubfolderMode,
+}
+
+/// Derive the URL subfolder base path from an optional public URL.
+///
+/// Returns the normalized path component with a leading slash and no trailing
+/// slash (e.g. `/maps`), or an empty string for a root deployment (no path,
+/// a bare `/`, or an unparseable value).
+///
+/// # Examples
+///
+/// ```
+/// # use tileserver_rs::config::derive_base_path;
+/// assert_eq!(derive_base_path(Some("https://example.com/maps")), "/maps");
+/// assert_eq!(derive_base_path(Some("https://example.com/maps/")), "/maps");
+/// assert_eq!(derive_base_path(Some("https://example.com")), "");
+/// assert_eq!(derive_base_path(Some("https://example.com/")), "");
+/// assert_eq!(derive_base_path(None), "");
+/// ```
+#[must_use]
+pub fn derive_base_path(public_url: Option<&str>) -> String {
+    let Some(raw) = public_url else {
+        return String::new();
+    };
+    // Strip the scheme + authority if present so we are left with the path.
+    let after_scheme = raw.split_once("://").map_or(raw, |(_, rest)| rest);
+    let path = match after_scheme.find('/') {
+        Some(idx) => &after_scheme[idx..],
+        None => "",
+    };
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() {
+        String::new()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 fn default_host() -> String {
@@ -427,6 +489,7 @@ impl Default for ServerConfig {
             extra_response_headers: None,
             disable_render: false,
             disable_ogc: false,
+            subfolder_mode: SubfolderMode::default(),
         }
     }
 }

--- a/crates/tileserver-rs/src/config.rs
+++ b/crates/tileserver-rs/src/config.rs
@@ -368,6 +368,31 @@ pub enum SubfolderMode {
     Nested,
 }
 
+impl SubfolderMode {
+    /// The in-server strip base for this mode given the derived subfolder
+    /// `base_path`.
+    ///
+    /// In [`SubfolderMode::Nested`] the server strips the subfolder prefix
+    /// itself, so the strip base is the full `base_path`. In
+    /// [`SubfolderMode::ProxyStrip`] the reverse proxy strips it, so the
+    /// in-server strip base is empty and the strip layer becomes a no-op.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tileserver_rs::config::SubfolderMode;
+    /// assert_eq!(SubfolderMode::Nested.strip_base("/maps"), "/maps");
+    /// assert_eq!(SubfolderMode::ProxyStrip.strip_base("/maps"), "");
+    /// ```
+    #[must_use]
+    pub fn strip_base(self, base_path: &str) -> String {
+        match self {
+            Self::Nested => base_path.to_owned(),
+            Self::ProxyStrip => String::new(),
+        }
+    }
+}
+
 /// Server configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
@@ -2885,6 +2910,122 @@ entries = [
             let c = CompositeConfig::default();
             assert!(c.id.is_empty());
             assert!(c.sources.is_empty());
+        }
+    }
+
+    mod subfolder {
+        use super::*;
+
+        // ---- derive_base_path ----------------------------------------
+
+        #[test]
+        fn derive_base_path_none_is_root() {
+            assert_eq!(derive_base_path(None), "");
+        }
+
+        #[test]
+        fn derive_base_path_no_path_component_is_root() {
+            assert_eq!(derive_base_path(Some("https://example.com")), "");
+        }
+
+        #[test]
+        fn derive_base_path_bare_slash_is_root() {
+            assert_eq!(derive_base_path(Some("https://example.com/")), "");
+        }
+
+        #[test]
+        fn derive_base_path_single_segment() {
+            assert_eq!(derive_base_path(Some("https://example.com/maps")), "/maps");
+        }
+
+        #[test]
+        fn derive_base_path_strips_trailing_slash() {
+            assert_eq!(derive_base_path(Some("https://example.com/maps/")), "/maps");
+        }
+
+        #[test]
+        fn derive_base_path_multi_segment() {
+            assert_eq!(
+                derive_base_path(Some("https://example.com/tiles/maps")),
+                "/tiles/maps"
+            );
+        }
+
+        #[test]
+        fn derive_base_path_preserves_port_in_authority() {
+            assert_eq!(
+                derive_base_path(Some("http://localhost:8080/maps")),
+                "/maps"
+            );
+        }
+
+        #[test]
+        fn derive_base_path_without_scheme_treats_first_slash_as_path() {
+            // No `://` — the authority-vs-path split falls back to the first
+            // slash, so `example.com/maps` still yields `/maps`.
+            assert_eq!(derive_base_path(Some("example.com/maps")), "/maps");
+        }
+
+        #[test]
+        fn derive_base_path_only_slashes_is_root() {
+            assert_eq!(derive_base_path(Some("https://example.com///")), "");
+        }
+
+        // ---- SubfolderMode -------------------------------------------
+
+        #[test]
+        fn subfolder_mode_default_is_proxy_strip() {
+            assert_eq!(SubfolderMode::default(), SubfolderMode::ProxyStrip);
+        }
+
+        #[test]
+        fn subfolder_mode_deserializes_kebab_case() {
+            #[derive(Deserialize)]
+            struct Wrap {
+                mode: SubfolderMode,
+            }
+            let proxy: Wrap = toml::from_str(r#"mode = "proxy-strip""#).expect("parse");
+            assert_eq!(proxy.mode, SubfolderMode::ProxyStrip);
+            let nested: Wrap = toml::from_str(r#"mode = "nested""#).expect("parse");
+            assert_eq!(nested.mode, SubfolderMode::Nested);
+        }
+
+        #[test]
+        fn subfolder_mode_rejects_unknown_variant() {
+            #[derive(Deserialize)]
+            struct Wrap {
+                #[allow(dead_code)]
+                mode: SubfolderMode,
+            }
+            assert!(toml::from_str::<Wrap>(r#"mode = "bogus""#).is_err());
+        }
+
+        #[test]
+        fn server_config_default_subfolder_mode_is_proxy_strip() {
+            assert_eq!(
+                ServerConfig::default().subfolder_mode,
+                SubfolderMode::ProxyStrip
+            );
+        }
+
+        // ---- SubfolderMode::strip_base -------------------------------
+
+        #[test]
+        fn strip_base_nested_returns_base_path() {
+            assert_eq!(SubfolderMode::Nested.strip_base("/maps"), "/maps");
+        }
+
+        #[test]
+        fn strip_base_proxy_strip_returns_empty() {
+            // The reverse proxy strips the prefix, so the in-server layer is a
+            // no-op regardless of the derived base path.
+            assert_eq!(SubfolderMode::ProxyStrip.strip_base("/maps"), "");
+        }
+
+        #[test]
+        fn strip_base_nested_with_empty_base_is_empty() {
+            // A root deployment in nested mode still yields an empty strip base.
+            assert_eq!(SubfolderMode::Nested.strip_base(""), "");
         }
     }
 }

--- a/crates/tileserver-rs/src/config_schema.rs
+++ b/crates/tileserver-rs/src/config_schema.rs
@@ -243,6 +243,17 @@ pub static CONFIG_SCHEMA: &[ConfigSectionSchema] = &[
                 optional: false,
                 enum_values: None,
             },
+            ConfigFieldSchema {
+                key: "subfolder_mode",
+                field_type: "enum",
+                default: Some("proxy-strip"),
+                description: "How to serve the embedded GUI and API when public_url \
+                    carries a path (subfolder deployment). `proxy-strip`: the reverse \
+                    proxy strips the prefix; `nested`: the server strips it itself. \
+                    Ignored for root deployments.",
+                optional: false,
+                enum_values: Some(&["proxy-strip", "nested"]),
+            },
         ],
     },
     ConfigSectionSchema {

--- a/crates/tileserver-rs/src/lib.rs
+++ b/crates/tileserver-rs/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod admin;
 pub mod autodetect;
+pub mod base_path;
 pub mod cache;
 pub mod cache_control;
 pub mod composite;
@@ -24,6 +25,8 @@ pub mod render;
 pub mod response_headers;
 pub mod routes;
 pub mod sources;
+#[cfg(feature = "frontend")]
+pub mod spa;
 pub mod startup;
 pub mod stylegen;
 pub mod styles;

--- a/crates/tileserver-rs/src/main.rs
+++ b/crates/tileserver-rs/src/main.rs
@@ -291,12 +291,7 @@ async fn main() -> anyhow::Result<()> {
     let base_path = tileserver_rs::config::derive_base_path(config.server.public_url.as_deref());
     #[cfg(feature = "frontend")]
     init_spa_cache(&base_path);
-    let strip_base = if config.server.subfolder_mode == tileserver_rs::config::SubfolderMode::Nested
-    {
-        base_path.clone()
-    } else {
-        String::new()
-    };
+    let strip_base = config.server.subfolder_mode.strip_base(&base_path);
 
     // Layers wrap the router from the OUTSIDE (routing runs before inner
     // `.layer()` middleware). Order: strip the subfolder prefix FIRST (nested

--- a/crates/tileserver-rs/src/main.rs
+++ b/crates/tileserver-rs/src/main.rs
@@ -282,7 +282,27 @@ async fn main() -> anyhow::Result<()> {
     // wrap the Router from the OUTSIDE: routing happens before inner `.layer()`
     // middleware, so applying it via `Router::layer()` would run too late. The
     // resulting service is served via `ServiceExt::into_make_service`.
-    let app = SelectiveTrailingSlashLayer.layer(router);
+    // Derive the URL subfolder from public_url (empty for a root deployment).
+    // The embedded GUI is rebased for BOTH subfolder modes so the browser
+    // requests prefixed asset/API URLs; the modes differ only in WHERE the
+    // prefix is stripped. In `Nested` mode the server strips it itself via
+    // `BasePathStripLayer`; in `ProxyStrip` mode the reverse proxy strips it,
+    // so the in-server strip base stays empty (a no-op layer).
+    let base_path = tileserver_rs::config::derive_base_path(config.server.public_url.as_deref());
+    #[cfg(feature = "frontend")]
+    init_spa_cache(&base_path);
+    let strip_base = if config.server.subfolder_mode == tileserver_rs::config::SubfolderMode::Nested
+    {
+        base_path.clone()
+    } else {
+        String::new()
+    };
+
+    // Layers wrap the router from the OUTSIDE (routing runs before inner
+    // `.layer()` middleware). Order: strip the subfolder prefix FIRST (nested
+    // mode only), then normalize trailing slashes, then route.
+    let app = tileserver_rs::base_path::BasePathStripLayer::new(strip_base.as_str())
+        .layer(SelectiveTrailingSlashLayer.layer(router));
 
     let addr: SocketAddr = format!("{}:{}", config.server.host, config.server.port).parse()?;
     tracing::info!("Starting tileserver on http://{}", addr);
@@ -443,11 +463,54 @@ async fn shutdown_signal() {
     tracing::info!("Shutdown signal received, starting graceful shutdown");
 }
 
+/// Rewritten embedded SPA assets, keyed by their root-relative path (e.g.
+/// `_nuxt/entry.js`). Populated once at startup for subfolder deployments;
+/// empty for root deployments, in which case [`serve_spa`] serves the raw
+/// embedded bytes unchanged (zero behavioural change for the common case).
+#[cfg(feature = "frontend")]
+static SPA_CACHE: std::sync::OnceLock<std::collections::HashMap<String, Vec<u8>>> =
+    std::sync::OnceLock::new();
+
+/// Build the rewritten-asset cache for a subfolder deployment. For an empty
+/// `base_path` (root deployment) the cache stays empty and every asset is
+/// served from the raw embed. Idempotent: only the first call populates it.
+#[cfg(feature = "frontend")]
+fn init_spa_cache(base_path: &str) {
+    let mut map = std::collections::HashMap::new();
+    if !base_path.is_empty() {
+        for file in Assets::iter() {
+            let path = file.as_ref();
+            if let Some(content) = Assets::get(path)
+                && let Some(rewritten) =
+                    tileserver_rs::spa::rewrite_asset(path, &content.data, base_path)
+            {
+                map.insert(path.to_owned(), rewritten);
+            }
+        }
+        tracing::info!(
+            base_path,
+            rewritten_assets = map.len(),
+            "Rebased embedded GUI for subfolder deployment"
+        );
+    }
+    let _ = SPA_CACHE.set(map);
+}
+
+/// Resolve embedded SPA bytes for `path`, preferring the rewritten cache and
+/// falling back to the raw embed.
+#[cfg(feature = "frontend")]
+fn resolve_spa_asset(path: &str) -> Option<Vec<u8>> {
+    if let Some(bytes) = SPA_CACHE.get().and_then(|cache| cache.get(path)) {
+        return Some(bytes.clone());
+    }
+    Assets::get(path).map(|content| content.data.to_vec())
+}
+
 #[cfg(feature = "frontend")]
 async fn serve_spa(uri: Uri) -> impl IntoResponse {
     let path = uri.path().trim_start_matches('/');
 
-    if let Some(content) = Assets::get(path) {
+    if let Some(data) = resolve_spa_asset(path) {
         let mime = mime_guess::from_path(path).first_or_octet_stream();
         let mut headers = HeaderMap::new();
         let content_type = HeaderValue::from_str(mime.as_ref())
@@ -461,11 +524,11 @@ async fn serve_spa(uri: Uri) -> impl IntoResponse {
             );
         }
 
-        return (headers, content.data.to_vec()).into_response();
+        return (headers, data).into_response();
     }
 
-    if let Some(index) = Assets::get("index.html") {
-        return Html(index.data.to_vec()).into_response();
+    if let Some(index) = resolve_spa_asset("index.html") {
+        return Html(index).into_response();
     }
 
     (StatusCode::NOT_FOUND, "Not Found").into_response()

--- a/crates/tileserver-rs/src/spa.rs
+++ b/crates/tileserver-rs/src/spa.rs
@@ -1,0 +1,138 @@
+//! Runtime rebasing of the embedded single-page application for subfolder
+//! deployments.
+//!
+//! The GUI is built once with a root (`/`) base and embedded in the binary at
+//! compile time. When the server is deployed under a URL subfolder (derived
+//! from `server.public_url`, e.g. `https://example.com/maps`), the browser
+//! must request subfolder-prefixed asset and API URLs. Rather than rebuild the
+//! SPA per deployment, the server rewrites the embedded text assets once at
+//! startup so every root-absolute reference is prefixed with the base path.
+//!
+//! The rewrite targets, all of which appear verbatim in the Nuxt/Vite build
+//! output, are:
+//! - `/_nuxt/` — the build assets directory (hardcoded in `index.html` and in
+//!   the chunk graph, so it must be rebased across every text asset).
+//! - `/fonts/` — `@nuxt/fonts` preload and `@font-face` `url()` references.
+//! - `/favicon.ico` and the inlined `app.baseURL` in `index.html`. Rewriting
+//!   `baseURL` makes the Vue Router history base and
+//!   `useRuntimeConfig().app.baseURL` (read by the API-URL helper and
+//!   `<NuxtLink>`) subfolder-aware at runtime with no client rebuild.
+//!
+//! For a root deployment (empty base path) every function here is a no-op, so
+//! the common case serves byte-identical embedded assets.
+
+/// Text asset extensions whose root-absolute references are rewritten. Binary
+/// assets (fonts, images, the favicon itself) are served unchanged.
+const TEXT_EXTENSIONS: [&str; 6] = ["html", "js", "css", "json", "xml", "svg"];
+
+/// Returns `true` if the asset at `path` is a text asset whose contents may
+/// carry root-absolute references that need rebasing.
+#[must_use]
+pub fn is_text_asset(path: &str) -> bool {
+    path.rsplit('.')
+        .next()
+        .is_some_and(|ext| TEXT_EXTENSIONS.contains(&ext))
+}
+
+/// Rewrite the root-absolute references in a single embedded text asset so
+/// they are prefixed with `base_path` (e.g. `/maps`).
+///
+/// Returns `Some(rewritten_bytes)` when the asset is a text asset and
+/// `base_path` is non-empty; otherwise returns `None`, signalling the caller
+/// to serve the original embedded bytes unchanged. `base_path` must be a
+/// normalized subfolder (leading slash, no trailing slash) as produced by
+/// [`crate::config::derive_base_path`]; an empty `base_path` (root deployment)
+/// always yields `None`.
+#[must_use]
+pub fn rewrite_asset(path: &str, content: &[u8], base_path: &str) -> Option<Vec<u8>> {
+    if base_path.is_empty() || !is_text_asset(path) {
+        return None;
+    }
+    // Text assets in a Nuxt/Vite build are UTF-8. If a text-extension asset is
+    // somehow not valid UTF-8, leave it untouched rather than corrupt it.
+    let text = std::str::from_utf8(content).ok()?;
+
+    let mut out = text
+        .replace("/_nuxt/", &format!("{base_path}/_nuxt/"))
+        .replace("/fonts/", &format!("{base_path}/fonts/"));
+
+    // `index.html` carries two references the prefix rules above do not cover:
+    // the favicon link and the inlined runtime `app.baseURL`. Rewriting
+    // `baseURL` is what makes the router + API helper subfolder-aware.
+    if path == "index.html" {
+        out = out
+            .replace(
+                "href=\"/favicon.ico\"",
+                &format!("href=\"{base_path}/favicon.ico\""),
+            )
+            .replace("baseURL:\"/\"", &format!("baseURL:\"{base_path}/\""));
+    }
+
+    Some(out.into_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_text_asset_matches_known_text_extensions() {
+        assert!(is_text_asset("index.html"));
+        assert!(is_text_asset("_nuxt/entry.abc.js"));
+        assert!(is_text_asset("_nuxt/entry.abc.css"));
+        assert!(is_text_asset("wmts.xml"));
+        assert!(!is_text_asset("fonts/switzer-300.woff2"));
+        assert!(!is_text_asset("favicon.ico"));
+        assert!(!is_text_asset("no_extension"));
+    }
+
+    #[test]
+    fn rewrite_is_noop_for_root_deployment() {
+        let html = br#"<script src="/_nuxt/entry.js"></script>"#;
+        assert_eq!(rewrite_asset("index.html", html, ""), None);
+    }
+
+    #[test]
+    fn rewrite_is_noop_for_binary_assets() {
+        assert_eq!(
+            rewrite_asset("fonts/switzer-300.woff2", &[0u8, 1, 2], "/maps"),
+            None
+        );
+    }
+
+    #[test]
+    fn rewrite_prefixes_nuxt_and_fonts_in_js() {
+        let js = br#"import"/_nuxt/chunk.js";fetch("/fonts/x.woff2")"#;
+        let out = rewrite_asset("_nuxt/entry.js", js, "/maps").expect("text asset rewritten");
+        let out = String::from_utf8(out).expect("valid utf8");
+        assert_eq!(
+            out,
+            r#"import"/maps/_nuxt/chunk.js";fetch("/maps/fonts/x.woff2")"#
+        );
+    }
+
+    #[test]
+    fn rewrite_index_html_rebases_base_url_and_favicon() {
+        let html = br#"<link rel="icon" href="/favicon.ico"><script>window.__NUXT__.config={app:{baseURL:"/",buildAssetsDir:"/_nuxt/"}}</script><script src="/_nuxt/e.js"></script>"#;
+        let out = rewrite_asset("index.html", html, "/maps").expect("index rewritten");
+        let out = String::from_utf8(out).expect("valid utf8");
+        assert!(out.contains(r#"href="/maps/favicon.ico""#));
+        assert!(out.contains(r#"baseURL:"/maps/""#));
+        assert!(out.contains(r#"buildAssetsDir:"/maps/_nuxt/""#));
+        assert!(out.contains(r#"src="/maps/_nuxt/e.js""#));
+        // The original root-absolute forms must be fully gone.
+        assert!(!out.contains(r#"href="/favicon.ico""#));
+        assert!(!out.contains(r#"baseURL:"/""#));
+    }
+
+    #[test]
+    fn rewrite_leaves_non_index_favicon_and_baseurl_untouched() {
+        // A JS chunk that happens to contain a `baseURL:"/"` literal is NOT the
+        // runtime config; only index.html carries the authoritative one, so the
+        // baseURL/favicon specials apply to index.html alone.
+        let js = br#"const x={baseURL:"/"};load("/_nuxt/a.js")"#;
+        let out = rewrite_asset("_nuxt/x.js", js, "/maps").expect("rewritten");
+        let out = String::from_utf8(out).expect("valid utf8");
+        assert_eq!(out, r#"const x={baseURL:"/"};load("/maps/_nuxt/a.js")"#);
+    }
+}

--- a/doctor.config.ts
+++ b/doctor.config.ts
@@ -63,6 +63,14 @@ export default {
     // installed. Same blind spot affects any catalog:-referenced dep imported via
     // a non-root subpath.
     'dead-code/unlisted-dependency': 'off',
+    // knip is blind to Nuxt auto-imports. Every composable, `app/utils/**`
+    // helper, and collection-key module is consumed via auto-import (never an
+    // explicit `import`), so knip reports ~25 live files (use-home-page,
+    // use-style-viewer, the whole utils/api TanStack layer, api-url, etc.) as
+    // unused. Across the project's history this rule surfaced exactly one truly
+    // dead file amid that permanent false-positive wall, so it is pure noise for
+    // a Nuxt app. Same auto-import blind spot as the two dead-code rules above.
+    'dead-code/unused-file': 'off',
     // Nuxt's generated .nuxt/tsconfig.json already sets `strict: true`; the rule
     // reads the root tsconfig literally and misses the value inherited via
     // `extends`, so it is a false positive here.


### PR DESCRIPTION
## Summary

Fixes #1385 — serve the GUI and API under a URL subfolder (e.g. `https://example.com/maps/`), not just the domain root.

The embedded SPA is built once with a root (`/`) base. When `public_url` carries a path component, the server derives the base path and **rebases the embedded assets at startup** — asset URLs (`/_nuxt/`, `/fonts/`, favicon), the inlined Vue Router base (`app.baseURL`), and all client API calls — so no client rebuild is needed. Root deployments serve **byte-identical** embedded assets (verified), so this is a no-op unless you opt in.

## Two modes via `server.subfolder_mode`

| Mode | Who strips the `/maps` prefix | nginx |
|---|---|---|
| `proxy-strip` _(default)_ | reverse proxy | `proxy_pass http://backend/;` (trailing slash) |
| `nested` | the server itself | `proxy_pass http://backend;` (no trailing slash) |

`nested` mode is fully testable locally with no proxy — the server responds directly at `:8080/maps/`.

## Changes

- **Rust core**: `SubfolderMode` enum + `derive_base_path()` in `config.rs`; `spa.rs` (pure asset-rewrite module, cached once at startup); `base_path.rs` (`BasePathStripLayer` for `nested` mode, mirrors the existing trailing-slash layer); `main.rs` wiring; config schema entry.
- **Client**: `apiUrl()` helper prefixing root-absolute server paths with the runtime `app.baseURL`, applied to every `$fetch`, native `fetch`, MapLibre source URL, and `:href`/`:src`. `NuxtLink :to` and chunk loading stay base-aware via Nuxt.
- **Docs**: subfolder deployment guide + `subfolder_mode` reference with nginx snippets for both modes.

## Testing

- New unit tests: `spa::` (rewrite/no-op/binary-skip/index-baseURL), `base_path::` (strip/no-op/non-matching-prefix + service tests), `config::derive_base_path` doctest. Full `--features frontend` lib suite green (1179 passed).
- `cargo clippy --all-features -D warnings` + `cargo fmt --check` clean.
- **Empirical (headless real browser + curl)**:
  - `nested` mode: `/maps/` mounts, `baseURL:"/maps/"`, all `/_nuxt/`+`/fonts/` rebased, **zero** un-rebased refs, `/maps/ping` `/maps/data.json` `/maps/styles.json` → 200, map viewer route `/maps/styles/{id}/` renders MapLibre canvas, **0 failed resources**.
  - root deployment: served `index.html` **byte-identical** to the embed, `baseURL:"/"`, browser mounts, **0 failed resources** — zero regression.
